### PR TITLE
Refactor email stylesheet override + email light theme

### DIFF
--- a/app/assets/stylesheets/decidim/_email-custom.scss
+++ b/app/assets/stylesheets/decidim/_email-custom.scss
@@ -1,0 +1,21 @@
+// Variables
+
+// - Default
+// $body-header-color: #1a181d;
+// $body-footer-color: #2c2930;
+
+// - Light theme
+$body-header-color: #fefefe;
+$body-footer-color: #fefefe;
+
+
+/* Application Overrides --------- */
+
+table.body th.decidim-bar,
+table.body td.decidim-bar{
+  background-color: $body-header-color;
+}
+
+.cityhall-bar{
+  background-color: $body-footer-color;
+}

--- a/app/assets/stylesheets/decidim/email.scss.erb
+++ b/app/assets/stylesheets/decidim/email.scss.erb
@@ -1,0 +1,2 @@
+@import "<%= Gem.loaded_specs['decidim-core'].full_gem_path %>/app/assets/stylesheets/decidim/email.scss";
+@import "email-custom"


### PR DESCRIPTION
This PR aims to improve the way we override the Decidim email stylesheet and to put the light theme by default (header & footer in _whitish_ color).

### Override the email stylesheet

- we overrides the `app/assets/stylesheets/decidim/email.scss` file
- this file is in fact an ERB file that will import the original file from the deployed `decidim-core` gem
- we import a local SCSS file to make it easier to edit for web developper

The result is that we always have an up to date email stylesheet from core and we can limit our code to custom styles and overrides.

> All we need to do is to edit the `app/assets/stylesheets/decidim/_email-custom.scss` file :tada: 

### Light theme
We simply change the header and the footer color with the one used for the main body 

![Clipboard - 16 septembre 2021 14_11](https://user-images.githubusercontent.com/464350/133610066-962b629e-f5e4-4e41-bbb8-e3fe1b23909e.jpg)
