### PR TITLE
Fix meetings order 

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -1,17 +1,15 @@
-## Overrides
+# Overrides
 
+## Fix meetings orders in indexes
+* `app/controllers/decidim/meetings/meetings_controller.rb`
+* `app/controllers/decidim/meetings/directory/meetings_controller.rb`
+##  Fix meetings registration serializer
 * `app/serializers/decidim/meetings/registration_serializer.rb`
-Fix meetings registration serializer
-
+## Fix UserAnswersSerializer for CSV exports
 * `lib/decidim/forms/user_answers_serializer.rb`
-Fix UserAnswersSerializer for CSV exports
-
+## 28c8d74 - Add basic tests to reference package (#1), 2021-07-26
 * `lib/extends/commands/decidim/admin/create_participatory_space_private_user_extends.rb`
-28c8d74 - Add basic tests to reference package (#1), 2021-07-26
-
 * `lib/extends/commands/decidim/admin/impersonate_user_extends.rb`
-28c8d74 - Add basic tests to reference package (#1), 2021-07-26
-
+##  cd5c2cc - Backport fix/user answers serializer (#11), 2021-09-30
 * `lib/decidim/forms/user_answers_serializer.rb`
-cd5c2cc - Backport fix/user answers serializer (#11), 2021-09-30
 

--- a/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module Directory
+      # Exposes the meeting resource so users can view them
+      class MeetingsController < Decidim::ApplicationController
+        layout "layouts/decidim/application"
+
+        include FilterResource
+        include Paginable
+
+        helper Decidim::WidgetUrlsHelper
+        helper Decidim::FiltersHelper
+        helper Decidim::Meetings::MapHelper
+        helper Decidim::ResourceHelper
+
+        helper_method :meetings, :search
+
+        def index
+          @meeting_spaces = search.results.map do |meeting|
+            klass = meeting.component.participatory_space.class
+            [klass.model_name.name.underscore, klass.model_name.human(count: 2)]
+          end.uniq
+          @meeting_spaces = @meeting_spaces.sort_by do |_param, name|
+            name
+          end
+          @meeting_spaces.prepend(["all", t(".all")])
+        end
+
+        def calendar
+          render plain: CalendarRenderer.for(current_organization), content_type: "type/calendar"
+        end
+
+        private
+
+        def meetings
+          @meetings ||= paginate(search.results.order(start_time: params.dig("filter", "date")&.include?("past") ? :desc : :asc))
+        end
+
+        def search_klass
+          MeetingSearch
+        end
+
+        def default_filter_params
+          {
+            date: "upcoming",
+            search_text: "",
+            scope_id: "",
+            space: "all"
+          }
+        end
+
+        def default_search_params
+          {
+            scope: Meeting.not_hidden.visible_meeting_for(current_user)
+          }
+        end
+
+        def context_params
+          { component: meeting_components, organization: current_organization }
+        end
+
+        def meeting_components
+          @meeting_components ||= Decidim::Component
+                                  .where(manifest_name: "meetings")
+                                  .where(participatory_space: participatory_spaces)
+                                  .published
+        end
+
+        def participatory_spaces
+          @participatory_spaces ||= current_organization.public_participatory_spaces
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/app/controllers/decidim/meetings/meetings_controller.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # Exposes the meeting resource so users can view them
+    class MeetingsController < Decidim::Meetings::ApplicationController
+      include FilterResource
+      include Flaggable
+      include FormFactory
+      include Paginable
+      helper Decidim::WidgetUrlsHelper
+      helper Decidim::ResourceVersionsHelper
+
+      helper_method :meetings, :meeting, :registration, :search
+
+      def new
+        enforce_permission_to :create, :meeting
+
+        @form = meeting_form.instance
+      end
+
+      def create
+        enforce_permission_to :create, :meeting
+
+        @form = meeting_form.from_params(params, current_component: current_component)
+
+        CreateMeeting.call(@form) do
+          on(:ok) do |meeting|
+            flash[:notice] = I18n.t("meetings.create.success", scope: "decidim.meetings")
+            redirect_to meeting_path(meeting)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("meetings.create.invalid", scope: "decidim.meetings")
+            render action: "new"
+          end
+        end
+      end
+
+      def index
+        return unless search.results.blank? && params.dig("filter", "date") != %w(past)
+
+        @past_meetings = search_klass.new(search_params.merge(date: %w(past)))
+
+        if @past_meetings.results.present?
+          params[:filter] ||= {}
+          params[:filter][:date] = %w(past)
+          @forced_past_meetings = true
+          @search = @past_meetings
+        end
+      end
+
+      def show
+        raise ActionController::RoutingError, "Not Found" unless meeting
+
+        return if meeting.current_user_can_visit_meeting?(current_user)
+
+        flash[:alert] = I18n.t("meeting.not_allowed", scope: "decidim.meetings")
+        redirect_to(ResourceLocatorPresenter.new(meeting).index)
+      end
+
+      def edit
+        enforce_permission_to :update, :meeting, meeting: meeting
+
+        @form = meeting_form.from_model(meeting)
+      end
+
+      def update
+        enforce_permission_to :update, :meeting, meeting: meeting
+
+        @form = meeting_form.from_params(params)
+
+        UpdateMeeting.call(@form, current_user, meeting) do
+          on(:ok) do |meeting|
+            flash[:notice] = I18n.t("meetings.update.success", scope: "decidim.meetings")
+            redirect_to Decidim::ResourceLocatorPresenter.new(meeting).path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("meetings.update.invalid", scope: "decidim.meetings")
+            render :edit
+          end
+        end
+      end
+
+      private
+
+      def meeting
+        @meeting ||= Meeting.not_hidden.where(component: current_component).find(params[:id])
+      end
+
+      def meetings
+        @meetings ||= paginate(search.results.order(start_time: params.dig("filter", "date")&.include?("past") ? :desc : :asc))
+      end
+
+      def registration
+        @registration ||= meeting.registrations.find_by(user: current_user)
+      end
+
+      def search_klass
+        MeetingSearch
+      end
+
+      def meeting_form
+        form(Decidim::Meetings::MeetingForm)
+      end
+
+      def default_filter_params
+        {
+          search_text: "",
+          date: %w(upcoming),
+          activity: "all",
+          scope_id: default_filter_scope_params,
+          category_id: default_filter_category_params,
+          origin: default_filter_origin_params,
+          type: default_filter_type_params
+        }
+      end
+
+      def default_filter_origin_params
+        filter_origin_params = %w(citizens)
+        filter_origin_params << "official"
+        filter_origin_params << "user_group" if current_organization.user_groups_enabled?
+        filter_origin_params
+      end
+
+      def default_filter_type_params
+        %w(all) + Decidim::Meetings::Meeting::TYPE_OF_MEETING
+      end
+
+      def default_search_params
+        {
+          scope: Meeting.not_hidden.visible_meeting_for(current_user)
+        }
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,20 @@ en:
           email_outro: You have received this notification because you are participating in "%{participatory_space_title}"
           email_subject: Your vote is still pending in %{participatory_space_title}
           notification_title: The vote on budget <a href="%{resource_path}">%{resource_title}</a> is still waiting for your confirmation in %{participatory_space_title}
+    meetings:
+      directory:
+        meetings:
+          index:
+            all: All
+      meeting:
+        not_allowed: You are not allowed to view this meeting
+      meetings:
+        create:
+          invalid: There was a problem creating this meeting.
+          success: You have created the meeting successfully.
+        update:
+          invalid: There was a problem updating the meeting.
+          success: You have updated the meeting successfully.
     verifications:
       authorizations:
         first_login:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -39,6 +39,20 @@ fr:
           email_outro: Vous avez reçu cette notification parce que vous avez commencé à voter sur la concertation "%{participatory_space_title}"
           email_subject: Votre vote est toujours en attente sur la concertation %{participatory_space_title}
           notification_title: Votre vote pour le budget <a href="%{resource_path}">%{resource_title}</a> attend d'être finalisé sur la concertation %{participatory_space_title}
+    meetings:
+      directory:
+        meetings:
+          index:
+            all: Tous
+      meeting:
+        not_allowed: Vous n'êtes pas autorisé à vous inscrire à cette rencontre.
+      meetings:
+        create:
+          invalid: Il y a eu une erreur lors de la création de la rencontre.
+          success: La rencontre a été créée avec succès.
+        update:
+          invalid: Il y a eu une erreur lors de la mise à jour de la rencontre.
+          success: La rencontre a été mise à jour avec succès.
     verifications:
       authorizations:
         first_login:

--- a/spec/system/explore_meeting_directory_spec.rb
+++ b/spec/system/explore_meeting_directory_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore meeting directory", type: :system do
+  let(:directory) do
+    Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
+  end
+  let(:organization) { create(:organization) }
+  let(:components) do
+    create_list(:meeting_component, 3, organization: organization)
+  end
+  let!(:meetings) do
+    components.flat_map do |component|
+      create_list(:meeting, 2, component: component)
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    visit directory
+  end
+
+  it "shows all the upcoming meetings" do
+    within "#meetings" do
+      expect(page).to have_css(".card--meeting", count: 6)
+    end
+  end
+
+  context "when there's a past meeting" do
+    let!(:past_meeting) do
+      create(:meeting, component: components.last, start_time: 1.week.ago)
+    end
+
+    it "allows filtering by past events" do
+      within ".filters" do
+        choose "Past"
+      end
+
+      expect(page).to have_content(past_meeting.title["en"])
+    end
+  end
+
+  context "with different participatory spaces" do
+    let(:assembly) do
+      create(:assembly, organization: organization)
+    end
+    let(:assembly_component) do
+      create(:meeting_component, participatory_space: assembly, organization: organization)
+    end
+    let!(:assembly_meeting) do
+      create(:meeting, component: assembly_component)
+    end
+
+    before do
+      visit directory
+    end
+
+    it "allows filtering by space" do
+      expect(page).to have_content(assembly_meeting.title["en"])
+
+      # Since in the first load all the meeting are present, we need can't rely on
+      # have_content to wait for the card list to change. This is a hack to
+      # reset the contents to no meetings at all, and then showing only the upcoming
+      # assembly meetings.
+      within ".filters" do
+        choose "Past"
+      end
+
+      expect(page).to have_no_css(".card--meeting")
+
+      within ".filters" do
+        choose "Assemblies"
+        choose "Upcoming"
+      end
+
+      expect(page).to have_content(assembly_meeting.title["en"])
+      expect(page).to have_css(".card--meeting", count: 1)
+    end
+  end
+end

--- a/spec/system/explore_meetings_spec.rb
+++ b/spec/system/explore_meetings_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore meetings", :slow, type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "meetings" }
+
+  let(:meetings_count) { 5 }
+  let!(:meetings) do
+    create_list(:meeting, meetings_count, :not_official, component: component)
+  end
+
+  before do
+    component_scope = create :scope, parent: participatory_process.scope
+    component_settings = component["settings"]["global"].merge!(scopes_enabled: true, scope_id: component_scope.id)
+    component.update!(settings: component_settings)
+  end
+
+  describe "index" do
+    it "shows all meetings for the given process" do
+      visit_component
+      expect(page).to have_selector(".card--meeting", count: meetings_count)
+
+      meetings.each do |meeting|
+        expect(page).to have_content(translated(meeting.title))
+      end
+    end
+
+    context "with hidden meetings" do
+      let(:meeting) { meetings.last }
+
+      before do
+        create :moderation, :hidden, reportable: meeting
+      end
+
+      it "does not list the hidden meetings" do
+        visit_component
+
+        expect(page).to have_selector(".card.card--meeting", count: meetings_count - 1)
+
+        expect(page).to have_no_content(translated(meeting.title))
+      end
+    end
+
+    context "when comments have been moderated" do
+      let(:meeting) { create(:meeting, component: component) }
+      let!(:comments) { create_list(:comment, 3, commentable: meeting) }
+      let!(:moderation) { create :moderation, reportable: comments.first, hidden_at: 1.day.ago }
+
+      it "displays unhidden comments count" do
+        visit_component
+
+        within("#meeting_#{meeting.id}") do
+          within(".card__status") do
+            within(".card-data__item:last-child") do
+              expect(page).to have_content(2)
+            end
+          end
+        end
+      end
+    end
+
+    context "when filtering" do
+      context "when filtering by origin" do
+        let!(:component) do
+          create(:meeting_component,
+                 :with_creation_enabled,
+                 participatory_space: participatory_process)
+        end
+
+        let!(:official_meeting) { create(:meeting, :official, component: component, author: organization) }
+        let!(:user_group_meeting) { create(:meeting, :user_group_author, component: component) }
+
+        context "with 'official' origin" do
+          it "lists the filtered meetings" do
+            visit_component
+
+            within ".origin_check_boxes_tree_filter" do
+              uncheck "All"
+              check "Official"
+            end
+
+            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).to have_content("1 MEETING")
+            expect(page).to have_css(".card--meeting", count: 1)
+
+            within ".card--meeting" do
+              expect(page).to have_content("Official meeting")
+            end
+          end
+        end
+
+        context "with 'groups' origin" do
+          it "lists the filtered meetings" do
+            visit_component
+
+            within ".origin_check_boxes_tree_filter" do
+              uncheck "All"
+              check "Groups"
+            end
+
+            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).to have_content("1 MEETING")
+            expect(page).to have_css(".card--meeting", count: 1)
+            within ".card--meeting" do
+              expect(page).to have_content(user_group_meeting.normalized_author.name)
+            end
+          end
+        end
+
+        context "with 'citizens' origin" do
+          it "lists the filtered meetings" do
+            visit_component
+
+            within ".origin_check_boxes_tree_filter" do
+              uncheck "All"
+              check "Citizens"
+            end
+
+            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).to have_css(".card--meeting", count: meetings_count)
+            expect(page).to have_content("#{meetings_count} MEETINGS")
+          end
+        end
+      end
+
+      it "allows filtering by date" do
+        past_meeting = create(:meeting, component: component, start_time: 1.day.ago)
+        visit_component
+
+        within ".date_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Past"
+        end
+
+        expect(page).to have_css(".card--meeting", count: 1)
+        expect(page).to have_content(translated(past_meeting.title))
+
+        within ".date_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Upcoming"
+        end
+
+        expect(page).to have_css(".card--meeting", count: 5)
+      end
+
+      it "allows filtering by scope" do
+        scope = create(:scope, organization: organization)
+        meeting = meetings.first
+        meeting.scope = scope
+        meeting.save
+
+        visit_component
+
+        within ".scope_id_check_boxes_tree_filter" do
+          check "All"
+          uncheck "All"
+          check translated(scope.name)
+        end
+
+        expect(page).to have_css(".card--meeting", count: 1)
+      end
+    end
+
+    context "when no upcoming meetings scheduled" do
+      let!(:meetings) do
+        create_list(:meeting, 2, component: component, start_time: Time.current - 4.days, end_time: Time.current - 2.days)
+      end
+
+      it "only shows the past meetings" do
+        visit_component
+        expect(page).to have_css(".card--meeting", count: 2)
+      end
+
+      it "shows the correct warning" do
+        visit_component
+        within ".callout" do
+          expect(page).to have_content("no scheduled meetings")
+        end
+      end
+    end
+
+    context "when no meetings scheduled" do
+      let!(:meetings) { [] }
+
+      it "shows the correct warning" do
+        visit_component
+        within ".callout" do
+          expect(page).to have_content("any meeting scheduled")
+        end
+      end
+    end
+
+    context "when paginating" do
+      before do
+        Decidim::Meetings::Meeting.destroy_all
+      end
+
+      let!(:collection) { create_list :meeting, collection_size, component: component }
+      let!(:resource_selector) { ".card--meeting" }
+
+      it_behaves_like "a paginated resource"
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to fix the meetings order for past meetings and meetings to come on our reference application. 
It also adds tests for meetings indexes and updates OVERLOAD file. 