### PR TITLE
Fix display sector selection (v0.24)

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -22,3 +22,19 @@
         fill: rgba($primary, .2);;
     }
 ```
+ - **V0.24** `app/assets/stylesheets/decidim/vizzs/_areachart.scss`
+
+* `app/views/decidim/scopes/picker.html.erb`
+c76437f - Modify cancel button behaviour to match close button, 2022-02-08
+
+* `app/helpers/decidim/backup_helper.rb`
+83830be - Add retention service for daily backups (#19), 2021-11-09
+
+* `app/services/decidim/s3_retention_service.rb`
+de6d804 - fix multipart object tagging (#40) (#41), 2021-12-24
+
+* `config/initializers/omniauth_publik.rb`
+9d50925 - Feature omniauth publik (#46), 2022-01-18
+
+* `lib/tasks/restore_dump.rake`
+705e0ad - Run rubocop, 2021-12-01

--- a/app/views/decidim/scopes/picker.html.erb
+++ b/app/views/decidim/scopes/picker.html.erb
@@ -1,0 +1,57 @@
+<div class="scope-picker picker-header picker-list">
+  <h6 id="data_picker-title" class="h2"><%= title %></h6>
+  <div>
+    <ul role="group" aria-label="<%= t("decidim.scopes.picker.currently_selected") %>">
+      <% unless root %>
+        <% if parent_scopes.length < 1 %>
+          <li>
+            <a href="<%= scopes_picker_path(**context) %>" role="option" aria-controls="data_picker-modal" aria-selected="true"><%= t("decidim.scopes.global") %></a>
+          </li>
+        <% else %>
+          <li>
+            <a href="<%= scopes_picker_path(**context) %>" role="option" aria-controls="data_picker-modal"><%= t("decidim.scopes.global") %></a>
+          </li>
+        <% end %>
+      <% end %>
+      <% parent_scopes.each_with_index do |scope, ind| %>
+        <% if ind == parent_scopes.length - 1 %>
+          <li>
+            <a href="<%= scopes_picker_path(current: scope.id, max_depth: max_depth&.id, **context) %>" role="option" aria-controls="data_picker-modal" aria-selected="true"><%= translated_attribute(scope.name) %></a>
+          </li>
+        <% else %>
+          <li>
+            <a href="<%= scopes_picker_path(current: scope.id, max_depth: max_depth&.id, **context) %>" role="option" aria-controls="data_picker-modal"><%= translated_attribute(scope.name) %></a>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+</div>
+
+<div class="scope-picker picker-content picker-list">
+  <div class="picker-scrollable-content">
+    <% if scopes&.any? %>
+      <ul role="group" aria-label="<%= t("decidim.scopes.picker.change") %>">
+        <% scopes.each do |scope| %>
+          <li>
+            <a href="<%= scopes_picker_path(current: scope.id, max_depth: max_depth&.id, **context) %>" role="option" aria-controls="data_picker-modal">
+              <%= translated_attribute(scope.name) %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>
+
+<div class="scope-picker picker-footer reveal__footer">
+  <div class="buttons button--double">
+    <% if current || !required %>
+      <a class="button" role="button" href="<%= scopes_picker_path(current: current&.id, **context) %>" aria-controls="<%= picker_target_id %>" data-picker-value="<%= current&.id || global_value %>" data-picker-text="<%= scope_name_for_picker(current, t("decidim.scopes.global")) %>" data-picker-choose><%= t("decidim.scopes.picker.choose") %></a>
+  <% else %>
+      <a class="button muted"><%= t("decidim.scopes.picker.choose") %></a>
+    <% end %>
+
+    <a class="button clear" role="button" data-close type="button" data-reveal-id="data_picker-modal" aria-label="<%= t("decidim.scopes.picker.cancel") %>"><%= t("decidim.scopes.picker.cancel") %></a>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,13 @@ en:
         update:
           invalid: There was a problem updating the meeting.
           success: You have updated the meeting successfully.
+    scopes:
+      global: Global
+      picker:
+        cancel: Cancel
+        change: Change
+        choose: Choose
+        currently_selected: Currently selected
     verifications:
       authorizations:
         first_login:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -53,6 +53,13 @@ fr:
         update:
           invalid: Il y a eu une erreur lors de la mise à jour de la rencontre.
           success: La rencontre a été mise à jour avec succès.
+    scopes:
+      global: Portée générale
+      picker:
+        cancel: Annuler
+        change: Modifier
+        choose: Sélectionner
+        currently_selected: Sélectionné
     verifications:
       authorizations:
         first_login:


### PR DESCRIPTION
#### Description

Monkey patch `decidim-core/app/views/decidim/scopes/picker.html.erb` and update cancel button of the sector selector modal to work like the close button.

#### Additional information

Monkey patch no longer needed on 0.25 since webpacker