### PR TITLE
Add repare data rake task

### DIFF
--- a/lib/tasks/repare_data.rake
+++ b/lib/tasks/repare_data.rake
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :repare do
+    desc "Check for nicknames that doesn't respect valid format and update them"
+    task nickname: :environment do
+      logger = Logger.new($stdout)
+      logger.info("[data:repare:nickname] :: Checking all nicknames...")
+      invalid_users = Decidim::User.where.not("nickname ~* ?", "^[\\w-]+$")
+
+      if invalid_users.blank?
+        logger.info("[data:repare:nickname] :: All nicknames seems to be valid")
+        logger.info("[data:repare:nickname] :: Operation terminated")
+        exit 0
+      end
+
+      logger.info("[data:repare:nickname] :: Found #{invalid_users.count} invalids nicknames")
+      logger.info("[data:repare:nickname] :: Invalid user IDs : [#{invalid_users.map(&:id).join(", ")}]")
+
+      updated_users = []
+      invalid_users.each do |user|
+        chars = []
+
+        user.nickname.codepoints.each do |ascii_code|
+          char = ascii_to_valid_char(ascii_code)
+          chars << char if char.present?
+        end
+
+        new_nickname = chars.join.downcase
+        logger.info("[data:repare:nickname] :: User (##{user.id}) renaming nickname from '#{user.nickname}' to '#{new_nickname}'")
+        user.nickname = new_nickname
+
+        updated_users << user
+      end
+
+      if ask_for_permission(updated_users.count)
+        logger.info("[data:repare:nickname] :: Updating users...")
+        updated_users.each do |user|
+          user.save!
+          logger.info("[data:repare:nickname] :: User (##{user.id}) successfully updated")
+        rescue StandardError => e
+          logger.error("[data:repare:nickname] :: User (##{user.id}) an error occured")
+          logger.error("[data:repare:nickname] :: #{e}")
+        end
+      else
+        logger.info("[data:repare:nickname] :: Operation terminated")
+      end
+      logger.close
+
+      exit 0
+    end
+  end
+end
+
+def ask_for_permission(users_count)
+  $stdout.puts "Do you want to update these #{users_count} users ? [y/n]"
+  answer = $stdin.gets.chomp
+
+  %w(y Y yes YES).include?(answer)
+end
+
+def ascii_to_valid_char(id)
+  letters = ("A".."Z").to_a.join("").codepoints
+  letters += ("a".."z").to_a.join("").codepoints
+  digits = ("0".."9").to_a.join("").codepoints
+  special_chars = %w(- _).join("").codepoints
+
+  valid_ascii_code = letters + digits + special_chars
+
+  valid_ascii_code.include?(id) ? id.chr : ""
+end

--- a/spec/lib/tasks/repare_data_spec.rb
+++ b/spec/lib/tasks/repare_data_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:repare:nickname", type: :task do
+  let!(:organization) { create(:organization) }
+  let(:task_cmd) { :"decidim:repare:nickname" }
+
+  let!(:user) { create(:user, organization: organization) }
+  let!(:valid_user_2) { create(:user, nickname: "Azerty_Uiop123", organization: organization) }
+  let(:invalid_user_1) { build(:user, nickname: "Foo bar", organization: organization) }
+  let(:invalid_user_2) { build(:user, nickname: "Foo M. bar", organization: organization) }
+  let(:invalid_user_3) { build(:user, nickname: "Foo-Bar_fooo$", organization: organization) }
+  let(:invalid_user_4) { build(:user, nickname: "foo.bar.foo", organization: organization) }
+  let(:invalid_user_5) { build(:user, nickname: ".foobar.foo_bar.", organization: organization) }
+
+  context "when executing task" do
+    before do
+      invalid_user_1.save(validate: false)
+      invalid_user_2.save(validate: false)
+      invalid_user_3.save(validate: false)
+      invalid_user_4.save(validate: false)
+      invalid_user_5.save(validate: false)
+    end
+
+    it "exits with 0 code" do
+      allow($stdin).to receive(:gets).and_return("y")
+
+      expect { Rake::Task[task_cmd].invoke }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(0)
+      end
+    end
+
+    context "when user accepts update" do
+      it "updates invalid nicknames" do
+        allow($stdin).to receive(:gets).and_return("y")
+
+        expect { Rake::Task[task_cmd].invoke }.to change(invalid_user_1, :nickname).from("Foo bar").to("foobar")
+
+        invalid_user_1.reload
+        expect(invalid_user_1.nickname).to eq("foobar")
+        invalid_user_2.reload
+        expect(invalid_user_2.nickname).to eq("foombar")
+        invalid_user_3.reload
+        expect(invalid_user_3.nickname).to eq("foobarfooo")
+        invalid_user_4.reload
+        expect(invalid_user_4.nickname).to eq("foobarfoo")
+      end
+    end
+
+    context "when user refuses update" do
+      it "updates invalid nicknames" do
+        allow($stdin).to receive(:gets).and_return("n")
+
+        expect { Rake::Task[task_cmd].invoke }.not_to change(invalid_user_1, :nickname)
+
+        invalid_user_1.reload
+        expect(invalid_user_1.nickname).to eq("Foo bar")
+        invalid_user_2.reload
+        expect(invalid_user_2.nickname).to eq("Foo M. bar")
+        invalid_user_3.reload
+        expect(invalid_user_3.nickname).to eq("Foo-Bar_fooo$")
+        invalid_user_4.reload
+        expect(invalid_user_4.nickname).to eq("foo.bar.foo")
+        invalid_user_5.reload
+        expect(invalid_user_5.nickname).to eq(".foobar.foo_bar.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Description

Rake task to sanitize invalids nicknames in database.

#### Testing

* Seed locally a decidim-app
* Generate invalids nicknames using `bundle exec rails console`
Command to type in rails console : 
```
["Azertpoy Uiop", "Azpoer ty. Upoiop", "Azer dfy_ Uiop", ".dfsgfo.", ".azerty", "efke$fdf ^ez", ].each_with_index { |value, index| Decidim::User.new(name: "Demo #{index}", nickname: value, password: "decidim123456", password_confirmation: "decidim123456", email: "demo#{index}@example.org", organization: Decidim::Organization.first).save(validate: false) }
```
* Now execute the rake task : `bundle exec rake decidim:repare:nickname`, you should now see this output
```
I, [2022-03-23T09:46:39.785722 #2702]  INFO -- : [data:repare:nickname] :: Found 6 invalids nicknames
I, [2022-03-23T09:46:39.785848 #2702]  INFO -- : [data:repare:nickname] :: Invalid user IDs : [230, 231, 232, 233, 234, 235]
I, [2022-03-23T09:46:39.786248 #2702]  INFO -- : [data:repare:nickname] :: User (#230) renaming nickname from 'Azertpoy Uiop' to 'azertpoyuiop'
I, [2022-03-23T09:46:39.786701 #2702]  INFO -- : [data:repare:nickname] :: User (#231) renaming nickname from 'Azpoer ty. Upoiop' to 'azpoertyupoiop'
I, [2022-03-23T09:46:39.787102 #2702]  INFO -- : [data:repare:nickname] :: User (#232) renaming nickname from 'Azer dfy_ Uiop' to 'azerdfy_uiop'
I, [2022-03-23T09:46:39.787344 #2702]  INFO -- : [data:repare:nickname] :: User (#233) renaming nickname from '.dfsgfo.' to 'dfsgfo'
I, [2022-03-23T09:46:39.787528 #2702]  INFO -- : [data:repare:nickname] :: User (#234) renaming nickname from '.azerty' to 'azerty'
I, [2022-03-23T09:46:39.787826 #2702]  INFO -- : [data:repare:nickname] :: User (#235) renaming nickname from 'efke$fdf ^ez' to 'efkefdfez'
Do you want to update these 6 users ? [y/n]
```

If you choose to type 'y', nicknames will be corrected, otherwise they wont.