### PR TITLE
Add robot.txt example

### DIFF
--- a/dist/robot.txt
+++ b/dist/robot.txt
@@ -1,0 +1,7 @@
+User-agent: Googlebot
+Disallow:
+Disallow: /profiles
+Disallow: /*.pdf
+
+User-agent: *
+Disallow: /

--- a/dist/robot.txt
+++ b/dist/robot.txt
@@ -1,5 +1,4 @@
 User-agent: Googlebot
-Disallow:
 Disallow: /profiles
 Disallow: /*.pdf
 


### PR DESCRIPTION
This robot.txt will only accept visits from Googlebot, and disallow crawling on `/profiles` and `/*.pdf`.
All other bots will be disallowed