### PR TITLE
Update spam detection module branch to 0.25

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-decidim_awesome"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "bump/0.25-stable"
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "bump/0.25-stable"
 gem "decidim-question_captcha", git: "https://github.com/OpenSourcePolitics/decidim-module-question_captcha.git", branch: DECIDIM_VERSION
-gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", branch: "release/0.25-stable"
+gem "decidim-spam_detection"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "release/0.25-stable"
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"
 gem "omniauth-publik", git: "https://github.com/OpenSourcePolitics/omniauth-publik", branch: "v0.0.9"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-decidim_awesome"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "bump/0.25-stable"
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "bump/0.25-stable"
 gem "decidim-question_captcha", git: "https://github.com/OpenSourcePolitics/decidim-module-question_captcha.git", branch: DECIDIM_VERSION
-gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git"
+gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", branch: "release/0.25-stable"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "release/0.25-stable"
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"
 gem "omniauth-publik", git: "https://github.com/OpenSourcePolitics/omniauth-publik", branch: "v0.0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GIT
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
   revision: d1d0eabb59772eba20d0301cc4a896871a1c9732
+  branch: release/0.25-stable
   specs:
     decidim-spam_detection (1.1.2)
       decidim-core (~> 0.25)
@@ -994,4 +995,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.3.10
+   2.3.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,14 +26,6 @@ GIT
       decidim-core (= 0.25.2)
 
 GIT
-  remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
-  revision: d1d0eabb59772eba20d0301cc4a896871a1c9732
-  branch: release/0.25-stable
-  specs:
-    decidim-spam_detection (1.1.2)
-      decidim-core (~> 0.25)
-
-GIT
   remote: https://github.com/OpenSourcePolitics/omniauth-france_connect
   revision: dfed6cd11d755ee643dad335c3bf0881d6007429
   specs:
@@ -405,6 +397,8 @@ GEM
       decidim-admin (>= 0.25.0, < 0.27)
       decidim-core (>= 0.25.0, < 0.27)
       sassc (~> 2.3)
+    decidim-spam_detection (1.1.2)
+      decidim-core (~> 0.25)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -963,7 +957,7 @@ DEPENDENCIES
   decidim-homepage_interactive_map!
   decidim-phone_authorization_handler!
   decidim-question_captcha!
-  decidim-spam_detection!
+  decidim-spam_detection
   decidim-term_customizer!
   dotenv-rails
   faker (~> 2.14)


### PR DESCRIPTION
Spam detection master branch was bumped to 0.26 decidim version.
This PR aims to update the 0.25 decidim-app branch to point to 0.25 spam detection branch. 