### PR TITLE
Fix Rack Attack throttle configuration

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 if Rails.env.production?
+  
+  # Remove the original throttle fron decidim-core
+  # see https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
+  Rails.application.config.after_initialize do
+    Rack::Attack.throttles.delete("requests by ip")
+  end
+  
   Rack::Attack.throttle("req/ip",
                         limit: Decidim.throttling_max_requests,
                         period: Decidim.throttling_period) do |req|
-    next if req.path.start_with?("/assets")
+    next if req.path.start_with?("/decidim-packs")
     next if req.path.start_with?("/rails/active_storage")
 
     rack_logger = Logger.new(Rails.root.join("log/rack_attack.log"))


### PR DESCRIPTION
### 1. Remove the [original configuration from decidim-core](https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19)
Can only be done in an `after_initialize` hook

### 2. Update filter for `/assets` path to `/decidim-packs`
Because this is the new CSS/JS path for webpack assets