### PR TITLE
[Feature] Rack Attack setup Fail2Ban

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -25,6 +25,10 @@ CURRENCY=
 THROTTLING_MAX_REQUESTS=100
 # THROTTLING_PERIOD - Integer - Period for each IP in minutes
 THROTTLING_PERIOD=1
-# ENABLE_RACK_ATTACK - Binary (Default "1" in production only) - Enable or Disable Rack Attack
-# ENABLE_RACK_ATTACK=0 # Disabled
-ENABLE_RACK_ATTACK=1 # Enable
+# ENABLE_RACK_ATTACK - Binary (Default 1 in production only) - Enable or Disable Rack Attack
+# ENABLE_RACK_ATTACK=0
+ENABLE_RACK_ATTACK=1
+# RACK_ATTACK_FAIL2BAN - Binary (Default 1) - Enable or Disable Rack Attack Fail2Ban service
+# RACK_ATTACK_FAIL2BAN=0
+RACK_ATTACK_FAIL2BAN=1
+

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -53,7 +53,6 @@ Rack::Attack.blocklist('fail2ban pentesters') do |req|
   # so the request is blocked
   Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 0, findtime: 10.minutes, bantime: 1.hour) do
     # The count for the IP is incremented if the return value is truthy
-    CGI.unescape(req.query_string) =~ %r{/etc/passwd} ||
       req.path.include?('/etc/passwd') ||
       req.path.include?('/wp-admin/') ||
       req.path.include?('/wp-login/') ||

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -48,18 +48,18 @@ end
 
 # Block suspicious requests for '/etc/password' or wordpress specific paths.
 # After 3 blocked requests in 10 minutes, block all requests from that IP for 5 minutes.
-Rack::Attack.blocklist('fail2ban pentesters') do |req|
+Rack::Attack.blocklist("fail2ban pentesters") do |req|
   # `filter` returns truthy value if request fails, or if it's from a previously banned IP
   # so the request is blocked
   Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 0, findtime: 10.minutes, bantime: 1.hour) do
     # The count for the IP is incremented if the return value is truthy
-      req.path.include?('/etc/passwd') ||
-      req.path.include?('/wp-admin/') ||
-      req.path.include?('/wp-login/') ||
-      req.path.include?('SELECT') ||
-      req.path.include?('CONCAT') ||
-      req.path.include?('UNION SELECT') ||
-      req.path.include?('/.git/')
+    req.path.include?("/etc/passwd") ||
+      req.path.include?("/wp-admin/") ||
+      req.path.include?("/wp-login/") ||
+      req.path.include?("SELECT") ||
+      req.path.include?("CONCAT") ||
+      req.path.include?("UNION%20SELECT") ||
+      req.path.include?("/.git/")
   end
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -41,28 +41,29 @@ Rack::Attack.throttled_responder = lambda do |request|
 end
 
 Rack::Attack.throttle("req/ip",
-                      limit: Rails.application.secrets.decidim[:throttling_max_requests],
-                      period: Rails.application.secrets.decidim[:throttling_period]) do |req|
+                      limit: Rails.application.secrets.dig(:decidim, :rack_attack, :throttle, :max_requests),
+                      period: Rails.application.secrets.dig(:decidim, :rack_attack, :throttle, :period)) do |req|
   req.ip unless req.path.start_with?("/decidim-packs") || req.path.start_with?("/rails/active_storage") || req.path.start_with?("/admin/")
 end
 
-# Block suspicious requests for '/etc/password' or wordpress specific paths.
-# After 3 blocked requests in 10 minutes, block all requests from that IP for 5 minutes.
-Rack::Attack.blocklist("fail2ban pentesters") do |req|
-  # `filter` returns truthy value if request fails, or if it's from a previously banned IP
-  # so the request is blocked
-  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 0, findtime: 10.minutes, bantime: 1.hour) do
-    # The count for the IP is incremented if the return value is truthy
-    req.path.include?("/etc/passwd") ||
-      req.path.include?("/wp-admin/") ||
-      req.path.include?("/wp-login/") ||
-      req.path.include?("SELECT") ||
-      req.path.include?("CONCAT") ||
-      req.path.include?("UNION%20SELECT") ||
-      req.path.include?("/.git/")
+if Rails.application.secrets.dig(:decidim, :rack_attack, :fail2ban, :enabled) == 1
+  # Block suspicious requests made for pentesting
+  # After 1 forbidden request, block all requests from that IP for 1 hour.
+  Rack::Attack.blocklist("fail2ban pentesters") do |req|
+    # `filter` returns truthy value if request fails, or if it's from a previously banned IP
+    # so the request is blocked
+    Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 0, findtime: 10.minutes, bantime: 1.hour) do
+      # The count for the IP is incremented if the return value is truthy
+      req.path.include?("/etc/passwd") ||
+        req.path.include?("/wp-admin/") ||
+        req.path.include?("/wp-login/") ||
+        req.path.include?("SELECT") ||
+        req.path.include?("CONCAT") ||
+        req.path.include?("UNION%20SELECT") ||
+        req.path.include?("/.git/")
+    end
   end
 end
-
 def html_template(until_period, organization_name)
   name = organization_name.presence || "our platform"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,6 @@ en:
   rack_attack:
     too_many_requests:
       title: Thank you for your participation on %{organization_name}
-      message: Your connection have been slowed because server received too many requests.
+      message: Your connection has been slowed because server received too many requests.
       time: "You will be able to navigate on our website in :"
       time_unit: seconds

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,8 +14,12 @@ default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
     currency: <%= ENV["CURRENCY"] || "€" %>
-    throttling_max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
-    throttling_period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
+    rack_attack:
+      fail2ban:
+        enabled: <%= ENV["RACK_ATTACK_FAIL2BAN"]&.to_i || 1 %>
+      throttle:
+        max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
+        period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
   scaleway:
     id: <%= ENV["SCALEWAY_ID"] %>
     token: <%= ENV["SCALEWAY_TOKEN"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,7 +15,7 @@ default: &default
   decidim:
     currency: <%= ENV["CURRENCY"] || "€" %>
     throttling_max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
-    throttling_period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 1 %>
+    throttling_period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
   scaleway:
     id: <%= ENV["SCALEWAY_ID"] %>
     token: <%= ENV["SCALEWAY_TOKEN"] %>

--- a/spec/lib/rack_attack_spec.rb
+++ b/spec/lib/rack_attack_spec.rb
@@ -19,7 +19,7 @@ describe "Rack::Attack", type: :request do
     let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
 
     it "successful for 100 requests, then blocks the user" do
-      100.times do
+      100.times do |_|
         get decidim.root_path, params: {}, headers: headers
         expect(response).to have_http_status(:ok)
       end

--- a/spec/lib/rack_attack_spec.rb
+++ b/spec/lib/rack_attack_spec.rb
@@ -18,15 +18,15 @@ describe "Rack::Attack", type: :request do
   describe "Throttling" do
     let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
 
-    it "successful for 100 requests, then blocks the user nicely" do
+    it "successful for 100 requests, then blocks the user" do
       100.times do
         get decidim.root_path, params: {}, headers: headers
         expect(response).to have_http_status(:ok)
       end
 
       get decidim.root_path, params: {}, headers: headers
-      expect(response.body).to include("Your connection have been slowed because server received too many requests.")
       expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include("Your connection have been slowed because server received too many requests.")
 
       travel_to(1.minute.from_now) do
         get decidim.root_path, params: {}, headers: headers
@@ -53,9 +53,10 @@ describe "Rack::Attack", type: :request do
 
   describe "Fail2Ban" do
     let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
+    let(:invalid_routes) { ['/etc/passwd', '/wp-admin/', '/wp-login/', 'SELECT', 'CONCAT', 'UNION SELECT', '/.git/'] }
 
-    it "Block directly requests for invalid routes for 1 hour" do
-      get "#{decidim.root_path}/etc/passwd", params: {}, headers: headers
+    shared_examples_for "block user for specific request" do |decidim, path|
+      get "#{decidim.root_path}#{path}", params: {}, headers: headers
       expect(response).to have_http_status(:forbidden)
 
       get decidim.root_path, params: {}, headers: headers
@@ -64,6 +65,21 @@ describe "Rack::Attack", type: :request do
       travel_to(61.minutes.from_now) do
         get decidim.root_path, params: {}, headers: headers
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    %w[/etc/passwd /wp-admin/index.php /wp-login/index.php SELECT CONCAT /.git/config].each do |path|
+      it "blocks user for specific request : '#{path}'" do
+        get "#{decidim.root_path}#{path}", params: {}, headers: headers
+        expect(response).to have_http_status(:forbidden)
+
+        get decidim.root_path, params: {}, headers: headers
+        expect(response).to have_http_status(:forbidden)
+
+        travel_to(61.minutes.from_now) do
+          get decidim.root_path, params: {}, headers: headers
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
   end

--- a/spec/lib/rack_attack_spec.rb
+++ b/spec/lib/rack_attack_spec.rb
@@ -35,7 +35,7 @@ describe "Rack::Attack", type: :request do
     end
 
     it "successful for 99 requests" do
-      99.times do
+      99.times do |_|
         get decidim.root_path, params: {}, headers: headers
         expect(response).to have_http_status(:ok)
       end
@@ -53,22 +53,8 @@ describe "Rack::Attack", type: :request do
 
   describe "Fail2Ban" do
     let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
-    let(:invalid_routes) { ['/etc/passwd', '/wp-admin/', '/wp-login/', 'SELECT', 'CONCAT', 'UNION SELECT', '/.git/'] }
 
-    shared_examples_for "block user for specific request" do |decidim, path|
-      get "#{decidim.root_path}#{path}", params: {}, headers: headers
-      expect(response).to have_http_status(:forbidden)
-
-      get decidim.root_path, params: {}, headers: headers
-      expect(response).to have_http_status(:forbidden)
-
-      travel_to(61.minutes.from_now) do
-        get decidim.root_path, params: {}, headers: headers
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    %w[/etc/passwd /wp-admin/index.php /wp-login/index.php SELECT CONCAT /.git/config].each do |path|
+    %w(/etc/passwd /wp-admin/index.php /wp-login/index.php SELECT CONCAT /.git/config).each do |path|
       it "blocks user for specific request : '#{path}'" do
         get "#{decidim.root_path}#{path}", params: {}, headers: headers
         expect(response).to have_http_status(:forbidden)

--- a/spec/lib/rack_attack_spec.rb
+++ b/spec/lib/rack_attack_spec.rb
@@ -26,7 +26,7 @@ describe "Rack::Attack", type: :request do
 
       get decidim.root_path, params: {}, headers: headers
       expect(response).to have_http_status(:too_many_requests)
-      expect(response.body).to include("Your connection have been slowed because server received too many requests.")
+      expect(response.body).to include("Your connection has been slowed because server received too many requests.")
 
       travel_to(1.minute.from_now) do
         get decidim.root_path, params: {}, headers: headers
@@ -41,7 +41,7 @@ describe "Rack::Attack", type: :request do
       end
 
       get decidim.root_path, params: {}, headers: headers
-      expect(response.body).not_to include("Your connection have been slowed because server received too many requests.")
+      expect(response.body).not_to include("Your connection has been slowed because server received too many requests.")
       expect(response).not_to have_http_status(:too_many_requests)
 
       travel_to(1.minute.from_now) do

--- a/spec/system/confirmation_spec.rb
+++ b/spec/system/confirmation_spec.rb
@@ -76,6 +76,9 @@ describe "Registration", type: :system do
 
     before do
       allow(Rails).to receive(:cache).and_return(memory_store)
+      Rack::Attack.enabled = true
+      Rack::Attack.reset!
+
       visit decidim_friendly_signup.confirmation_codes_path(confirmation_token: confirmation_token)
 
       6.times do
@@ -84,8 +87,12 @@ describe "Registration", type: :system do
       end
     end
 
+    after do
+      Rack::Attack.enabled = false
+    end
+
     it "throttles after 5 attempts per minute" do
-      expect(page).to have_content("Retry later")
+      expect(page).to have_content("Your connection has been slowed because server received too many requests.")
     end
   end
 end


### PR DESCRIPTION
#### Description

Bots tries to find security vulnerabilities by requesting random routes. 

I think we should consider setup `Fail2Ban` service for some requests like Wordpress, Filesystem and others

Currently, configuration will ban each IP which tries at least once to access a forbidden request for 1 hour (can be more !)

#### Tasks

- [x] Ignore throttle on `/admin` routes
- [x] Add Fail2Ban (enabled by default)
- [x] Add specs and fix module friendly specs