### PR TITLE
Fix - MetricsJob failure - Day already taken

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,7 +15,7 @@
 
 :schedule:
   CalculateAllMetrics:
-    cron: '0 0 0 * * *' # Run at midnight
+    cron: '0 9 0 * * *' # Run at 00:09
     class: CalculateAllMetricsJob
     queue: scheduled
   PreloadOpenData:


### PR DESCRIPTION
Hello ! I send you this PR to try to fix a bug where you had a MetricsJob failure following this message - "Day has already been taken".

I've tried to modify your Sidekiq config to make your job execute at 00:09 when it was previously at 00:00 to avoid any repetition of the following command : rake decidim:metrics:all that seemed to self-repeat and produce this error.

If this doesn't work, please tell me then i'll send you my other solution that is linked to the file that is responsible of this error which is "app/queries/decidim/comments/metrics/comments_metric_manage.rb" that we can see on the stacktrace you sent there -> 
```from decidim (5043f94d3d98) decidim-comments/app/queries/decidim/comments/metrics/comments_metric_manage.rb:23:in `block in save'
  from decidim (5043f94d3d98) decidim-comments/app/queries/decidim/comments/metrics/comments_metric_manage.rb:12:in `each'
  from decidim (5043f94d3d98) decidim-comments/app/queries/decidim/comments/metrics/comments_metric_manage.rb:12:in `save'```

with the idea to add a rescue to the part of the function that produces the issue.