### PR TITLE
Fix extends

### DIFF
--- a/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
@@ -17,7 +17,7 @@ module SessionControllerExtends
     private
 
     # Skip authorization handler by default
-    def skip_fist_login_authorization?
+    def skip_first_login_authorization?
       ActiveRecord::Type::Boolean.new.cast(ENV.fetch("SKIP_FIRST_LOGIN_AUTHORIZATION", "false"))
     end
   end

--- a/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 module SessionControllerExtends
-  def after_sign_in_path_for(user)
-    if user.present? && user.blocked?
-      check_user_block_status(user)
-    elsif first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user) && !skip_authorization_handler?
-      decidim_verifications.first_login_authorizations_path
-    else
-      super
+  extend ActiveSupport::Concern
+
+  included do
+    def after_sign_in_path_for(user)
+      if user.present? && user.blocked?
+        check_user_block_status(user)
+      elsif !skip_fist_login_authorization? && (first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user))
+        decidim_verifications.first_login_authorizations_path
+      else
+        super
+      end
     end
-  end
 
-  private
+    private
 
-  # Skip authorization handler by default
-  def skip_authorization_handler?
-    ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] ? ActiveRecord::Type::Boolean.new.cast(ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"]) : true
+    # Skip authorization handler by default
+    def skip_fist_login_authorization?
+      ActiveRecord::Type::Boolean.new.cast(ENV.fetch("SKIP_FIRST_LOGIN_AUTHORIZATION", "false"))
+    end
   end
 end
 
 Decidim::Devise::SessionsController.class_eval do
-  prepend(SessionControllerExtends)
+  include(SessionControllerExtends)
 end

--- a/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
@@ -7,7 +7,7 @@ module SessionControllerExtends
     def after_sign_in_path_for(user)
       if user.present? && user.blocked?
         check_user_block_status(user)
-      elsif !skip_fist_login_authorization? && (first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user))
+      elsif !skip_first_login_authorization? && (first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user))
         decidim_verifications.first_login_authorizations_path
       else
         super

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -68,19 +68,23 @@ module Decidim
 
                   it { is_expected.to eq("/authorizations/first_login") }
                 end
+
+                context "when first login authorization is skipped" do
+                  before do
+                    ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] = "true"
+                  end
+
+                  after do
+                    ENV.delete("SKIP_FIRST_LOGIN_AUTHORIZATION")
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
               end
 
               context "and otherwise", with_authorization_workflows: [] do
                 before do
                   allow(user.organization).to receive(:available_authorizations).and_return([])
-                end
-
-                it { is_expected.to eq("/") }
-              end
-
-              context "and authorization handler is skipped" do
-                before do
-                  allow(ENV).to receive(:[]).with("SKIP_FIRST_LOGIN_AUTHORIZATION").and_return("true")
                 end
 
                 it { is_expected.to eq("/") }


### PR DESCRIPTION
#### :tophat: Description
Extends was not properly loaded therefore the first login authorization could not be skipped
