### PR TITLE
Bump friendly sign up to fix emails links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git
-  revision: fbf147b5aae425130976807b5ed38f76393439aa
+  revision: ed9f58716b7103afaa8b19a874086aaa485018d4
   specs:
     decidim-friendly_signup (0.4.2)
       decidim-core (~> 0.26.0)


### PR DESCRIPTION
#### :tophat: Description
Bump friendly sign up to fix emails links

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/OpenSourcePolitics/decidim-module-friendly_signup/pull/14?
- Fixes https://github.com/OpenSourcePolitics/decidim-module-friendly_signup/issues/10?

#### Testing
1. Create an account
2. Go to letter opener
3. The link is redirecting to the friendly sign up confirmation page (with code)