### PR TITLE
Add cache_hash on project list item cell

### DIFF
--- a/app/cells/decidim/budgets/project_list_item_cell.rb
+++ b/app/cells/decidim/budgets/project_list_item_cell.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    # This cell renders a horizontal project card
+    # for an given instance of a Project in a budget list
+    class ProjectListItemCell < Decidim::ViewModel
+      include ActiveSupport::NumberHelper
+      include Decidim::LayoutHelper
+      include Decidim::ActionAuthorizationHelper
+      include Decidim::Budgets::ProjectsHelper
+      include Decidim::Budgets::Engine.routes.url_helpers
+
+      delegate :current_user, :current_settings, :current_order, :current_component,
+               :current_participatory_space, :can_have_order?, :voting_open?, :voting_finished?, to: :parent_controller
+
+      private
+
+      def resource_path
+        resource_locator([model.budget, model]).path
+      end
+
+      def resource_title
+        translated_attribute model.title
+      end
+
+      def resource_added?
+        current_order && current_order.projects.include?(model)
+      end
+
+      def resource_allocation
+        current_order.allocation_for(model)
+      end
+
+      def data_class
+        [].tap do |list|
+          list << "budget-list__data--added" if can_have_order? && resource_added?
+          list << "show-for-medium" if voting_finished? || (current_order_checked_out? && !resource_added?)
+        end.join(" ")
+      end
+
+      def vote_button_disabled?
+        current_user && !can_have_order?
+      end
+
+      def vote_button_class
+        return "success" if resource_added?
+
+        "hollow"
+      end
+
+      def vote_button_method
+        return :delete if resource_added?
+
+        :post
+      end
+
+      def vote_button_label
+        if resource_added?
+          return t(
+            "decidim.budgets.projects.project.remove",
+            resource_name: resource_title
+          )
+        end
+
+        t("decidim.budgets.projects.project.add", resource_name: resource_title)
+      end
+
+      def cache_hash
+        hash = []
+        hash.push(model.id)
+        hash.push(resource_title)
+        hash.push(model.budget_amount)
+        hash.push(model&.category.try(:id))
+        hash.push(resource_added?)
+        hash.push(can_have_order?)
+        hash.join(Decidim.cache_key_separator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

We notice a potential rendering optimization in budget projects index on project cell.

Now each project cell in index path is saved in Rails cache

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://www.notion.so/opensourcepolitics/Perf-Tester-r-gression-decidim-app-9db0feb545c64b779743833d2b243250

#### Testing

Go to a budget projects index path
Note each project present
Try to log in as user:
- Vote a project
Logout

**Aim is to be sure that graphical interface is well synchronized with actual state**

#### Tasks

- [x] Add note about overrides in OVERLOADS.md

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
![cell_rendering_caching](https://user-images.githubusercontent.com/26109239/213504981-5bc13acf-198d-4b6b-8ba5-3ff7a4120128.png)

**Legend:**
* Yellow (Default): is response time of the projects page with initial configuration (without optimization) on 10 iterations
* Green / Blue (Cell Rendering / All) are equals, is response time with caching of projects cell on 10 iterations

### Additional information

🚨 Caching may occur unexpected behaviour like a desynchronization of display 

