### PR TITLE
Setup different sample rate for sidekiq

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -35,3 +35,5 @@ AVAILABLE_LOCALES="fr,en"
 # Force SSL - binary (default: 1)
 # Can be disable for reverse proxy setup
 FORCE_SSL=1
+SENTRY_SIDEKIQ_SAMPLE_RATE=0.1
+SENTRY_SAMPLE_RATE=0.5

--- a/lib/initializers/sentry_setup.rb
+++ b/lib/initializers/sentry_setup.rb
@@ -12,7 +12,7 @@ module SentrySetup
         config.dsn = Rails.application.secrets.dig(:sentry, :dsn)
         config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-        config.traces_sample_rate = sample_rate
+        config.traces_sample_rate = sample_rate.to_f
       end
 
       Sentry.set_tags('server.hostname': hostname) if hostname.present?
@@ -36,7 +36,7 @@ module SentrySetup
     end
 
     def sample_rate
-      Sidekiq.server? ? ENV.fetch("SENTRY_SAMPLE_RATE", 0.1) : ENV.fetch("SENTRY_SAMPLE_RATE", 0.5)
+      Sidekiq.server? ? ENV.fetch("SENTRY_SIDEKIQ_SAMPLE_RATE", "0.1") : ENV.fetch("SENTRY_SAMPLE_RATE", "0.5")
     end
   end
 end

--- a/lib/initializers/sentry_setup.rb
+++ b/lib/initializers/sentry_setup.rb
@@ -10,11 +10,9 @@ module SentrySetup
 
       Sentry.init do |config|
         config.dsn = Rails.application.secrets.dig(:sentry, :dsn)
-        config.breadcrumbs_logger = [:active_support_logger]
+        config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-        # To activate performance monitoring, set one of these options.
-        # We recommend adjusting the value in production:
-        config.traces_sample_rate = ENV.fetch("SENTRY_SAMPLE_RATE", 1.0)
+        config.traces_sample_rate = sample_rate
       end
 
       Sentry.set_tags('server.hostname': hostname) if hostname.present?
@@ -35,6 +33,10 @@ module SentrySetup
 
     def ip
       server_metadata&.dig("public_ip", "address")
+    end
+
+    def sample_rate
+      Sidekiq.server? ? ENV.fetch("SENTRY_SAMPLE_RATE", 0.1) : ENV.fetch("SENTRY_SAMPLE_RATE", 0.5)
     end
   end
 end

--- a/spec/lib/sentry_setup_spec.rb
+++ b/spec/lib/sentry_setup_spec.rb
@@ -32,7 +32,7 @@ describe SentrySetup do
   describe ".init" do
     it "is configured" do
       expect(Sentry.configuration.dsn.host).to eq("sentry.dsn")
-      expect(Sentry.configuration.traces_sample_rate).to eq(1.0)
+      expect(Sentry.configuration.traces_sample_rate).to eq(0.5)
     end
 
     context "when sentry is disabled" do
@@ -91,6 +91,22 @@ describe SentrySetup do
 
     it "returns a metadata hash" do
       expect(subject.send(:server_metadata)).to be_a(Hash)
+    end
+  end
+
+  describe ".sample rate" do
+    it "returns the sample rate" do
+      expect(subject.send(:sample_rate)).to eq(0.5)
+    end
+
+    context "when in a sidekiq worker" do
+      before do
+        allow(Sidekiq).to receive(:server?).and_return("constant")
+      end
+
+      it "returns the sample rate" do
+        expect(subject.send(:sample_rate)).to eq(0.1)
+      end
     end
   end
 end

--- a/spec/lib/sentry_setup_spec.rb
+++ b/spec/lib/sentry_setup_spec.rb
@@ -96,7 +96,7 @@ describe SentrySetup do
 
   describe ".sample rate" do
     it "returns the sample rate" do
-      expect(subject.send(:sample_rate)).to eq(0.5)
+      expect(subject.send(:sample_rate)).to eq("0.5")
     end
 
     context "when in a sidekiq worker" do
@@ -105,7 +105,7 @@ describe SentrySetup do
       end
 
       it "returns the sample rate" do
-        expect(subject.send(:sample_rate)).to eq(0.1)
+        expect(subject.send(:sample_rate)).to eq("0.1")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: Description
Allows to customize the sample size in the context of sidekiq in order to reduce costs and noise generated on the error tracers.

The default values are respectively 50% (web) and 10% (sidekiq) and configurable through the following environment variables: SENTRY_SAMPLE_RATE (web) and SENTRY_SIDEKIQ_SAMPLE_RATE (sidekiq)

#### Tasks
- [x] Add specs