### PR TITLE
Use fail fast to continue tests on matrix if failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
         name: Lint Ruby files
   tests:
     strategy:
+      fail-fast: false
       matrix:
         slice: [ "0-2", "1-2" ]
     name: Tests


### PR DESCRIPTION
#### :tophat: Description
When tests are failing inside a matrix job, all suite is failing.
Introducing fail-fast false allows the whole suite to run even in a failing case.