### PR TITLE
Remove useless gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ group :production do
   gem "dalli"
   gem "health_check", "~> 3.1"
   gem "lograge"
-  gem "newrelic_rpm"
-  gem "passenger"
   gem "sendgrid-ruby"
   gem "sentry-rails"
   gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,7 +619,6 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    newrelic_rpm (9.1.0)
     nio4r (2.5.9)
     nokogiri (1.13.4-arm64-darwin)
       racc (~> 1.4)
@@ -687,9 +686,6 @@ GEM
       parallel
     parser (3.2.2.0)
       ast (~> 2.4.1)
-    passenger (6.0.17)
-      rack
-      rake (>= 0.8.1)
     pg (1.1.4)
     pg_search (2.3.6)
       activerecord (>= 5.2)
@@ -1014,13 +1010,11 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   lograge
-  newrelic_rpm
   nokogiri (= 1.13.4)
   omniauth-france_connect!
   omniauth-publik!
   omniauth-rails_csrf_protection (~> 1.0)
   parallel_tests
-  passenger
   puma (>= 5.5.1)
   rack-attack (~> 6.6)
   rubocop-faker


### PR DESCRIPTION
- Gem passenger is never used because we use a standalone integration with Nginx
- Gem new relic is never used
