### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -23,15 +23,3 @@ jobs:
           key: ${{ secrets.ANSIBLE_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: ansible-playbook -u ${{ secrets.ANSIBLE_USERNAME }} --private-key="~/.ssh/ansible-deploy/ansible-deploy" -i /home/${{ secrets.ANSIBLE_USERNAME }}/ansible/decidim/inventories/production.yml /home/${{ secrets.ANSIBLE_USERNAME }}/ansible/decidim/playbooks/update_decidim_app.yml
-  build_and_push_image:
-    name: Build and push image to Registry
-    if: "github.ref == 'refs/heads/master'"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: OpenSourcePolitics/build-and-push-images-action@master
-        with:
-          registry: ${{ vars.REGISTRY_ENDPOINT }}
-          namespace: ${{ vars.REGISTRY_NAMESPACE }}
-          password: ${{ secrets.TOKEN }}
-          image_name: ${{ vars.IMAGE_NAME }}
-          tag: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_and_push_image_prod:
+    name: Build and push image to Registry
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: OpenSourcePolitics/build-and-push-images-action@master
+        with:
+          registry: ${{ vars.REGISTRY_ENDPOINT }}
+          namespace: ${{ vars.REGISTRY_NAMESPACE }}
+          password: ${{ secrets.TOKEN }}
+          image_name: ${{ vars.IMAGE_NAME }}
+          tag: "${{github.ref_name}}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,7 +242,7 @@ jobs:
           key: ${{ secrets.ANSIBLE_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: ansible-playbook -u ${{ secrets.ANSIBLE_USERNAME }} --private-key="~/.ssh/ansible-deploy/ansible-deploy" -i /home/${{ secrets.ANSIBLE_USERNAME }}/ansible/decidim/inventories/staging.yml /home/${{ secrets.ANSIBLE_USERNAME }}/ansible/decidim/playbooks/update_decidim_app.yml
-  build_and_push_image:
+  build_and_push_image_dev:
     name: Build and push image to Registry
     if: "github.ref == 'refs/heads/develop'"
     needs: [lint, tests, system_tests, test_build]
@@ -254,4 +254,22 @@ jobs:
           namespace: ${{ vars.REGISTRY_NAMESPACE }}
           password: ${{ secrets.TOKEN }}
           image_name: ${{ vars.IMAGE_NAME }}
-          tag: "develop"
+          tag: "develop-${{ github.sha }}"
+  generate_release:
+    name: Generate release
+    needs: [lint, tests, system_tests, test_build]
+    if: "github.ref == 'refs/heads/master'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Bump version and push tag
+        id: tag_version
+      - uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ncipollo/release-action@v1
+        name: Create a GitHub release
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
#### :tophat: Description
On the master branch after all tests pass, 
* generates a default patch release. (see https://github.com/mathieudutour/github-tag-action)
* generates a release on github
* upload an image with the corresponding tag on scaleway registry.



