### PR TITLE
[Fix] - Display of images in surveys

### DIFF
--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -11,7 +11,7 @@
   <h2 class="section-heading"><%= translated_attribute questionnaire.title %></h2>
   <div class="row">
     <div class="columns large-<%= columns %> medium-centered lead">
-      <%= decidim_sanitize_editor translated_attribute questionnaire.description %>
+      <%= decidim_sanitize_editor_admin translated_attribute questionnaire.description %>
     </div>
   </div>
 </div>

--- a/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -70,7 +70,7 @@ module Decidim
 
       describe "when the form is invalid" do
         before do
-          expect(form).to receive(:invalid?).and_return(true)
+          allow(form).to receive(:invalid?).and_return(true)
         end
 
         it "broadcasts invalid" do

--- a/spec/system/survey_spec.rb
+++ b/spec/system/survey_spec.rb
@@ -94,6 +94,24 @@ describe "Answer a survey", type: :system do
     end
   end
 
+  context "when survey contains images" do
+    let!(:description) do
+      {
+        "en" => "<p>Survey's content</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+        "ca" => "<p>Contingut de l'enquesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+        "es" => "<p>Contenido de la encuesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>"
+      }
+    end
+    let(:image_url) { "https://decidim.org/assets/decidim/logo-2x-1b6d1f7f7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d.png" }
+    let(:router) { Decidim::EngineRouter.main_proxy(component) }
+
+    it "shows image" do
+      visit_component
+      expect(page).to have_selector("img[src='#{image_url}']")
+      expect(page).to have_selector("iframe[src='#{image_url}']")
+    end
+  end
+
   context "when survey has action log entry" do
     let!(:action_log) { create(:action_log, user: user, organization: component.organization, resource: survey, component: component, participatory_space: component.participatory_space, visibility: "all") }
     let(:router) { Decidim::EngineRouter.main_proxy(component) }


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
This fixes the displaying of images into the surveys

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Angers-bug-affichage-image-fonctionnalit-enqu-te-b6861a22e68d46aa92f74ceba69c4409?pvs=4)

#### Tasks
- [x] Add specs
- [x] Refreshing the backport

