### PR TITLE
[Fix] - Disappearance of templates

### DIFF
--- a/app/permissions/decidim/admin/permissions.rb
+++ b/app/permissions/decidim/admin/permissions.rb
@@ -36,6 +36,7 @@ module Decidim
           allow! if read_metrics_action?
           allow! if static_page_action?
           allow! if organization_action?
+          allow! if templates_action?
           allow! if user_action?
 
           allow! if permission_action.subject == :category
@@ -66,6 +67,11 @@ module Decidim
 
       def user_manager?
         user && !user.admin? && user.role?("user_manager")
+      end
+
+      def templates_action?
+        permission_action.subject == :templates &&
+          permission_action.action == :read
       end
 
       def read_admin_dashboard_action?

--- a/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/spec/permissions/decidim/admin/permissions_spec.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::Permissions do
+  subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+  let(:user) { build :user, :admin, organization: organization }
+  let(:organization) { build :organization }
+  let(:context) { {} }
+  let(:permission_action) { Decidim::PermissionAction.new(action) }
+  let(:registrations_enabled) { true }
+  let(:action) do
+    { scope: :admin, action: action_name, subject: action_subject }
+    { scope: :admin, action: action_name, subject: action_subject }
+  end
+  let(:action_name) { :foo }
+  let(:action_subject) { :bar }
+
+  shared_examples "needs to accept Terms of Use for" do |action_subject_name, action_name|
+    let(:action_subject) { action_subject_name }
+    let(:action_name) { action_name }
+
+    context "when admin has accepted Terms of Use" do
+      let(:user) { build :user, :admin, admin_terms_accepted_at: Time.current, organization: organization }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  context "when scope is not admin" do
+    let(:action) do
+      { scope: :public, action: :foo, subject: :bar }
+    end
+
+    context "when reading the admin dashboard" do
+      let(:action) do
+        { scope: :public, action: :read, subject: :admin_dashboard }
+      end
+
+      it { is_expected.to eq true }
+
+      context "when user is a user manager" do
+        let(:user) { build :user, :user_manager }
+
+        it { is_expected.to eq true }
+      end
+    end
+  end
+
+  context "when user is not present" do
+    let(:user) { nil }
+
+    it { is_expected.to eq false }
+  end
+
+  context "when user is a user manager" do
+    let(:user) { build :user, :user_manager }
+
+    it_behaves_like "delegates permissions to", Decidim::Admin::UserManagerPermissions
+
+    context "when entering a space area with space admin role" do
+      let(:action) do
+        { scope: :admin, action: :enter, subject: :space_area }
+      end
+      let(:participatory_process) { create(:participatory_process, organization: user.organization) }
+
+      before do
+        ::Decidim::ParticipatoryProcessUserRole.create(user: user, participatory_process: participatory_process, role: :admin)
+      end
+
+      it "allows users to enter the space area" do
+        expect { subject }.to raise_error(Decidim::PermissionAction::PermissionNotSetError)
+      end
+    end
+  end
+
+  context "when reading the admin dashboard" do
+    let(:action_name) { :read }
+    let(:action_subject) { :admin_dashboard }
+
+    it { is_expected.to eq true }
+  end
+
+  describe "admin logs" do
+    let(:action_subject) { :admin_log }
+
+    it_behaves_like "permission is not set"
+
+    context "when reading" do
+      let(:action_name) { :read }
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "metrics" do
+    let(:action_subject) { :metrics }
+
+    it_behaves_like "permission is not set"
+
+    context "when reading" do
+      let(:action_name) { :read }
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "static pages" do
+    let(:action_subject) { :static_page }
+    let(:page) { build(:static_page, :default) }
+    let(:context) { { static_page: page } }
+
+    context "when updating" do
+      let(:action_name) { :update }
+
+      it { is_expected.to eq true }
+
+      context "when page is not present" do
+        let(:page) { nil }
+
+        it_behaves_like "permission is not set"
+      end
+    end
+
+    context "when updating the slug" do
+      let(:action_name) { :update_slug }
+
+      context "when page is not present" do
+        let(:page) { nil }
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when page is default" do
+        it_behaves_like "permission is not set"
+      end
+
+      context "when page is not default" do
+        let(:page) { build :static_page }
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "when any other action" do
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "global moderation" do
+    it_behaves_like "needs to accept Terms of Use for", :global_moderation, :read
+  end
+
+  describe "share tokens" do
+    let(:action_subject) { :share_token }
+
+    context "when any action" do
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "organization" do
+    let(:action_subject) { :organization }
+    let(:context) { { organization: organization } }
+
+    context "when updating" do
+      let(:action_name) { :update }
+
+      context "when user belongs to organization" do
+        it { is_expected.to eq true }
+      end
+
+      context "when user does not belong to organization" do
+        let(:user) { build :user, :admin }
+
+        it_behaves_like "permission is not set"
+      end
+    end
+
+    context "when any other action" do
+      it_behaves_like "permission is not set"
+    end
+  end
+
+  describe "templates" do
+    let(:action_subject) { :templates }
+    let(:context) { { organization: organization } }
+
+    context "when reading" do
+      let(:action_name) { :read }
+
+      context "when user belongs to organization" do
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "when any other action" do
+      it_behaves_like "permission is not set"
+    end
+  end
+
+  describe "managed users" do
+    let(:action_subject) { :managed_user }
+    let(:context) { { organization: organization } }
+
+    context "when creating" do
+      let(:action_name) { :create }
+
+      before do
+        allow(organization)
+          .to receive(:available_authorizations)
+                .and_return(authorizations)
+      end
+
+      context "when organization available authorizations are empty" do
+        let(:authorizations) { [] }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when organization available authorizations are not empty" do
+        let(:authorizations) { [:foo] }
+
+        it_behaves_like "needs to accept Terms of Use for", :managed_user, :create
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when any other action" do
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "users" do
+    let(:action_subject) { :user }
+    let(:subject_user) { build :user }
+    let(:context) { { user: subject_user } }
+
+    context "when destroying" do
+      let(:action_name) { :destroy }
+
+      context "when destroying another user" do
+        it { is_expected.to eq true }
+      end
+
+      context "when destroying itself" do
+        let(:subject_user) { user }
+
+        it_behaves_like "permission is not set"
+      end
+    end
+
+    context "when promoting" do
+      let(:action_name) { :promote }
+
+      context "when subject user is not managed" do
+        it_behaves_like "permission is not set"
+      end
+
+      context "when subject user is managed" do
+        let(:subject_user) { build :user, :managed, organization: organization }
+
+        context "when there are active impersonation logs" do
+          before do
+            create :impersonation_log, user: subject_user, admin: user
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when there are no active impersonation logs" do
+          it { is_expected.to eq true }
+        end
+      end
+    end
+
+    context "when impersonating" do
+      let(:action_name) { :impersonate }
+      let(:organization) { build :organization, available_authorizations: ["dummy_authorization_handler"] }
+
+      context "when organization has no available authorizations" do
+        let(:organization) { build :organization, available_authorizations: [] }
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when subject user is admin" do
+        let(:subject_user) { build :user, :admin, organization: organization }
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when subject user has some roles" do
+        let(:subject_user) { build :user, roles: ["my_role"] }
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when there are active impersonation logs" do
+        let(:subject_user) { build :user, organization: organization }
+
+        before do
+          create :impersonation_log, user: subject_user, admin: user
+        end
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when there are no active impersonation logs" do
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "when show their email" do
+      let(:action_name) { :show_email }
+
+      it { is_expected.to eq true }
+
+      context "when user is not an admin" do
+        let(:user) { build :user, organization: organization }
+
+        it_behaves_like "permission is not set"
+      end
+    end
+
+    context "when any other action" do
+      it { is_expected.to eq true }
+    end
+  end
+
+  shared_examples "can perform any action for" do |action_subject_name|
+    let(:action_subject) { action_subject_name }
+
+    it { is_expected.to eq true }
+  end
+
+  it_behaves_like "can perform any action for", :category
+  it_behaves_like "can perform any action for", :component
+  it_behaves_like "can perform any action for", :admin_user
+  it_behaves_like "can perform any action for", :attachment
+  it_behaves_like "can perform any action for", :attachment_collection
+  it_behaves_like "can perform any action for", :scope
+  it_behaves_like "can perform any action for", :scope_type
+  it_behaves_like "can perform any action for", :area
+  it_behaves_like "can perform any action for", :area_type
+  it_behaves_like "can perform any action for", :newsletter
+  it_behaves_like "can perform any action for", :user_group
+  it_behaves_like "can perform any action for", :officialization
+  it_behaves_like "can perform any action for", :moderate_users
+  it_behaves_like "can perform any action for", :authorization
+  it_behaves_like "can perform any action for", :authorization_workflow
+end

--- a/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/spec/permissions/decidim/admin/permissions_spec.rb
@@ -25,12 +25,6 @@ describe Decidim::Admin::Permissions do
 
       it { is_expected.to be true }
     end
-
-    context "when admin hasn't accepted Terms of Use" do
-      let(:user) { build :user, :admin, admin_terms_accepted_at: nil, organization: organization }
-
-      it_behaves_like "permission is not set"
-    end
   end
 
   context "when scope is not admin" do
@@ -51,8 +45,6 @@ describe Decidim::Admin::Permissions do
         it { is_expected.to eq true }
       end
     end
-
-    it_behaves_like "permission is not set"
   end
 
   context "when user is not present" do
@@ -82,10 +74,6 @@ describe Decidim::Admin::Permissions do
     end
   end
 
-  context "when action is not registered" do
-    it_behaves_like "permission is not set"
-  end
-
   context "when reading the admin dashboard" do
     let(:action_name) { :read }
     let(:action_subject) { :admin_dashboard }
@@ -102,18 +90,6 @@ describe Decidim::Admin::Permissions do
       let(:action_name) { :read }
 
       it { is_expected.to eq true }
-    end
-  end
-
-  describe "user statistics" do
-    let(:action_subject) { :users_statistics }
-
-    it_behaves_like "permission is not set"
-
-    context "when reading" do
-      let(:action_name) { :read }
-
-      it { is_expected.to be true }
     end
   end
 
@@ -350,24 +326,6 @@ describe Decidim::Admin::Permissions do
 
     context "when any other action" do
       it { is_expected.to eq true }
-    end
-  end
-
-  describe "admins" do
-    let(:action_subject) { :admin_user }
-
-    context "when trying to delete admin rights from self" do
-      let(:action_name) { :destroy }
-      let(:context) { { user: user } }
-
-      it_behaves_like "permission is not set"
-    end
-
-    context "when trying to block self" do
-      let(:action_name) { :block }
-      let(:context) { { user: user } }
-
-      it_behaves_like "permission is not set"
     end
   end
 

--- a/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/spec/permissions/decidim/admin/permissions_spec.rb
@@ -25,6 +25,12 @@ describe Decidim::Admin::Permissions do
 
       it { is_expected.to be true }
     end
+
+    context "when admin hasn't accepted Terms of Use" do
+      let(:user) { build :user, :admin, admin_terms_accepted_at: nil, organization: organization }
+
+      it_behaves_like "permission is not set"
+    end
   end
 
   context "when scope is not admin" do
@@ -45,6 +51,8 @@ describe Decidim::Admin::Permissions do
         it { is_expected.to eq true }
       end
     end
+
+    it_behaves_like "permission is not set"
   end
 
   context "when user is not present" do
@@ -74,6 +82,10 @@ describe Decidim::Admin::Permissions do
     end
   end
 
+  context "when action is not registered" do
+    it_behaves_like "permission is not set"
+  end
+
   context "when reading the admin dashboard" do
     let(:action_name) { :read }
     let(:action_subject) { :admin_dashboard }
@@ -90,6 +102,18 @@ describe Decidim::Admin::Permissions do
       let(:action_name) { :read }
 
       it { is_expected.to eq true }
+    end
+  end
+
+  describe "user statistics" do
+    let(:action_subject) { :users_statistics }
+
+    it_behaves_like "permission is not set"
+
+    context "when reading" do
+      let(:action_name) { :read }
+
+      it { is_expected.to be true }
     end
   end
 
@@ -326,6 +350,24 @@ describe Decidim::Admin::Permissions do
 
     context "when any other action" do
       it { is_expected.to eq true }
+    end
+  end
+
+  describe "admins" do
+    let(:action_subject) { :admin_user }
+
+    context "when trying to delete admin rights from self" do
+      let(:action_name) { :destroy }
+      let(:context) { { user: user } }
+
+      it_behaves_like "permission is not set"
+    end
+
+    context "when trying to block self" do
+      let(:action_name) { :block }
+      let(:context) { { user: user } }
+
+      it_behaves_like "permission is not set"
     end
   end
 

--- a/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/spec/permissions/decidim/admin/permissions_spec.rb
@@ -12,7 +12,6 @@ describe Decidim::Admin::Permissions do
   let(:registrations_enabled) { true }
   let(:action) do
     { scope: :admin, action: action_name, subject: action_subject }
-    { scope: :admin, action: action_name, subject: action_subject }
   end
   let(:action_name) { :foo }
   let(:action_subject) { :bar }
@@ -210,7 +209,7 @@ describe Decidim::Admin::Permissions do
       before do
         allow(organization)
           .to receive(:available_authorizations)
-                .and_return(authorizations)
+          .and_return(authorizations)
       end
 
       context "when organization available authorizations are empty" do


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
This PR is here to fix the disappearance of templates from the back office main navbar

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/BUG-Disparition-du-module-Mod-le-de-questionnaire-c886ec0ca84a4ee38f4b7a5754af3c5b?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Check if "templates" is available
* Check features

#### Tasks
- [x] Add specs
- [x] Backport missing permissions (linked to [This commit](https://github.com/decidim/decidim/commit/2e28d705ccf276c02e9f8ec1cf962dc47e1a747f))

