### PR TITLE
Add upgrade task

### DIFF
--- a/lib/tasks/decidim_app.rake
+++ b/lib/tasks/decidim_app.rake
@@ -36,6 +36,9 @@ namespace :decidim_app do
     Decidim::SystemAdminCreator.create!(ENV) ? puts("System admin created successfully") : puts("System admin creation failed")
   end
 
+  # This task is used to upgrade your decidim-app to the latest version
+  # Meant to be used in a CI/CD pipeline or a k8s job/operator
+  # You can add your own customizations here
   desc "Upgrade decidim-app"
   task upgrade: :environment do
     puts "Running db:migrate"

--- a/lib/tasks/decidim_app.rake
+++ b/lib/tasks/decidim_app.rake
@@ -35,4 +35,10 @@ namespace :decidim_app do
   task create_system_admin: :environment do
     Decidim::SystemAdminCreator.create!(ENV) ? puts("System admin created successfully") : puts("System admin creation failed")
   end
+
+  desc "Upgrade decidim-app"
+  task upgrade: :environment do
+    puts "Running db:migrate"
+    Rake::Task["db:migrate"].invoke
+  end
 end

--- a/spec/lib/tasks/upgrade_task_spec.rb
+++ b/spec/lib/tasks/upgrade_task_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim_app:upgrade", type: :task do
+  it "preloads the Rails environment" do
+    expect(task.prerequisites).to include "environment"
+  end
+
+  it "calls db:migrate" do
+    expect(Rake::Task["db:migrate"]).to receive(:invoke)
+
+    task.execute
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
In the case of the IndieHoster migration, we needed to have a centralized interface in order to perform application updates. In the case of an upgrade, this task allows you to define a Hook that can be enriched with all the methods required during migration, such as resetting the search or synchronizing locals as required.
