### PR TITLE
feat: improve k8s rake

### DIFF
--- a/lib/k8s_configuration_exporter.rb
+++ b/lib/k8s_configuration_exporter.rb
@@ -6,7 +6,7 @@ require "k8s_organization_exporter"
 class K8sConfigurationExporter
   EXPORT_PATH = Rails.root.join("tmp/k8s-migration")
 
-  def initialize(image="")
+  def initialize(image = "")
     @image = image
     @organizations = Decidim::Organization.all
     @logger = LoggerWithStdout.new("log/k8s-export-#{Time.zone.now.strftime("%Y-%m-%d-%H-%M-%S")}.log")
@@ -36,7 +36,7 @@ class K8sConfigurationExporter
     @logger.info("-------------------------")
     @organizations.find_each do |organization|
       @logger.info("exporting organization with host #{organization.host}")
-      K8sOrganizationExporter.export!(organization, @logger, EXPORT_PATH, organization.host, @image)
+      K8sOrganizationExporter.export!(organization, @logger, EXPORT_PATH, @image)
     end
   end
 
@@ -46,5 +46,4 @@ class K8sConfigurationExporter
     @logger.info("creating migration directory #{EXPORT_PATH}")
     FileUtils.mkdir_p(EXPORT_PATH)
   end
-
 end

--- a/lib/k8s_configuration_exporter.rb
+++ b/lib/k8s_configuration_exporter.rb
@@ -6,15 +6,14 @@ require "k8s_organization_exporter"
 class K8sConfigurationExporter
   EXPORT_PATH = Rails.root.join("tmp/k8s-migration")
 
-  def initialize(image, enable_sync)
+  def initialize(image)
     @image = image
-    @enable_sync = enable_sync
     @organizations = Decidim::Organization.all
     @logger = LoggerWithStdout.new("log/#{hostname}-k8s-export-#{Time.zone.now.strftime("%Y-%m-%d-%H-%M-%S")}.log")
   end
 
-  def self.export!(image, enable_sync)
-    new(image, enable_sync).export!
+  def self.export!(image)
+    new(image).export!
   end
 
   def export!
@@ -26,8 +25,6 @@ class K8sConfigurationExporter
       @logger.info("exporting organization with host #{organization.host}")
       K8sOrganizationExporter.export!(organization, @logger, EXPORT_PATH, hostname, @image)
     end
-
-    perform_sync
   end
 
   def clean_migration_directory
@@ -35,18 +32,6 @@ class K8sConfigurationExporter
     FileUtils.rm_rf(EXPORT_PATH)
     @logger.info("creating migration directory #{EXPORT_PATH}")
     FileUtils.mkdir_p(EXPORT_PATH)
-  end
-
-  def perform_sync
-    if @enable_sync
-      @logger.info("Cleaning bucket #{@hostname}-migration")
-      system("rclone delete scw-migration:#{@hostname}-migration --rmdirs --config ../scaleway.config")
-      @logger.info("Syncing export to bucket #{@hostname}-migration")
-      system("rclone copy #{EXPORT_PATH} scw-migration:#{@hostname}-migration --config ../scaleway.config --progress --copy-links")
-    else
-      @logger.info("NOT syncing export to bucket #{@hostname}-migration because ENABLE_SYNC is missing or false")
-      true
-    end
   end
 
   def hostname

--- a/lib/k8s_configuration_exporter.rb
+++ b/lib/k8s_configuration_exporter.rb
@@ -6,10 +6,23 @@ require "k8s_organization_exporter"
 class K8sConfigurationExporter
   EXPORT_PATH = Rails.root.join("tmp/k8s-migration")
 
-  def initialize(image)
+  def initialize(image="")
     @image = image
     @organizations = Decidim::Organization.all
-    @logger = LoggerWithStdout.new("log/#{hostname}-k8s-export-#{Time.zone.now.strftime("%Y-%m-%d-%H-%M-%S")}.log")
+    @logger = LoggerWithStdout.new("log/k8s-export-#{Time.zone.now.strftime("%Y-%m-%d-%H-%M-%S")}.log")
+  end
+
+  def self.dump_db
+    new.dump_db
+  end
+
+  def dump_db
+    @logger.info("found #{@organizations.count} organization#{"s" if @organizations.count.positive?}")
+    @logger.info("-------------------------")
+    @organizations.find_each do |organization|
+      @logger.info("Dumping database organization with host #{organization.host}")
+      K8sOrganizationExporter.dumping_database(organization, @logger, EXPORT_PATH, organization.host)
+    end
   end
 
   def self.export!(image)
@@ -23,7 +36,7 @@ class K8sConfigurationExporter
     @logger.info("-------------------------")
     @organizations.find_each do |organization|
       @logger.info("exporting organization with host #{organization.host}")
-      K8sOrganizationExporter.export!(organization, @logger, EXPORT_PATH, hostname, @image)
+      K8sOrganizationExporter.export!(organization, @logger, EXPORT_PATH, organization.host, @image)
     end
   end
 
@@ -34,13 +47,4 @@ class K8sConfigurationExporter
     FileUtils.mkdir_p(EXPORT_PATH)
   end
 
-  def hostname
-    # Socket.gethostname returns a string with ASCII-8BIT encoding, which is not compatible with parameterize
-    # We need to force the encoding to UTF-8 before calling parameterize on it
-    # We need to dup the string because force_encoding returns a new string and the original is frozen
-    @hostname ||= Socket.gethostname
-                        .dup
-                        .force_encoding("UTF-8")
-                        .parameterize
-  end
 end

--- a/lib/k8s_organization_exporter.rb
+++ b/lib/k8s_organization_exporter.rb
@@ -6,7 +6,14 @@ class K8sOrganizationExporter
                                   BACKUP_S3SYNC_ACCESS_KEY
                                   BACKUP_S3SYNC_SECRET_KEY
                                   BACKUP_S3SYNC_BUCKET
-                                  BACKUP_S3RETENTION_ENABLED).freeze
+                                  BACKUP_S3RETENTION_ENABLED
+                                  DEFAULT_LOCALE
+                                  AVAILABLE_LOCALES
+                                  FORCE_SSL
+                                  SCALEWAY_ID
+                                  SCALEWAY_TOKEN
+                                  SCALEWAY_BUCKET_NAME
+                                  SECRET_KEY_BASE).freeze
   ORGANIZATION_COLUMNS = %w(id
                             default_locale
                             available_locales
@@ -55,8 +62,10 @@ class K8sOrganizationExporter
   def exporting_env_vars
     # TODO: Shouldn't we export this to a k8s secret?
     @logger.info("exporting env variables to #{organization_export_path}/manifests/#{resource_name}--de.yml")
-    File.write("#{organization_export_path}/manifests/#{resource_name}-config.yml",
+    File.write("#{organization_export_path}/manifests/#{resource_name}-custom-env.yml",
                YAML.dump(all_env_vars))
+    File.write("#{organization_export_path}/manifests/#{resource_name}--de.yml",
+               YAML.dump(secret_key_base_env_var))
   end
 
   def creating_directories
@@ -70,12 +79,32 @@ class K8sOrganizationExporter
   end
 
   def all_env_vars
-    env_vars.merge!(smtp_settings).merge!(omniauth_settings)
+    {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata:{
+        name: "#{resource_name}-custom-env"
+      },
+      stringData: @env_vars.merge!(smtp_settings).merge!(omniauth_settings).to_json
+    }.deep_stringify_keys
   end
 
   def env_vars
     @env_vars ||= Dotenv.parse(".env")
                         .reject { |key, _value| FORBIDDEN_ENVIRONMENT_KEYS.include?(key) }
+  end
+
+  def secret_key_base_env_var
+    {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata:{
+        name: "#{resource_name}--de"
+      },
+      stringData: {
+        SECRET_KEY_BASE: "#{Dotenv.parse(".env")['SECRET_KEY_BASE']}"
+      }
+    }.deep_stringify_keys
   end
 
   def omniauth_settings
@@ -117,12 +146,20 @@ class K8sOrganizationExporter
         image: @image,
         host: @organization.host,
         additionalHosts: @organization.secondary_hosts,
-        organization: organization_columns,
+        organization: { id: organization_columns["id"] },
+        locale:{
+          default: organization_columns["default_locale"],
+          available: organization_columns["available_locales"],
+        },
+        usersRegistrationMode: organization_columns["users_registration_mode"],
+        forceUsersToAuthenticateBeforeAccessOrganization: organization_columns["force_users_to_authenticate_before_access_organization"],
+        availableAuthorizations: organization_columns["available_authorizations"],
+        fileUploadSettings: organization_columns["file_upload_settings"],
         timeZone: @organization.time_zone,
         envFrom: [
           {
             secretRef: {
-              name: "#{resource_name}-config"
+              name: "#{resource_name}-custom-env"
             }
           }
         ]
@@ -135,15 +172,11 @@ class K8sOrganizationExporter
   end
 
   def resource_name
-    @resource_name ||= "#{@hostname}--#{organization_slug}"
+    @resource_name ||= "#{@hostname}"
   end
 
   def bucket_name
     @bucket_name ||= env_vars["SCALEWAY_BUCKET_NAME"]
-  end
-
-  def organization_slug
-    @organization_slug ||= @organization.host.parameterize(separator: "_", preserve_case: true)
   end
 
   private

--- a/lib/k8s_organization_exporter.rb
+++ b/lib/k8s_organization_exporter.rb
@@ -85,7 +85,7 @@ class K8sOrganizationExporter
       metadata: {
         name: "#{resource_name}-custom-env"
       },
-      stringData: env_vars.merge!(smtp_settings).merge!(omniauth_settings).to_json
+      stringData: env_vars.merge!(smtp_settings).merge!(omniauth_settings)
     }.deep_stringify_keys
   end
 

--- a/lib/k8s_organization_exporter.rb
+++ b/lib/k8s_organization_exporter.rb
@@ -85,7 +85,7 @@ class K8sOrganizationExporter
       metadata:{
         name: "#{resource_name}-custom-env"
       },
-      stringData: @env_vars.merge!(smtp_settings).merge!(omniauth_settings).to_json
+      stringData: env_vars.merge!(smtp_settings).merge!(omniauth_settings).to_json
     }.deep_stringify_keys
   end
 

--- a/lib/k8s_organization_exporter.rb
+++ b/lib/k8s_organization_exporter.rb
@@ -82,7 +82,7 @@ class K8sOrganizationExporter
     {
       apiVersion: "v1",
       kind: "Secret",
-      metadata:{
+      metadata: {
         name: "#{resource_name}-custom-env"
       },
       stringData: env_vars.merge!(smtp_settings).merge!(omniauth_settings).to_json
@@ -98,11 +98,11 @@ class K8sOrganizationExporter
     {
       apiVersion: "v1",
       kind: "Secret",
-      metadata:{
+      metadata: {
         name: "#{resource_name}--de"
       },
       stringData: {
-        SECRET_KEY_BASE: "#{Dotenv.parse(".env")['SECRET_KEY_BASE']}"
+        SECRET_KEY_BASE: (Dotenv.parse(".env")["SECRET_KEY_BASE"]).to_s
       }
     }.deep_stringify_keys
   end
@@ -147,9 +147,9 @@ class K8sOrganizationExporter
         host: @organization.host,
         additionalHosts: @organization.secondary_hosts,
         organization: { id: organization_columns["id"] },
-        locale:{
+        locale: {
           default: organization_columns["default_locale"],
-          available: organization_columns["available_locales"],
+          available: organization_columns["available_locales"]
         },
         usersRegistrationMode: organization_columns["users_registration_mode"],
         forceUsersToAuthenticateBeforeAccessOrganization: organization_columns["force_users_to_authenticate_before_access_organization"],
@@ -172,7 +172,7 @@ class K8sOrganizationExporter
   end
 
   def resource_name
-    @resource_name ||= "#{@hostname}"
+    @resource_name ||= @hostname.to_s
   end
 
   def bucket_name

--- a/lib/k8s_organization_exporter.rb
+++ b/lib/k8s_organization_exporter.rb
@@ -49,12 +49,12 @@ class K8sOrganizationExporter
     @logger.info("dumping database #{@database_name} to #{organization_export_path}/postgres/#{resource_name}--de.dump")
     system("pg_dump -Fc #{@database_name} > #{organization_export_path}/postgres/#{resource_name}--de.dump")
   end
-  
+
   def exporting_configuration
     @logger.info("exporting application configuration to #{organization_export_path}/application.yml")
     File.write("#{organization_export_path}/application.yml", YAML.dump(organization_settings))
   end
-  
+
   def exporting_env_vars
     @logger.info("exporting env variables to #{organization_export_path}/manifests/#{resource_name}-custom-env.yml")
     File.write("#{organization_export_path}/manifests/#{resource_name}-custom-env.yml",

--- a/lib/tasks/k8s.rake
+++ b/lib/tasks/k8s.rake
@@ -3,6 +3,11 @@
 require "k8s_configuration_exporter"
 
 namespace :k8s do
+  desc "usage: bundle exec rails k8s:dump_db"
+  task dump_db: :environment do
+    K8sConfigurationExporter.dump_db
+  end
+
   desc "usage: bundle exec rails k8s:export_configuration IMAGE=<docker_image_ref>"
   task export_configuration: :environment do
     image = ENV["IMAGE"]

--- a/lib/tasks/k8s.rake
+++ b/lib/tasks/k8s.rake
@@ -3,13 +3,11 @@
 require "k8s_configuration_exporter"
 
 namespace :k8s do
-  desc "usage: bundle exec rails k8s:export_configuration IMAGE=<docker_image_ref> [ENABLE_SYNC=true]"
+  desc "usage: bundle exec rails k8s:export_configuration IMAGE=<docker_image_ref>"
   task export_configuration: :environment do
     image = ENV["IMAGE"]
-    enable_sync = ENV["ENABLE_SYNC"] == "true"
+    raise "You must specify a docker image, usage: bundle exec rails k8s:export_configuration IMAGE=<image_ref>" if image.blank?
 
-    raise "You must specify a docker image, usage: bundle exec rails decidim:k8s:export_configuration IMAGE=<image_ref> [ENABLE_SYNC=true]" if image.blank?
-
-    K8sConfigurationExporter.export!(image, enable_sync)
+    K8sConfigurationExporter.export!(image)
   end
 end

--- a/spec/lib/k8s_configuration_exporter_spec.rb
+++ b/spec/lib/k8s_configuration_exporter_spec.rb
@@ -9,17 +9,6 @@ describe K8sConfigurationExporter do
   let(:organization) { create(:organization) }
   let(:image) { "registry.gitlab.com/my-image" }
   let(:enable_sync) { true }
-  let(:hostname) { "123.123.123.123" }
-
-  before do
-    allow(Socket).to receive(:gethostname).and_return(hostname)
-  end
-
-  describe "#hostname" do
-    it "returns the hostname" do
-      expect(subject.hostname).to eq("123-123-123-123")
-    end
-  end
 
   describe "#clean_migration_directory" do
     it "cleans the migration directory" do
@@ -32,7 +21,7 @@ describe K8sConfigurationExporter do
 
   describe "#export!" do
     it "exports the organizations" do
-      expect(K8sOrganizationExporter).to receive(:export!).with(organization, subject.instance_variable_get(:@logger), described_class::EXPORT_PATH, "123-123-123-123", image).and_return(true)
+      expect(K8sOrganizationExporter).to receive(:export!).with(organization, subject.instance_variable_get(:@logger), described_class::EXPORT_PATH, image).and_return(true)
 
       subject.export!
     end

--- a/spec/lib/k8s_configuration_exporter_spec.rb
+++ b/spec/lib/k8s_configuration_exporter_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "k8s_configuration_exporter"
 
 describe K8sConfigurationExporter do
-  subject { described_class.new(image, enable_sync) }
+  subject { described_class.new(image) }
 
   let(:organization) { create(:organization) }
   let(:image) { "registry.gitlab.com/my-image" }
@@ -18,29 +18,6 @@ describe K8sConfigurationExporter do
   describe "#hostname" do
     it "returns the hostname" do
       expect(subject.hostname).to eq("123-123-123-123")
-    end
-  end
-
-  describe "#perform_sync" do
-    it "syncs the export to the bucket" do
-      # rubocop:disable RSpec/SubjectStub
-      expect(subject).to receive(:system).with("rclone delete scw-migration:123-123-123-123-migration --rmdirs --config ../scaleway.config")
-      expect(subject).to receive(:system).with("rclone copy #{described_class::EXPORT_PATH} scw-migration:123-123-123-123-migration --config ../scaleway.config --progress --copy-links")
-      # rubocop:enable RSpec/SubjectStub
-
-      subject.perform_sync
-    end
-
-    context "when enable_sync is false" do
-      let(:enable_sync) { false }
-
-      it "does not sync the export to the bucket" do
-        # rubocop:disable RSpec/SubjectStub
-        expect(subject).not_to receive(:system)
-        # rubocop:enable RSpec/SubjectStub
-
-        subject.perform_sync
-      end
     end
   end
 
@@ -67,7 +44,7 @@ describe K8sConfigurationExporter do
       expect_any_instance_of(described_class).to receive(:export!)
       # rubocop:enable RSpec/AnyInstance
 
-      described_class.export!(image, enable_sync)
+      described_class.export!(image)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
Dans les grandes lignes:
Je n'avais pas besoin du sync, je vais le faire en ansible.

Il me fallait un secret spécifique pour la SECRET_KEY_BASE, l'opérateur attends cela.
Et J'ai changé les quelques nom d'objets ci et là, pour correspondre aux attentes de l'opérateur.

#### Testing
```
ssh mako@decidim-migration-dry-run -p 124
cd decidim-app
bundle exec rails k8s:export_configuration IMAGE="rg.fr-par.scw.cloud/decidim-app/decidim-app:develop"
```

Le hostname de cette instance de test est:
```
decidim-migration-dry-run.osp.dev
```
(Et donc les ressources sont nommées sur le sous domaine.)

L'output est:

Le contenu du bucket est bien dans:
```
tmp/k8s-migration/decidim-migration-dry-run/buckets/decidim-migration-dry-run--de/
```

Et le dump pg dans:
```
tmp/k8s-migration/decidim-migration-dry-run/postgres/decidim-migration-dry-run--de.dump
```

tmp/k8s-migration/decidim-migration-dry-run/application.yml
```bash
---
apiVersion: apps.libre.sh/v1alpha1
kind: Decidim
metadata:
  name: decidim-migration-dry-run
spec:
  image: rg.fr-par.scw.cloud/decidim-app/decidim-app:develop
  host: decidim-migration-dry-run.osp.dev
  additionalHosts: []
  organization:
    id: 1
  locale:
    default: en
    available:
    - fr
    - en
  usersRegistrationMode: 0
  forceUsersToAuthenticateBeforeAccessOrganization: false
  availableAuthorizations:
  - id_documents
  - postal_letter
  - csv_census
  - phone_authorization_handler
  - osp_authorization_handler
  fileUploadSettings:
    maximum_file_size:
      avatar: 5
      default: 10
    allowed_content_types:
      admin:
      - image/*
      - application/vnd.oasis.opendocument
      - application/vnd.ms-*
      - application/msword
      - application/vnd.ms-word
      - application/vnd.openxmlformats-officedocument
      - application/vnd.oasis.opendocument
      - application/pdf
      - application/rtf
      - text/plain
      default:
      - image/*
      - application/pdf
      - application/rtf
      - text/plain
    allowed_file_extensions:
      admin:
      - jpg
      - jpeg
      - gif
      - png
      - bmp
      - pdf
      - doc
      - docx
      - xls
      - xlsx
      - ppt
      - pptx
      - ppx
      - rtf
      - txt
      - odt
      - ott
      - odf
      - otg
      - ods
      - ots
      image:
      - jpg
      - jpeg
      - gif
      - png
      - bmp
      - ico
      default:
      - jpg
      - jpeg
      - gif
      - png
      - bmp
      - pdf
      - rtf
      - txt
  timeZone: UTC
  envFrom:
  - secretRef:
      name: decidim-migration-dry-run-custom-env
```

tmp/k8s-migration/decidim-migration-dry-run/manifests/decidim-migration-dry-run--de.yml
```bash
---
apiVersion: v1
kind: Secret
metadata:
  name: decidim-migration-dry-run--de
stringData:
  SECRET_KEY_BASE: xxx
```

tmp/k8s-migration/decidim-migration-dry-run/manifests/decidim-migration-dry-run-custom-env.yml
```bash
---
apiVersion: v1
kind: Secret
metadata:
  name: decidim-migration-dry-run-custom-env
stringData:
  THROTTLING_MAX_REQUESTS: '100'
  THROTTLING_PERIOD: '1'
  ENABLE_RACK_ATTACK: '1'
  RACK_ATTACK_FAIL2BAN: '1'
  SENTRY_SIDEKIQ_SAMPLE_RATE: '0.1'
  SENTRY_SAMPLE_RATE: '0.5'
  FRIENDLY_SIGNUP_OVERRIDE_PASSWORDS: '1'
  FRIENDLY_SIGNUP_INSTANT_VALIDATION: '1'
  FRIENDLY_SIGNUP_HIDE_NICKNAME: '1'
  FRIENDLY_SIGNUP_USE_CONFIRMATION_CODES: '1'
  ENABLE_LETTER_OPENER: '0'
  SMTP_FROM: arnulfo <ginette@mcglynn.name>
  SMTP_PORT: '25'
  SMTP_ADDRESS: decidim-migration-dry-run.osp.dev
  SMTP_USER_NAME: darwin_brown
  SMTP_FROM_EMAIL: ginette@mcglynn.name
  SMTP_FROM_LABEL: arnulfo
  SMTP_PASSWORD: xxx
```