### PR TITLE
Disable deface since it's precompiled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 
 RUN bundle exec bootsnap precompile --gemfile app/ lib/ config/ bin/ db/ && \
     bundle exec rails assets:precompile && \
-    bundle exec rails deface:precompile
+    DEFACE_ENABLED=true bundle exec rails deface:precompile
 
 # Configure endpoint.
 COPY ./entrypoint.sh /usr/bin/

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -144,4 +144,7 @@ Rails.application.configure do
   # are known to cause issue with moderation due to expiration
   # Setting this to 100 years should be enough
   config.global_id.expires_in = 100.years
+
+  # It's important to disable Deface once precompiling is used to prevent overrides getting applied twice
+  config.deface.enabled = ENV["DEFACE_ENABLED"] == "true"
 end


### PR DESCRIPTION
Don't activate deface in production since it's been precompiled. 

This P.R. needs to be tested in production mode.