### PR TITLE
add service and tasks to repair comments

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -88,7 +88,9 @@ jobs:
           key: asset-cache-${{ runner.os }}-${{ steps.cache-hash.outputs.hash }}
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
-      - uses: nanasess/setup-chromedriver@v1.0.1
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: "114.0.5735.90"
       - run:  bundle exec rake "test:run[exclude, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
@@ -153,7 +155,9 @@ jobs:
           key: asset-cache-${{ runner.os }}-${{ steps.cache-hash.outputs.hash }}
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
-      - uses: nanasess/setup-chromedriver@v1.0.1
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: "114.0.5735.90"
       - run:  bundle exec rake "test:run[include, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH

--- a/app/services/decidim/repair_comments_service.rb
+++ b/app/services/decidim/repair_comments_service.rb
@@ -19,12 +19,16 @@ module Decidim
     end
 
     def invalid_comments
-      @invalid_comments ||= Decidim::Comments::Comment.all.map do |comment|
+      return @invalid_comments if @invalid_comments
+
+      invalid_comments = []
+      Decidim::Comments::Comment.find_each do |comment|
         next if translated_attribute(comment.body).is_a?(String)
 
         comment.body.delete("machine_translations")
-        [comment, comment.body.values.first]
-      end.compact
+        invalid_comments << [comment, comment.body.values.first]
+      end
+      @invalid_comments = invalid_comments
     end
 
     private

--- a/app/services/decidim/repair_comments_service.rb
+++ b/app/services/decidim/repair_comments_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  class RepairCommentsService
+    include Decidim::TranslatableAttributes
+
+    def self.run
+      new.execute
+    end
+
+    def execute
+      return [] if ok?
+
+      update_comments!
+    end
+
+    def ok?
+      invalid_comments.empty?
+    end
+
+    def invalid_comments
+      @invalid_comments ||= Decidim::Comments::Comment.all.map do |comment|
+        next if translated_attribute(comment.body).is_a?(String)
+
+        comment.body.delete("machine_translations")
+        [comment, comment.body.values.first]
+      end.compact
+    end
+
+    private
+
+    # Update each users with new nickname
+    # Returns Array of updated User ID
+    def update_comments!
+      invalid_comments.map do |comment, new_body|
+        comment.body = new_body
+
+        comment.id if comment.save!(validate: false) # Validation is skipped to allow updating comments from root that don't accepts new comments
+      end.compact
+    end
+  end
+end

--- a/app/services/decidim/repair_comments_service.rb
+++ b/app/services/decidim/repair_comments_service.rb
@@ -25,7 +25,6 @@ module Decidim
       Decidim::Comments::Comment.find_each do |comment|
         next if translated_attribute(comment.body).is_a?(String)
 
-        comment.body.delete("machine_translations")
         invalid_comments << [comment, comment.body.values.first]
       end
       @invalid_comments = invalid_comments

--- a/lib/tasks/repair_data.rake
+++ b/lib/tasks/repair_data.rake
@@ -18,5 +18,22 @@ namespace :decidim do
 
       logger.info("Operation terminated")
     end
+
+    desc "Check for malformed comments body and repair them if needed"
+    task comments: :environment do
+      logger = Logger.new($stdout)
+      logger.info("Checking all comments...")
+
+      updated_comments_ids = Decidim::RepairCommentsService.run
+
+      if updated_comments_ids.blank?
+        logger.info("No comments updated")
+      else
+        logger.info("#{updated_comments_ids} comments updated")
+        logger.info("Updated comments ID : #{updated_comments_ids.join(",")}")
+      end
+
+      logger.info("Operation terminated")
+    end
   end
 end

--- a/spec/services/decidim/repair_comments_service_spec.rb
+++ b/spec/services/decidim/repair_comments_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::RepairCommentsService do
+  subject { described_class.new }
+
+  let!(:comments) { create_list(:comment, 10) }
+
+  describe "#execute" do
+    it "returns empty array" do
+      expect(subject.execute).to be_empty
+    end
+
+    it "does not change valid comments" do
+      expect { subject.execute }.not_to(change { comments.map(&:body) })
+    end
+
+    context "when invalid bodys" do
+      let(:invalid) { build :comment }
+
+      before do
+        invalid.body = { "en" => { "en" => "foobar" } }
+        invalid.save!(validate: false)
+      end
+
+      it "returns array of invalid comments IDs" do
+        expect(subject.execute).to eq([invalid.id])
+        expect(invalid.reload.body).to eq({ "en" => "foobar" })
+      end
+    end
+  end
+
+  describe "#ok?" do
+    it "returns true" do
+      expect(subject).to be_ok
+    end
+  end
+
+  describe "#invalid_comments" do
+    let(:invalid) { build :comment }
+
+    before do
+      invalid.body = { "en" => { "en" => "foobar" } }
+      invalid.save!(validate: false)
+    end
+
+    it "returns array of invalid comments" do
+      expect(subject.invalid_comments).to eq([[invalid, { "en" => "foobar" }]])
+    end
+  end
+end

--- a/spec/services/decidim/repair_comments_service_spec.rb
+++ b/spec/services/decidim/repair_comments_service_spec.rb
@@ -26,7 +26,8 @@ describe Decidim::RepairCommentsService do
 
       it "returns array of invalid comments IDs" do
         expect(subject.execute).to eq([invalid.id])
-        expect(invalid.reload.body).to eq({ "en" => "foobar" })
+        invalid.reload.body.delete("machine_translations")
+        expect(invalid.body).to eq({ "en" => "foobar" })
       end
     end
   end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR adds a rake task to repair comments that are formatted like { "en" => { "en" => "foobar"}}
It turns these into { "en" => "foobar" } and does nothing to the others

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=52077469164a42c68f3e170e24f54f14&pm=c)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Change the format of a comment in the database
* run the rake task
* see it goes back to the good format

#### Tasks
- [x] Add specs
