### PR TITLE
Removes database health check (post mortem #1)

### DIFF
--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -25,5 +25,5 @@ HealthCheck.setup do |config|
   config.http_status_for_error_object = 500
 
   # You can customize which checks happen on a standard health check, eg to set an explicit list use:
-  config.standard_checks = %w(database migrations)
+  config.standard_checks = %w(migrations)
 end


### PR DESCRIPTION
Health checl is checking for database status before booting resulting in a cascade failure.