### PR TITLE
feat(k8s): dump in plain sql when remote db

### DIFF
--- a/lib/decidim_app/k8s/organization_exporter.rb
+++ b/lib/decidim_app/k8s/organization_exporter.rb
@@ -59,13 +59,20 @@ module DecidimApp
       def dumping_database
         @logger.info("dumping database #{@database_configuration[:database]} to #{organization_export_path}/postgres/#{resource_name}--de.dump")
 
-        cmd = "pg_dump -Fc"
+        dump_format = "c"
+        dump_extension = "dump"
+        if @database_configuration[:host].present?
+          dump_format = "p"
+          dump_extension = "sql"
+        end
+
+        cmd = "pg_dump -F#{dump_format}"
         cmd += " -h '#{@database_configuration[:host]}'" if @database_configuration[:host].present?
         cmd += " -p '#{@database_configuration[:port]}'" if @database_configuration[:port].present?
         cmd += " -U '#{@database_configuration[:username]}'" if @database_configuration[:username].present?
         cmd = "PGPASSWORD=#{@database_configuration[:password]} #{cmd}" if @database_configuration[:password].present?
         cmd += " -d '#{@database_configuration[:database]}'" if @database_configuration[:database].present?
-        cmd += " -f #{organization_export_path}/postgres/#{resource_name}--de.dump"
+        cmd += " -f #{organization_export_path}/postgres/#{resource_name}--de.#{dump_extension}"
 
         system(cmd)
       end

--- a/spec/lib/decidim_app/k8s/organization_exporter_spec.rb
+++ b/spec/lib/decidim_app/k8s/organization_exporter_spec.rb
@@ -54,13 +54,20 @@ describe DecidimApp::K8s::OrganizationExporter do
     it "dumps the database" do
       # rubocop:disable RSpec/SubjectStub
 
-      cmd = "pg_dump -Fc"
+      dump_format = "c"
+      dump_extension = "dump"
+      if @database_configuration[:host].present?
+        dump_format = "p"
+        dump_extension = "sql"
+      end
+
+      cmd = "pg_dump -F#{dump_format}"
       cmd += " -h '#{database_configuration[:host]}'" if database_configuration[:host].present?
       cmd += " -p '#{database_configuration[:port]}'" if database_configuration[:port].present?
       cmd += " -U '#{database_configuration[:username]}'" if database_configuration[:username].present?
       cmd = "PGPASSWORD=#{database_configuration[:password]} #{cmd}" if database_configuration[:password].present?
       cmd += " -d '#{database_configuration[:database]}'" if database_configuration[:database].present?
-      cmd += " -f #{export_path}/#{name_space}--#{hostname}/postgres/#{hostname}--de.dump"
+      cmd += " -f #{export_path}/#{name_space}--#{hostname}/postgres/#{hostname}--de.#{dump_extension}"
 
       expect(subject).to receive(:system).with(cmd)
       # rubocop:enable RSpec/SubjectStub


### PR DESCRIPTION
#### :tophat: Description
To avoid crash during import of external Postgres, IndieHosters needs to dump in plain SQL. 

#### Tasks
- [x] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation
