### PR TITLE
Don't raise if env var is not set

### DIFF
--- a/lib/tasks/repair_data.rake
+++ b/lib/tasks/repair_data.rake
@@ -54,14 +54,14 @@ namespace :decidim do
     end
 
     task url_in_content: :environment do
-      Logger.new($stdout)
+      logger = Logger.new($stdout)
       deprecated_hosts = ENV["DEPRECATED_OBJECTSTORE_S3_HOSTS"].to_s.split(",").map(&:strip)
 
       if deprecated_hosts.blank?
-        logger.warn("DEPRECATED_OBJECTSTORE_S3_HOST env variable is not set")
+        logger.warn("DEPRECATED_OBJECTSTORE_S3_HOSTS env variable is not set")
       else
         deprecated_hosts.each do |host|
-          Decidim::RepairUrlInContentService.run(host, Logger.new($stdout))
+          Decidim::RepairUrlInContentService.run(host, logger)
         end
       end
     end

--- a/lib/tasks/repair_data.rake
+++ b/lib/tasks/repair_data.rake
@@ -54,12 +54,15 @@ namespace :decidim do
     end
 
     task url_in_content: :environment do
+      Logger.new($stdout)
       deprecated_hosts = ENV["DEPRECATED_OBJECTSTORE_S3_HOSTS"].to_s.split(",").map(&:strip)
 
-      raise ArgumentError, "DEPRECATED_OBJECTSTORE_S3_HOST env variable is not set" if deprecated_hosts.blank?
-
-      deprecated_hosts.each do |host|
-        Decidim::RepairUrlInContentService.run(host, Logger.new($stdout))
+      if deprecated_hosts.blank?
+        logger.warn("DEPRECATED_OBJECTSTORE_S3_HOST env variable is not set")
+      else
+        deprecated_hosts.each do |host|
+          Decidim::RepairUrlInContentService.run(host, Logger.new($stdout))
+        end
       end
     end
   end

--- a/spec/lib/tasks/repair_data_url_in_content_spec.rb
+++ b/spec/lib/tasks/repair_data_url_in_content_spec.rb
@@ -32,7 +32,9 @@ describe "rake decidim:repair:url_in_content", type: :task do
     ["", nil].each do |value|
       it "raises an error" do
         with_modified_env deprecated_hosts: value do
-          expect { task.execute }.to raise_error(ArgumentError)
+          expect(Decidim::RepairUrlInContentService).not_to receive(:run)
+
+          task.execute
         end
       end
     end


### PR DESCRIPTION
Allow repair task to run and do nothing if en var is not set