### PR TITLE
fix: Rescue when blob is not found when using repair url

### DIFF
--- a/lib/decidim/content_fixer.rb
+++ b/lib/decidim/content_fixer.rb
@@ -81,7 +81,6 @@ module Decidim
 
     def find_service_url_for_blob(blob_id)
       Rails.application.routes.url_helpers.rails_blob_path(ActiveStorage::Blob.find(blob_id), only_path: true)
-
     rescue ActiveRecord::RecordNotFound
       @logger.warn "Blob #{blob_id} not found"
       nil

--- a/lib/decidim/content_fixer.rb
+++ b/lib/decidim/content_fixer.rb
@@ -81,6 +81,10 @@ module Decidim
 
     def find_service_url_for_blob(blob_id)
       Rails.application.routes.url_helpers.rails_blob_path(ActiveStorage::Blob.find(blob_id), only_path: true)
+
+    rescue ActiveRecord::RecordNotFound
+      @logger.warn "Blob #{blob_id} not found"
+      nil
     end
 
     def nokogiri_will_wrap_with_p?(content)

--- a/spec/lib/decidim/content_fixer_spec.rb
+++ b/spec/lib/decidim/content_fixer_spec.rb
@@ -135,5 +135,11 @@ describe Decidim::ContentFixer do
     it "returns the service url for the given blob" do
       expect(subject.find_service_url_for_blob(blob.id)).to eq(blob_path)
     end
+
+    context "when blob is not found" do
+      it "returns nil" do
+        expect(subject.find_service_url_for_blob(blob.id + 1)).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
When using repair url sometime a blob is not found, this P.R. rescue this condition and allows the task to continue without issue