### PR TITLE
fix: Rescue when blob is not found when using repair url (#409)

### DIFF
--- a/lib/decidim/content_fixer.rb
+++ b/lib/decidim/content_fixer.rb
@@ -34,6 +34,8 @@ module Decidim
     end
 
     def find_and_replace(content)
+      return if content.nil?
+
       wrapper = nokogiri_will_wrap_with_p?(content) ? "p" : "body"
 
       doc = Nokogiri::HTML(content)

--- a/lib/decidim/content_fixer.rb
+++ b/lib/decidim/content_fixer.rb
@@ -81,6 +81,9 @@ module Decidim
 
     def find_service_url_for_blob(blob_id)
       Rails.application.routes.url_helpers.rails_blob_path(ActiveStorage::Blob.find(blob_id), only_path: true)
+    rescue ActiveRecord::RecordNotFound
+      @logger.warn "Blob #{blob_id} not found"
+      nil
     end
 
     def nokogiri_will_wrap_with_p?(content)

--- a/spec/lib/decidim/content_fixer_spec.rb
+++ b/spec/lib/decidim/content_fixer_spec.rb
@@ -87,6 +87,14 @@ describe Decidim::ContentFixer do
         expect(replaced_content).not_to include(deprecated_endpoint)
       end
     end
+
+    context "when content is nil" do
+      let(:content) { nil }
+
+      it "returns an empty string" do
+        expect(subject.find_and_replace(content)).to eq(nil)
+      end
+    end
   end
 
   describe "#new_source" do

--- a/spec/lib/decidim/content_fixer_spec.rb
+++ b/spec/lib/decidim/content_fixer_spec.rb
@@ -135,5 +135,11 @@ describe Decidim::ContentFixer do
     it "returns the service url for the given blob" do
       expect(subject.find_service_url_for_blob(blob.id)).to eq(blob_path)
     end
+
+    context "when blob is not found" do
+      it "returns nil" do
+        expect(subject.find_service_url_for_blob(blob.id + 1)).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
in somes cases the content to repair was nil and throwing an error, we avoid this situation in this P.R.