### PR TITLE
Feat: Add extra user fields gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "decidim-templates", "~> #{DECIDIM_VERSION}.0"
 # External Decidim gems
 gem "decidim-cache_cleaner"
 gem "decidim-decidim_awesome"
+gem "decidim-extra_user_fields", git: "https://github.com/armandfardeau/decidim-module-extra_user_fields", branch: "fix/remove-virtus-recitfy"
 gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git",
                                                                 branch: DECIDIM_BRANCH
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem "decidim-templates", "~> #{DECIDIM_VERSION}.0"
 # External Decidim gems
 gem "decidim-cache_cleaner"
 gem "decidim-decidim_awesome"
-gem "decidim-extra_user_fields", git: "https://github.com/armandfardeau/decidim-module-extra_user_fields", branch: "fix/remove-virtus-recitfy"
 gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git",
                                                                 branch: DECIDIM_BRANCH
+gem "decidim-extra_user_fields", git: "https://github.com/paulinebessoles/decidim-module-extra_user_fields", branch: "feat/add_tests_0_27"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 # TODO: Bump to 0.27.0 when released
 # gem "decidim-gallery"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,6 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
-    connection_pool (2.4.0)
     countries (3.1.0)
       i18n_data (~> 0.11.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -593,7 +592,6 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     i18n_data (0.11.0)
-    icalendar (2.8.0)
     icalendar (2.9.0)
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
@@ -1072,8 +1070,8 @@ DEPENDENCIES
   decidim-conferences (~> 0.27.0)
   decidim-decidim_awesome
   decidim-dev (~> 0.27.0)
-  decidim-extra_user_fields!
   decidim-extended_socio_demographic_authorization_handler!
+  decidim-extra_user_fields!
   decidim-friendly_signup!
   decidim-homepage_interactive_map!
   decidim-initiatives (~> 0.27.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,16 +57,6 @@ GIT
       omniauth-oauth2 (>= 1.7.2, < 2.0)
 
 GIT
-  remote: https://github.com/armandfardeau/decidim-module-extra_user_fields
-  revision: 737848d673778838422fa93135901d5f1876ec1b
-  branch: fix/remove-virtus-recitfy
-  specs:
-    decidim-extra_user_fields (0.27.2)
-      country_select (~> 4.0)
-      decidim-core (>= 0.27.0, < 0.28)
-      deface (~> 1.5)
-
-GIT
   remote: https://github.com/mainio/decidim-module-term_customizer.git
   revision: f1a8ed5c79079acc97ca109f0e5935ce0f6acd05
   branch: develop
@@ -74,6 +64,16 @@ GIT
     decidim-term_customizer (0.27.0)
       decidim-admin (~> 0.27.0)
       decidim-core (~> 0.27.0)
+
+GIT
+  remote: https://github.com/paulinebessoles/decidim-module-extra_user_fields
+  revision: 430933c63c5788fa19e223a455f602fc22f28ec4
+  branch: feat/add_tests_0_27
+  specs:
+    decidim-extra_user_fields (0.27.2)
+      country_select (~> 4.0)
+      decidim-core (>= 0.27.0, < 0.28)
+      deface (~> 1.5)
 
 GIT
   remote: https://github.com/sgruhier/foundation_rails_helper.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,16 @@ GIT
       omniauth-oauth2 (>= 1.7.2, < 2.0)
 
 GIT
+  remote: https://github.com/armandfardeau/decidim-module-extra_user_fields
+  revision: 737848d673778838422fa93135901d5f1876ec1b
+  branch: fix/remove-virtus-recitfy
+  specs:
+    decidim-extra_user_fields (0.27.2)
+      country_select (~> 4.0)
+      decidim-core (>= 0.27.0, < 0.28)
+      deface (~> 1.5)
+
+GIT
   remote: https://github.com/mainio/decidim-module-term_customizer.git
   revision: f1a8ed5c79079acc97ca109f0e5935ce0f6acd05
   branch: develop
@@ -241,6 +251,14 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    connection_pool (2.4.0)
+    countries (3.1.0)
+      i18n_data (~> 0.11.0)
+      sixarm_ruby_unaccent (~> 1.1)
+      unicode_utils (~> 1.4)
+    country_select (4.0.0)
+      countries (~> 3.0)
+      sort_alphabetical (~> 1.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -574,6 +592,8 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    i18n_data (0.11.0)
+    icalendar (2.8.0)
     icalendar (2.9.0)
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
@@ -933,12 +953,15 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sixarm_ruby_unaccent (1.2.2)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
     social-share-button (1.2.4)
       coffee-rails
+    sort_alphabetical (1.1.0)
+      unicode_utils (>= 1.2.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -969,6 +992,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.4.2)
+    unicode_utils (1.4.0)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -1048,6 +1072,7 @@ DEPENDENCIES
   decidim-conferences (~> 0.27.0)
   decidim-decidim_awesome
   decidim-dev (~> 0.27.0)
+  decidim-extra_user_fields!
   decidim-extended_socio_demographic_authorization_handler!
   decidim-friendly_signup!
   decidim-homepage_interactive_map!
@@ -1091,4 +1116,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.4.9
+   2.3.19

--- a/db/migrate/20230830154806_add_extra_user_fields_to_decidim_organization.decidim_extra_user_fields.rb
+++ b/db/migrate/20230830154806_add_extra_user_fields_to_decidim_organization.decidim_extra_user_fields.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# This migration comes from decidim_extra_user_fields (originally 20221024121407)
+
+class AddExtraUserFieldsToDecidimOrganization < ActiveRecord::Migration[6.0]
+  def up
+    add_column :decidim_organizations, :extra_user_fields, :jsonb, default: { "enabled" => false }
+  end
+
+  def down
+    remove_column :decidim_organizations, :extra_user_fields, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_24_135807) do
+ActiveRecord::Schema.define(version: 2023_08_30_154806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1331,6 +1331,7 @@ ActiveRecord::Schema.define(version: 2023_08_24_135807) do
     t.boolean "delete_inactive_users", default: false, null: false
     t.integer "delete_inactive_users_email_after"
     t.integer "delete_inactive_users_after"
+    t.jsonb "extra_user_fields", default: {"enabled"=>false}
     t.index ["host"], name: "index_decidim_organizations_on_host", unique: true
     t.index ["name"], name: "index_decidim_organizations_on_name", unique: true
   end


### PR DESCRIPTION
#### :tophat: Description
This PR aims to add the extra user fields gem to the decidim-app 0.27

#### Testing
Example:
* Log in as admin
* Access Backoffice
* Go to Settings
* See a dedicated tab for extra user fields

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
