### PR TITLE
Add x86_64-darwin-22 to platform list in Genfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1058,6 +1058,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Yeah ! There are still some people who use up to date Mac OS (13.5.2) on Intel powered devices 😛 