### PR TITLE
Load the admin password configuration like decidim-core

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -63,3 +63,8 @@ GALLERY_ANIMATION_ENABLE=0
 # Deactivate DEFACE when views are already precompiled
 # More information: https://github.com/spree/deface#production--precompiling
 DEFACE_ENABLED=false
+# Admin admin password configurations
+DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS=365
+DECIDIM_ADMIN_PASSWORD_MIN_LENGTH=15
+DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES=5
+DECIDIM_ADMIN_PASSWORD_STRONG="false"

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -19,6 +19,15 @@ Decidim.configure do |config|
   # Timeout session
   config.expire_session_after = ENV.fetch("DECIDIM_SESSION_TIMEOUT", 180).to_i.minutes
 
+  # Admin admin password configurations
+  Rails.application.secrets.dig(:decidim, :admin_password, :strong).tap do |strong_pw|
+    # When the strong password is not configured, default to true
+    config.admin_password_strong = strong_pw.nil? ? true : strong_pw.present?
+  end
+  config.admin_password_expiration_days = Rails.application.secrets.dig(:decidim, :admin_password, :expiration_days)
+  config.admin_password_min_length = Rails.application.secrets.dig(:decidim, :admin_password, :min_length)
+  config.admin_password_repetition_times = Rails.application.secrets.dig(:decidim, :admin_password, :repetition_times)
+
   config.maximum_attachment_height_or_width = 6000
 
   # Whether SSL should be forced or not (only in production).

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,11 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    admin_password:
+      expiration_days: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 365).to_i %>
+      min_length: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_MIN_LENGTH", 15).to_i %>
+      repetition_times: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES", 5).to_i %>
+      strong: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_STRONG", "false").to_s %>
     currency: <%= ENV["CURRENCY"] || "€" %>
     initiatives:
       creation_enabled: <%= ENV.fetch("INITIATIVES_CREATION_ENABLED", "auto").to_s %>


### PR DESCRIPTION
Fix Admin password config

Add variables : 

- `DECIDIM_ADMIN_PASSWORD_STRONG`  default to `false` (`true` in decidim)
- `DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS`  default to `365` (`90` indecidim)
- `DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES`  default to `15`
- `DECIDIM_ADMIN_PASSWORD_MIN_LENGTH`  default to `5`