### PR TITLE
Set no component by default for initiatives components

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,7 +25,7 @@ default: &default
       similarity_limit: <%= ENV.fetch("INITIATIVES_SIMILARITY_LIMIT", 5).to_i %>
       minimum_committee_members: <%= ENV.fetch("INITIATIVES_MINIMUM_COMMITTEE_MEMBERS", 2).to_i %>
       default_signature_time_period_length: <%= ENV.fetch("INITIATIVES_DEFAULT_SIGNATURE_TIME_PERIOD_LENGTH", 120).to_i %>
-      default_components: <%= ENV.fetch("INITIATIVES_DEFAULT_COMPONENTS", "pages,meetings").split(",").to_json %>
+      default_components: <%= ENV.fetch("INITIATIVES_DEFAULT_COMPONENTS", "").split(",").to_json %>
       first_notification_percentage: <%= ENV.fetch("INITIATIVES_FIRST_NOTIFICATION_PERCENTAGE", 33).to_i %>
       second_notification_percentage: <%= ENV.fetch("INITIATIVES_SECOND_NOTIFICATION_PERCENTAGE", 66).to_i %>
       stats_cache_expiration_time: <%= ENV.fetch("INITIATIVES_STATS_CACHE_EXPIRATION_TIME", 5).to_i %>


### PR DESCRIPTION
#### :tophat: Description
When `INITIATIVES_DEFAULT_COMPONENTS` env variable is not defined, the default is breaking the initiative show view, because the extra white space between "pages" and "meetings". 

This components shouldn't be there in the default decidim-app, so I delete them by default. 

#### :pushpin: Related Issues
```
I, [2023-10-09T10:35:46.762498 #1101639]  INFO -- : [4d2fb5ff-4a14-4703-989a-
a9641b52b656]   Rendered cell decidim/navbar_admin_link (0.9ms)
I, [2023-10-09T10:35:46.783901 #1101639]  INFO -- : [4d2fb5ff-4a14-4703-989a-
a9641b52b656]   Rendered cell decidim/follow_button (12.9ms)
I, [2023-10-09T10:35:46.890136 #1101639]  INFO -- : [4d2fb5ff-4a14-4703-989a-
a9641b52b656]   Rendered cell decidim/data_consent (0.4ms)
I, [2023-10-09T10:35:47.065961 #1101639]  INFO -- : [4d2fb5ff-4a14-4703-989a-
a9641b52b656] {&quot;method&quot;:&quot;GET&quot;,&quot;path&quot;:&quot;/initiatives/i-
2&quot;,&quot;format&quot;:&quot;html&quot;,&quot;controller&quot;:&quot;Decidim::Initiatives::InitiativesController&quot;,
&quot;action&quot;:&quot;show&quot;,&quot;status&quot;:500,&quot;error&quot;:&quot;ActionView::Template::Error: undefined m
ethod `decidim_initiative_ meetings&#39; for #&lt;Decidim::EngineRouter:0x00007fd254f
29cb0 @engine=\&quot;decidim_initiative_ meetings\&quot;, @default_url_options={:host=&gt;\
&quot;ddimsco01-rec\&quot;, :component_id=&gt;214, :initiative_slug=&gt;\&quot;i-
2\&quot;}&gt;\nDid you mean?  decidim_initiative_meetings\n               decidim_init
iative_debates\n               decidim_initiative_budgets\n               deci
dim_initiative_pages\n               decidim_initiative_blogs\n               
decidim_initiative_sortitions\n               decidim_admin_initiative_meeting
s\n               _decidim_initiative_meetings&quot;,&quot;allocations&quot;:50122,&quot;duration&quot;
:347.24,&quot;view&quot;:0.0,&quot;db&quot;:43.37,&quot;remote_ip&quot;:&quot;192.168.132.61&quot;,&quot;params&quot;:{&quot;slug&quot;:&quot;i
-2&quot;},&quot;user_id&quot;:12590,&quot;organization_id&quot;:3,&quot;referer&quot;:&quot;https://ddimsco01-
rec/admin/initiatives&quot;}
F, [2023-10-09T10:35:47.071656 #1101639] FATAL -- : [4d2fb5ff-4a14-4703-989a-
a9641b52b656]   
[4d2fb5ff-4a14-4703-989a-
a9641b52b656] ActionView::Template::Error (undefined method `decidim_initiativ
e_ meetings&#39; for #&lt;Decidim::EngineRouter:0x00007fd254f29cb0 @engine=&quot;decidim_i
nitiative_ meetings&quot;, @default_url_options={:host=&gt;&quot;ddimsco01-
rec&quot;, :component_id=&gt;214, :initiative_slug=&gt;&quot;i-2&quot;}&gt;
Did you mean?  decidim_initiative_meetings
               decidim_initiative_debates
               decidim_initiative_budgets
               decidim_initiative_pages
               decidim_initiative_blogs
               decidim_initiative_sortitions
               decidim_admin_initiative_meetings
               _decidim_initiative_meetings):
[4d2fb5ff-4a14-4703-989a-
a9641b52b656]     39:     ] + components.map do |component|
[4d2fb5ff-4a14-4703-989a-a9641b52b656]     40:       {
[4d2fb5ff-4a14-4703-989a-
a9641b52b656]     41:         name: translated_attribute(component.name),
[4d2fb5ff-4a14-4703-989a-
a9641b52b656]     42:         url: main_component_path(component),
```

#### Testing
*Describe the best way to test or validate your PR
1. Don't set an env var for `INITIATIVES_DEFAULT_COMPONENTS `
2. Create an initiative
3. See that you can access to the show

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
