### PR TITLE
fix: Devise emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolit
 gem "decidim-ludens", git: "https://github.com/OpenSourcePolitics/decidim-ludens.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: DECIDIM_BRANCH
 gem "decidim-spam_detection"
-gem "decidim-term_customizer", git: "https://github.com/armandfardeau/decidim-module-term_customizer.git", branch: "fix/precompile-on-docker"
+gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"
 
 # Omniauth gems
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,15 @@ GIT
       rgeo-proj4 (~> 3.1)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git
+  revision: 54050b317815bff1edaad3d26744a941be1d31bf
+  branch: fix/email_with_precompile
+  specs:
+    decidim-term_customizer (0.27.0)
+      decidim-admin (~> 0.27.0)
+      decidim-core (~> 0.27.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler
   revision: 79f2a5f6c3357d63f92423a2b173893f4c4d06d8
   branch: release/0.27-stable
@@ -65,15 +74,6 @@ GIT
       country_select (~> 4.0)
       decidim-core (>= 0.27.0, < 0.28)
       deface (~> 1.5)
-
-GIT
-  remote: https://github.com/armandfardeau/decidim-module-term_customizer.git
-  revision: 5c2b648e07c5fd51e2598256886895b9a83d698c
-  branch: fix/precompile-on-docker
-  specs:
-    decidim-term_customizer (0.27.0)
-      decidim-admin (~> 0.27.0)
-      decidim-core (~> 0.27.0)
 
 GIT
   remote: https://github.com/sgruhier/foundation_rails_helper.git


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Allow admins to customize Devise mail translations

#### Testing
*Describe the best way to test or validate your PR.*
Create multiple devise translation customizations :

For account confirmation mails :

Create TermCustomizer entries

    devise.mailer.confirmation_instructions.instruction
    devise.mailer.confirmation_instructions.subject 

Refresh cache and create a new account

For reset password confirmation :
Create TermCustomizer entries

    devise.mailer.reset_password_instructions.subject

Refresh cache and ask a reset password for user@example.org

For new admin invitation
Create TermCustomizer entries

    devise.mailer.invite_admin.subject

Refresh cache and invite a new admin