### PR TITLE
fix: change the commit to fix notifications not sending on dcd-app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git
-  revision: 54050b317815bff1edaad3d26744a941be1d31bf
+  revision: bfb4ba25dcfe504c9c9d7afd376c04c28cb23ce8
   branch: fix/email_with_precompile
   specs:
     decidim-term_customizer (0.27.0)


### PR DESCRIPTION
#### :tophat: Description
We had an issue with notifications not sending onto the 0.27 apps because a change we made in the module term customizer. So as we fixed it on the branch we needed to update the last commit.

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as user
* Go follow a process
* Log as an admin
* Comment the process that has been followed
* Log as the previous user
* Check if you received the notification

#### Tasks
- [x] Change Revision of Term Custo

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
