### PR TITLE
Add missing jobs for initiatives rake tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ coverage/
 public/sw.js*
 app/compiled_views/
 certificate-https-local/
+
+.DS_Store

--- a/app/jobs/check_published_initiatives.rb
+++ b/app/jobs/check_published_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckPublishedInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_published"
+  end
+end

--- a/app/jobs/check_validating_initiatives.rb
+++ b/app/jobs/check_validating_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckValidatingInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_validating"
+  end
+end

--- a/app/jobs/notify_progress_initiatives.rb
+++ b/app/jobs/notify_progress_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NotifyProgressInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:notify_progress"
+  end
+end

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -5,7 +5,7 @@
         <div class="social-register">
           <% if provider.match?("france") %>
             <span class="register__separator">
-              <span class="register__separator__text"><%= t("devise.shared.links.sign_in_with_france_connect")%></span>
+              <span class="register__separator__text"><%= t("devise.shared.links.sign_in_with_france_connect") %></span>
             </span>
             <div class="text-center">
               <p><%= t("decidim.omniauth.france_connect.explanation") %></p>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,6 +15,7 @@
   - reminders
   - active_storage_analysis
   - active_storage_purge
+  - initiatives
 
 :scheduler:
   :schedule:
@@ -44,3 +45,15 @@
       class: NotificationsDigestMailJob
       queue: mailers
       args: :weekly
+    CheckPublishedInitiatives:
+      cron: '0 1 * * *'
+      class: CheckPublishedInitiatives
+      queue: initiatives
+    CheckValidatingInitiatives:
+      cron: '0 1 * * *'
+      class: CheckValidatingInitiatives
+      queue: initiatives
+    NotifyProgressInitiatives:
+      cron: '0 1 * * *'
+      class: NotifyProgressInitiatives
+      queue: initiatives


### PR DESCRIPTION
This will scheduled daily these 3 rake tasks : 
- `decidim_initiatives:check_validating`
- `decidim_initiatives:check_published`
- `decidim_initiatives:notify_progress`

see : https://github.com/decidim/decidim/tree/release/0.27-stable/decidim-initiatives#rake-tasks

**+** 2 stowaway : 
- add (again) `.DS_Store` files to `.gitignore`
- fix a missing space with erblint