### PR TITLE
fix: Downgrade wicked_pdf to 2.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1076,7 +1076,7 @@ GEM
     websocket-extensions (0.1.5)
     wicked (1.4.0)
       railties (>= 3.0.7)
-    wicked_pdf (2.7.0)
+    wicked_pdf (2.6.3)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)

--- a/spec/system/admin/export_initiative_signatures_spec.rb
+++ b/spec/system/admin/export_initiative_signatures_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Export" do
+  include_context "when admins initiative"
+
+  let!(:votes) { create_list(:initiative_user_vote, 5, initiative: initiative) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it "downloads the PDF file", :download do
+    visit decidim_admin_initiatives.initiatives_path
+
+    within find("tr", text: translated(initiative.title)) do
+      page.find(".action-icon--edit").click
+    end
+
+    click_link "Export PDF of signatures"
+    within ".confirm-reveal" do
+      click_link "OK"
+    end
+
+    expect(File.basename(download_path)).to include("votes_#{initiative.id}.pdf")
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Downgrade `wicked_pdf` to be compatible with Webpacker.
Add specs

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #458 
- Related to https://github.com/mileszs/wicked_pdf/issues/1098
- [Notion card](https://www.notion.so/opensourcepolitics/Bordeaux-500-error-on-signatures-export-6da1705f36f54902bc72e831effb9fc1?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

If you have a Running Docker env you can easily setup using : `make run`
#### Tasks
- [x] Add specs
- [x] Downgrade wicked_pdf

