### PR TITLE
feat: Add disclaimer on initiative type page

### DIFF
--- a/app/views/decidim/initiatives/admin/initiatives_types/new.html.erb
+++ b/app/views/decidim/initiatives/admin/initiatives_types/new.html.erb
@@ -1,0 +1,13 @@
+<% add_decidim_page_title(t(".title")) %>
+<h2 class="process-title-summary">
+  <%= t ".title" %>
+</h2>
+
+<%= decidim_form_for(@form, html: { class: "form new_initiatives_types" }) do |f| %>
+  <%= render partial: "form", object: f %>
+
+  <p class="callout warning"><%== t("decidim.initiatives.admin.initiatives.form.new.warning") %></p>
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -99,6 +99,7 @@ ignore_missing:
  - activemodel.errors.models.questionnaire.request_invalid
  - decidim.admin.menu.admin_accountability
  - layouts.decidim.footer.download_open_data
+ - decidim.initiatives.admin.initiatives_types.new.{title,create}
 
 # Consider these keys used:
 ignore_unused:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,8 @@ en:
         initiatives:
           form:
             attachments: Attachments
+            new:
+              warning: If you save your initiative type, it will display initiatives in the front-office
             settings: Settings
             title: General information
       pages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -75,6 +75,8 @@ fr:
         initiatives:
           form:
             attachments: Pièces jointes
+            new:
+              warning: Les initiatives types créées seront directement visibles par les utilisateurs. <br> Veuillez vous assurer que les informations sont correctes avant de les créer. <br> <em>Une fois le premier type d'initiative créé, cela ne pourra plus être modifié.</em>
             settings: Paramètres
             title: Informations générales
       pages:

--- a/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages initiatives types", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:initiatives_type) { create(:initiatives_type, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_initiatives.initiatives_types_path
+  end
+
+  context "when accessing initiative types list" do
+    it "shows the initiative type data" do
+      expect(page).to have_i18n_content(initiatives_type.title)
+    end
+  end
+
+  context "when creating an initiative type" do
+    it "creates the initiative type" do
+      click_link "New initiative type"
+
+      fill_in_i18n(
+        :initiatives_type_title,
+        "#initiatives_type-title-tabs",
+        en: "My initiative type"
+      )
+
+      fill_in_i18n_editor(
+        :initiatives_type_description,
+        "#initiatives_type-description-tabs",
+        en: "A longer description"
+      )
+
+      select("Online", from: "Signature type")
+
+      dynamically_attach_file(:initiatives_type_banner_image, Decidim::Dev.asset("city2.jpeg"))
+
+      click_button "Create"
+
+      within ".callout-wrapper" do
+        expect(page).to have_content("A new initiative type has been successfully created")
+      end
+    end
+
+    it "has a warning message visible" do
+      click_link "New initiative type"
+
+      expect(page).to have_content("If you save your initiative type, it will display initiatives in the front-office")
+    end
+  end
+
+  context "when updating an initiative type" do
+    it "updates the initiative type" do
+      within find("tr", text: translated(initiatives_type.title)) do
+        page.find(".action-icon--edit").click
+      end
+
+      fill_in_i18n(
+        :initiatives_type_title,
+        "#initiatives_type-title-tabs",
+        en: "My updated initiative type"
+      )
+
+      select("Mixed", from: "Signature type")
+      check "Enable attachments"
+      uncheck "Enable participants to undo their online signatures"
+      check "Enable authors to choose the end of signature collection period"
+      check "Enable authors to choose the area for their initiative"
+      uncheck "Enable comments"
+
+      click_button "Update"
+
+      within ".callout-wrapper" do
+        expect(page).to have_content("The initiative type has been successfully updated")
+      end
+    end
+  end
+
+  context "when deleting an initiative type" do
+    it "deletes the initiative type" do
+      within find("tr", text: translated(initiatives_type.title)) do
+        accept_confirm do
+          page.find(".action-icon--remove").click
+        end
+      end
+
+      within ".callout-wrapper" do
+        expect(page).to have_content("The initiative type has been successfully removed")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

As an administrator, when I create my first Initiative type, I can't remove it and it is directly available to visitors. This PR add a message to warn the admin about this behaviour

<img width="500" alt="Screenshot 2024-01-31 at 11 31 17" src="https://github.com/OpenSourcePolitics/decidim-app/assets/26109239/0a6d2c51-1ade-4c2d-9e83-6f589d8e9177">



#### :pushpin: Related Issues
*Link your PR to an issue*

- [Notion card](https://www.notion.so/opensourcepolitics/Decidim-app-0-27-Variable-d-env-pour-espace-p-titions-en-BO-c5ab31949dbd484ba09c781325ffdf15?pvs=4)
