### PR TITLE
fix: Add random on scheduled jobs and reduce max retries

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,11 +20,11 @@
 :scheduler:
   :schedule:
     CalculateAllMetrics:
-      cron: '0 9 0 * * *' # Run at 00:09
+      cron: '0 <%= Random.rand(9..59) %> <%= Random.rand(0..4) %> * * *' # Run randomly between 00:09 and 04:59
       class: CalculateAllMetricsJob
       queue: scheduled
     PreloadOpenData:
-      cron: '0 0 1 * * *' # Run at 01:00
+      cron: '0 <%= Random.rand(10..59) %> <%= Random.rand(0..4) %> * * *' # Run randomly between 00:10 and 04:59
       class: PreloadOpenDataJob
       queue: scheduled
     DetectSpamUsers:
@@ -32,7 +32,7 @@
       class: Decidim::SpamDetection::MarkUsersJob
       queue: scheduled
     Backup:
-      cron: '0 0 4 * * *' # Run at 04:00
+      cron: '0 <%= Random.rand(0..59) %> <%= Random.rand(2..3) %> * * *' # Run randomly between 02:00 and 03:59
       class: BackupJob
       queue: backups
     SendNotificationMailDaily:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 :concurrency: 5
+:max_retries: 5
 :queues:
   - mailers
   - default


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

When executed at the same time, scheduled jobs can generates instabilities on infrastructure.
It also reduce max retries count from 25 to 5

This PR aims to randomize the moment of each job

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Sidekiq-Randomize-recurring-jobs-06bc512ec6ce4bd7806e589391763f9d?pvs=4)

### How to review

- Dev, ensure for a 6 digits cron format it matches the comment 
- Product, ensure for each job if the period is not too large
