### PR TITLE
fix: Flaky test on locales spec

### DIFF
--- a/spec/system/locales_spec.rb
+++ b/spec/system/locales_spec.rb
@@ -75,8 +75,7 @@ describe "Locales", type: :system do
     context "with a signed in user" do
       let(:user) { create(:user, :confirmed, locale: "fr", organization: organization) }
 
-      it "uses the user's locale" do
-        # Make sure the user is authenticated
+      it "displays content based on user's locale" do
         expect(page).not_to have_content("Sign in")
         expect(page).not_to have_content("S'identifier")
         expect(page).to have_content("Accueil")

--- a/spec/system/locales_spec.rb
+++ b/spec/system/locales_spec.rb
@@ -4,10 +4,12 @@ require "spec_helper"
 
 describe "Locales", type: :system do
   describe "switching locales" do
-    let(:organization) { create(:organization, available_locales: %w(fr en)) }
+    let(:organization) { create(:organization, available_locales: %w(fr en), default_locale: "en") }
+    let(:user) { create(:user, :confirmed, locale: "en", organization: organization) }
 
     before do
       switch_to_host(organization.host)
+      login_as user, scope: :user
       visit decidim.root_path
     end
 
@@ -37,40 +39,46 @@ describe "Locales", type: :system do
       expect(page).to have_content("Accueil")
     end
 
-    it "displays devise messages with the right locale when not authenticated" do
-      within_language_menu do
-        click_link "Français"
+    context "when not authenticated" do
+      let(:user) { nil }
+
+      it "displays devise messages with the right locale when not authenticated" do
+        within_language_menu do
+          click_link "Français"
+        end
+
+        visit decidim_admin.root_path
+
+        expect(page).to have_content("Vous devez vous identifier ou vous créer un compte avant de continuer")
       end
-
-      visit decidim_admin.root_path
-
-      expect(page).to have_content("Vous devez vous identifier ou vous créer un compte avant de continuer")
     end
 
-    it "displays devise messages with the right locale when authentication fails" do
-      within_language_menu do
-        click_link "Français"
+    context "when authentication fails" do
+      let(:user) { nil }
+
+      it "displays devise messages with the right locale" do
+        within_language_menu do
+          click_link "Français"
+        end
+
+        find(".sign-in-link").click
+
+        fill_in "session_user_email", with: "toto@example.org"
+        fill_in "session_user_password", with: "toto"
+
+        click_button "S'identifier"
+
+        expect(page).to have_content("Email ou mot de passe invalide")
       end
-
-      find(".sign-in-link").click
-
-      fill_in "session_user_email", with: "toto@example.org"
-      fill_in "session_user_password", with: "toto"
-
-      click_button "S'identifier"
-
-      expect(page).to have_content("Email ou mot de passe invalide")
     end
 
     context "with a signed in user" do
       let(:user) { create(:user, :confirmed, locale: "fr", organization: organization) }
 
-      before do
-        login_as user, scope: :user
-        visit decidim.root_path
-      end
-
       it "uses the user's locale" do
+        # Make sure the user is authenticated
+        expect(page).not_to have_content("Sign in")
+        expect(page).not_to have_content("S'identifier")
         expect(page).to have_content("Accueil")
       end
     end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

It fixes the flaky that was present in the locales spec test because we noticed that 80% of the time user was not logged in properly on the failing test when he should have been.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #497 
- [Notion card](https://www.notion.so/opensourcepolitics/Decidim-app-Flaky-spec-in-locales-system-specs-91581b8e9ee9498889b98aa61d54ac44?pvs=4)

#### Testing
#### Tasks
- [x] Fix specs

