### PR TITLE
fix: Require exporters before initialization

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -4,4 +4,6 @@ require "extends/controllers/decidim/devise/account_controller_extends"
 require "extends/cells/decidim/content_blocks/hero_cell_extends"
 require "extends/uploaders/decidim/application_uploader_extends"
 require "extends/lib/decidim/proposals/imports/proposal_answer_creator_extends"
+
+require "decidim/exporters/serializer"
 require "extends/lib/decidim/forms/user_answers_serializer_extend"


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

As an administrator, when I navigate to the Proposal index in the backoffice, an internal server error is raised.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Decidim-app-Internal-server-error-on-proposals-backoffice-index-1849406e2204436c88abad17095261d0?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to proposals index
* List should be available

This error is only reproductible in dev mode (not Docker prod mode)
