### PR TITLE
Add decidim anonymous proposals dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 DECIDIM_VERSION = "0.27"
 DECIDIM_BRANCH = "release/#{DECIDIM_VERSION}-stable".freeze
+DECIDIM_ANONYMOUS_PROPOSALS_VERSION = { git: "https://github.com/PopulateTools/decidim-module-anonymous_proposals", branch: "anonymous_proposals_for_registered_users" }
 
 ruby RUBY_VERSION
 
@@ -27,6 +28,7 @@ gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePo
 gem "decidim-spam_detection"
 gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"
+gem "decidim-anonymous_proposals", DECIDIM_ANONYMOUS_PROPOSALS_VERSION
 
 # Omniauth gems
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,15 @@ GIT
       omniauth-oauth2 (>= 1.7.2, < 2.0)
 
 GIT
+  remote: https://github.com/PopulateTools/decidim-module-anonymous_proposals
+  revision: b44a938500716dbfd99e8615769045701137c82e
+  branch: anonymous_proposals_for_registered_users
+  specs:
+    decidim-anonymous_proposals (0.27.0)
+      decidim-core (>= 0.27.0)
+      deface (~> 1.5)
+
+GIT
   remote: https://github.com/sgruhier/foundation_rails_helper.git
   revision: bc33600db7a2d16ce3cdc1f8369d0d7e7c4245b5
   specs:
@@ -1100,6 +1109,7 @@ DEPENDENCIES
   climate_control (~> 1.2)
   dalli
   decidim (~> 0.27.0)
+  decidim-anonymous_proposals!
   decidim-cache_cleaner
   decidim-conferences (~> 0.27.0)
   decidim-decidim_awesome


### PR DESCRIPTION
#### :tophat: Description

This PR adds anonymous proposals dependencies to the application. The version used is compatible with 0.27 Decidim release (there is another branch with the code adapted to 0.28)

After deploying the code additional steps should be done to check the functionality:

The PR basically adds the dependency into the Gemfile. The next steps to make work the module are:
* Run the decidim_anonymous_proposals:generate_anonymous_group task to create an anonymous group to associate the proposals with
* Ensure that the DEFACE_ENABLED environment variable is set as true to allow the module to overwrite the forms and create new proposal button

#### :pushpin: Related Issues
- Related to PopulateTools/issues#1894

#### Testing
After doing the previous steps of the description:

* Log in as admin
* Access Backoffice
* Go to an existing proposals component or create a new one and enable from its settings the creation of anonymous proposals and also allow participants to create proposals
