### PR TITLE
fix the unsubscribe link in newsletters

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -84,3 +84,6 @@ RAILS_LOG_LEVEL=warn
 
 # Default notifications sending frequency : (daily, weekly, none, real_time)
 # NOTIFICATIONS_SENDING_FREQUENCY=daily
+
+#Timeout for the unsubscribe link of the newsletter
+#NEWSLETTERS_UNSUBSCRIBE_TIMEOUT=

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decid
 gem "decidim-gallery", git: "https://github.com/OpenSourcePolitics/decidim-module-gallery.git", branch: "fix/nokogiri_deps"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-ludens", git: "https://github.com/OpenSourcePolitics/decidim-ludens.git", branch: DECIDIM_BRANCH
-gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "chore/update-initializer"
+gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
 gem "decidim-spam_detection"
 gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler
-  revision: 80e376ec674dad17812a3ee1e542a3bc88461add
-  branch: chore/update-initializer
+  revision: a3e77fb29e9a19793b3ff8b5d2273d41fac0919b
+  branch: release/0.27-stable
   specs:
     decidim-phone_authorization_handler (1.0.0)
       decidim-core (~> 0.27)
@@ -1104,6 +1104,7 @@ PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module DevelopmentApp
       require "extends/commands/decidim/initiatives/admin/update_initiative_answer_extends"
       require "extends/controllers/decidim/initiatives/committee_requests_controller_extends"
       require "extends/models/decidim/budgets/project_extend"
+      require "extends/controllers/decidim/newsletters_controller_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -108,6 +108,9 @@ ignore_missing:
  - decidim.account.email_change.*
  - decidim.account.show.*
  - layouts.decidim.user_menu.profile
+ - decidim.newsletters.unsubscribe.success
+ - decidim.newsletters.unsubscribe.error
+ - decidim.newsletters.unsubscribe.token_error
 
 # Consider these keys used:
 ignore_unused:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,4 +141,7 @@ ignore_unused:
   - activemodel.attributes.attachment.documents
   - activemodel.attributes.participatory_space_private_user_csv_import.file
   - decidim.forms.user_answers_serializer.{email,name}
+  - decidim.newsletters.unsubscribe.success
+  - decidim.newsletters.unsubscribe.error
+  - decidim.newsletters.unsubscribe.token_error
 

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -115,6 +115,9 @@ Decidim.configure do |config|
   config.enable_machine_translations = Rails.application.secrets.translator[:enabled]
   config.machine_translation_service = "DeeplTranslator"
   config.machine_translation_delay = Rails.application.secrets.translator[:delay]
+
+  # newsletter unsubscribe link timeout
+  config.newsletters_unsubscribe_timeout = Rails.application.secrets.dig(:decidim, :newsletters_unsubscribe_timeout)
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,6 +39,7 @@ default: &default
       throttle:
         max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
         period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
+    newsletters_unsubscribe_timeout: <%=  ENV.fetch("NEWSLETTERS_UNSUBSCRIBE_TIMEOUT", 365).to_i %>
   modules:
     gallery:
       enable_animation: <%= ENV.fetch("GALLERY_ANIMATION_ENABLE", "0") == "1" %>

--- a/lib/extends/controllers/decidim/newsletters_controller_extends.rb
+++ b/lib/extends/controllers/decidim/newsletters_controller_extends.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module NewslettersExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def unsubscribe
+      encryptor = Decidim::NewsletterEncryptor
+
+      decrypted_string = encryptor.sent_at_decrypted(params[:u])
+      user = Decidim::User.find_by(decidim_organization_id: current_organization.id, id: decrypted_string.split("-").first)
+      sent_at_time = Time.zone.at(decrypted_string.split("-").second.to_i)
+
+      if sent_at_time > Rails.application.secrets.dig(:decidim, :newsletters_unsubscribe_timeout).days.ago
+        Decidim::UnsubscribeSettings.call(user) do
+          on(:ok) do
+            flash.now[:notice] = t("newsletters.unsubscribe.success", scope: "decidim")
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = t("newsletters.unsubscribe.error", scope: "decidim")
+            render action: :unsubscribe
+          end
+        end
+      else
+        flash.now[:alert] = t("newsletters.unsubscribe.token_error", scope: "decidim")
+        render action: :unsubscribe
+      end
+    end
+  end
+end
+
+Decidim::NewslettersController.include(NewslettersExtends)

--- a/spec/controllers/newsletters_controller_spec.rb
+++ b/spec/controllers/newsletters_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe NewslettersController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+    end
+
+    describe "GET show" do
+      context "when the newsletter is not send" do
+        let(:newsletter) { create(:newsletter, organization: organization) }
+
+        it "expect a 404 page" do
+          expect { get :show, params: { id: newsletter.id } }
+            .to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      context "when the newsletter is send" do
+        let(:newsletter) { create(:newsletter, organization: organization, sent_at: Time.current) }
+
+        context "when the user is present" do
+          let(:user) { create(:user, organization: organization) }
+          let(:encryptor) { Decidim::NewsletterEncryptor }
+          let(:encrypted_token) { encryptor.sent_at_encrypted(user.id, newsletter.sent_at) }
+
+          before do
+            allow(controller).to receive(:current_user) { user }
+            allow(controller).to receive(:encrypted_token) { encrypted_token }
+          end
+
+          it "renders the newsletter with unsubscribe link" do
+            get :show, params: { id: newsletter.id }
+
+            expect(assigns(:encrypted_token)).not_to be_empty
+          end
+        end
+
+        context "when the user is not present" do
+          it "renders the newsletter" do
+            get :show, params: { id: newsletter.id }
+
+            expect(response).to render_template(:show)
+          end
+        end
+      end
+    end
+
+    describe "GET Unsubscribed" do
+      let(:user_id) { "1" }
+
+      describe "when user click to unsubscribe" do
+        let(:encryptor) { Decidim::NewsletterEncryptor }
+
+        describe "when sent_at is between newsletter_unsubscribe_timeout variable and today" do
+          let(:decrypted_string) { encryptor.sent_at_decrypted(params[:u]) }
+          let(:time) { 2.days.ago.to_i }
+          let(:sent_at_time) { Time.zone.at(decrypted_string.split("-").second.to_i) }
+
+          context "and newsletter notifications is true" do
+            let!(:user) { create(:user, organization: organization, id: user_id, newsletter_notifications_at: Time.current) }
+
+            before do
+              allow(Rails.application.secrets).to receive(:dig).with(:decidim, :newsletters_unsubscribe_timeout).and_return(30)
+            end
+
+            it "unsubscribes user" do
+              get :unsubscribe, params: { u: encryptor.sent_at_encrypted(user_id, time) }
+              expect(response).to render_template(:unsubscribe)
+              expect(controller.flash.notice).to have_content("successfully")
+            end
+          end
+
+          context "and newsletter notifications is false" do
+            let!(:user) { create(:user, organization: organization, id: user_id, newsletter_notifications_at: nil) }
+
+            before do
+              allow(Rails.application.secrets).to receive(:dig).with(:decidim, :newsletters_unsubscribe_timeout).and_return(30)
+            end
+
+            it "does not unsubscribe user" do
+              get :unsubscribe, params: { u: encryptor.sent_at_encrypted(user_id, time) }
+              expect(response).to render_template(:unsubscribe)
+              expect(controller.flash.alert).to have_content("problem")
+            end
+          end
+        end
+
+        describe "when sent_at is before than newsletter_unsubscribe_timeout variable" do
+          let(:decrypted_string) { encryptor.sent_at_decrypted(params[:u]) }
+          let(:time) { 35.days.ago.to_i }
+          let(:sent_at_time) { Time.zone.at(decrypted_string.split("-").second.to_i) }
+
+          context "and newsletter notifications is true" do
+            let!(:user) { create(:user, organization: organization, id: user_id, newsletter_notifications_at: Time.current) }
+
+            before do
+              allow(Rails.application.secrets).to receive(:dig).with(:decidim, :newsletters_unsubscribe_timeout).and_return(30)
+            end
+
+            it "say token has expired" do
+              get :unsubscribe, params: { u: encryptor.sent_at_encrypted(user_id, time) }
+              expect(response).to render_template(:unsubscribe)
+              expect(controller.flash.alert).to have_content("expired")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
Fix the unsubscribe link in newletters 

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=b64a299d6e2143c88e3a0ee40a075de3&pm=c)

#### Testing

1. as an admin, got to your account and accept newletters
2. as an admin, create a newletter
3. select the recipients "send to all users"
4. click on deliver newsletter
5. go to received email and click on unsubsrcibe link
6. get a message confirming that you are unsubscribed

