### PR TITLE
ci: Disable codecov upload

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -107,8 +107,8 @@ jobs:
       - uses: nanasess/setup-chromedriver@v2
       - run:  bundle exec rake "test:run[exclude, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
-      - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
-        name: Upload coverage
+      #- run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
+      #  name: Upload coverage
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -173,8 +173,8 @@ jobs:
       - uses: nanasess/setup-chromedriver@v2
       - run:  bundle exec rake "test:run[include, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
-      - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
-        name: Upload coverage
+      #- run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
+      #  name: Upload coverage
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Codecov upload is failing because of a throttling about a limit reached. We must reconfigure account to increase this limit. 
I remove codecov upload from Github Actions workflows for unlocking CI/CD