### PR TITLE
feat: Add module budgets_importer to Marseille

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp"
 
 # External Decidim gems
 gem "decidim-budget_category_voting", git: "https://github.com/alecslupu-pfa/decidim-budget_category_voting.git", branch: DECIDIM_BRANCH
+gem "decidim-budgets_importer", git: "https://github.com/OpenSourcePolitics/decidim-module-budgets_importer.git"
 gem "decidim-cache_cleaner"
 gem "decidim-category_enhanced", "~> 0.0.1"
 gem "decidim-decidim_awesome"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,13 @@ GIT
       decidim-core (~> 0.27.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-budgets_importer.git
+  revision: eec557bf67a3cd0e00a1c6bdcc8aa56e4908b635
+  specs:
+    decidim-budgets_importer (2.0.0)
+      decidim-core (~> 0.27)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git
   revision: adec5e66cd07b5e5fdce5562453a7e8d6de88013
   branch: release/0.27-stable
@@ -1130,6 +1137,7 @@ DEPENDENCIES
   decidim (~> 0.27.0)
   decidim-budget_category_voting!
   decidim-budgets_booth!
+  decidim-budgets_importer!
   decidim-cache_cleaner
   decidim-category_enhanced (~> 0.0.1)
   decidim-conferences (~> 0.27.0)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -111,6 +111,7 @@ ignore_missing:
  - decidim.newsletters.unsubscribe.success
  - decidim.newsletters.unsubscribe.error
  - decidim.newsletters.unsubscribe.token_error
+ - activemodel.errors.models.assembly.attributes.document.invalid_document_type
 
 # Consider these keys used:
 ignore_unused:
@@ -148,4 +149,4 @@ ignore_unused:
   - decidim.newsletters.unsubscribe.success
   - decidim.newsletters.unsubscribe.error
   - decidim.newsletters.unsubscribe.token_error
-
+  - activemodel.errors.models.assembly.attributes.document.invalid_document_type

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -14,6 +14,12 @@ fr:
         private_space: Espace privé
       participatory_space_private_user_csv_import:
         file: importer un fichier d'utilisateurs
+    errors:
+      models:
+        assembly:
+          attributes:
+            document:
+              invalid_document_type: Le type de document n'est pas valide
   decidim:
     admin:
       menu:

--- a/spec/commands/decidim/budgets_importer/admin/import_project_spec.rb
+++ b/spec/commands/decidim/budgets_importer/admin/import_project_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module BudgetsImporter
+    module Admin
+      describe ImportProject do
+        describe "call" do
+          let(:organization) { create :organization }
+          let(:current_user) { create :user, :admin, :confirmed, organization: organization }
+          let(:participatory_process) { create :participatory_process, organization: organization }
+          let(:current_component) { create(:component, manifest_name: :budgets, participatory_space: participatory_process) }
+          let!(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }
+          let!(:proposal) { create(:proposal, id: 1, component: proposal_component) }
+          let!(:proposal2) { create(:proposal, id: 2, component: proposal_component) }
+          let(:budget) { create :budget, component: current_component }
+          let!(:category) { create(:category, id: 1, participatory_space: current_component.participatory_space) }
+          let(:document) { upload_test_file(fixture_test_file(filename, mime_type)) }
+          let(:filename) { "projects-import.csv" }
+          let(:mime_type) { "text/csv" }
+          let(:blob) { ActiveStorage::Blob.find_signed(document) }
+          let(:blob_file_path) { ActiveStorage::Blob.service.path_for(blob.key) }
+          let(:valid) { true }
+          let!(:form) do
+            double(
+              valid?: valid,
+              invalid?: !valid,
+              current_component: current_component,
+              current_user: current_user,
+              budget: budget,
+              blob: blob,
+              file_path: blob_file_path
+            )
+          end
+
+          let(:command) { described_class.new(form) }
+
+          shared_examples_for "saves imported projects" do
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "creates the projects" do
+              expect do
+                command.call
+              end.to change { Decidim::Budgets::Project.where(budget: budget).count }.by(2)
+            end
+
+            it "broadcast_registry is empty" do
+              cmd = command.call
+              expect(cmd.broadcast_registry.registry).to be_empty
+              expect(cmd.broadcast_registry).not_to be_invalid
+            end
+          end
+
+          shared_examples_for "does not save imported projects" do
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+
+            it "does not create the projects" do
+              expect do
+                command.call
+              end.not_to(change { Decidim::Budgets::Project.where(budget: budget).count })
+            end
+
+            it "broadcast_registry is invalid" do
+              cmd = command.call
+
+              if valid
+                expect(cmd.broadcast_registry.registry).not_to be_empty
+                expect(cmd.broadcast_registry).to be_invalid
+              else
+                expect(cmd.broadcast_registry.registry).to be_empty
+                expect(cmd.broadcast_registry).not_to be_invalid
+              end
+            end
+          end
+
+          it_behaves_like "saves imported projects"
+
+          describe "when document is JSON" do
+            let(:filename) { "projects-import.json" }
+            let(:mime_type) { "application/json" }
+
+            it_behaves_like "saves imported projects"
+          end
+
+          describe "when document is XLSX" do
+            let(:filename) { "projects-import.xlsx" }
+            let(:mime_type) { "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }
+
+            it_behaves_like "saves imported projects"
+          end
+
+          describe "when the form is invalid" do
+            let(:valid) { false }
+
+            it_behaves_like "does not save imported projects"
+          end
+
+          context "when category ID does not exist" do
+            let(:category) { create(:category) }
+
+            it_behaves_like "does not save imported projects"
+          end
+
+          context "when related proposal ID does not exist in participatory space" do
+            let!(:proposal) { create(:proposal, id: 1) }
+
+            it_behaves_like "does not save imported projects"
+          end
+
+          context "when one of related proposals ID does not exist" do
+            let!(:proposal) { create(:proposal, id: 10, component: proposal_component) }
+
+            it_behaves_like "does not save imported projects"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,3 +35,22 @@ RSpec.configure do |config|
     end
   end
 end
+
+def bundler_gem_path(gem_name)
+  spec = Bundler.rubygems.find_name(gem_name).first
+  spec.full_gem_path
+rescue Gem::LoadError
+  nil
+end
+
+def fixture_asset(name)
+  fixture_path = bundler_gem_path("decidim-budgets_importer")
+  return "" if fixture_path.blank?
+
+  File.expand_path(File.join(fixture_path, "spec", "fixtures", "files", name))
+end
+
+# Public: Returns a file for testing, just like file fields expect it
+def fixture_test_file(filename, content_type)
+  Rack::Test::UploadedFile.new(fixture_asset(filename), content_type)
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Add module budgets importer

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Marseille-Rebase-branch-ajout-module-budget-importer-0feda0d027124390a355bb2f42d7c691?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to Participatory process : http://localhost:3000/admin/participatory_processes
* Click on a PP of the list : http://localhost:3000/admin/participatory_processes/[SLUG]/edit?locale=fr
* Click on Budgets on the "Components" sidebar
* Access the projects page by clicking on the action icon
<img width="600" alt="Screenshot 2024-05-20 at 14 20 57" src="https://github.com/OpenSourcePolitics/decidim-app/assets/26109239/1d538d24-1aaf-43e5-a115-5cdc889a8dba">

* Download a sample export by clicking on the dropdown `Export > Export as JSON` (retrieve zip file in the letter opener http://localhost:3000/letter_opener)

* Then try to upload these projects by clicking on dropdown "Import > Import projects to budgets"
* Follow form and upload
* See new projects in the list

#### Tasks
- [x] Add specs
- [x] Add modules
- [x] Verify french translations
