### PR TITLE
Fix: SMS Gateway Service

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -85,11 +85,13 @@ RAILS_LOG_LEVEL=warn
 # Default notifications sending frequency : (daily, weekly, none, real_time)
 # NOTIFICATIONS_SENDING_FREQUENCY=daily
 
-#SMS_GATEWAY_SERVICE=
-#SMS_GATEWAY_USERNAME=
-#SMS_GATEWAY_PASSWORD=
-#SMS_GATEWAY_URL=
-#SMS_GATEWAY_PLATFORM=
+## SMS Gateway Service (eg: decidim-half_signup)
+# SMS_GATEWAY_SERVICE="Decidim::SmsGatewayService"
+# SMS_GATEWAY_URL="https://sms.gateway.service/api"
+# SMS_GATEWAY_USERNAME=
+# SMS_GATEWAY_PASSWORD=
+## Set to replace the organization name
+# SMS_GATEWAY_PLATFORM="hashimoto.local"
 
 #Timeout for the unsubscribe link of the newsletter
 #NEWSLETTERS_UNSUBSCRIBE_TIMEOUT=

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development do
   gem "rubocop-faker"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
-  gem "web-console", "4.0.4"
+  gem "web-console", "~> 4.1"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1075,7 +1075,7 @@ GEM
       rexml (~> 3.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.0.4)
+    web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
@@ -1175,7 +1175,7 @@ DEPENDENCIES
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   sys-filesystem
-  web-console (= 4.0.4)
+  web-console (~> 4.1)
   wicked_pdf (= 2.6.3)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: cec7c1f329777a1a011214346c7a957475fa7679
+  revision: 5f24e2cd183767e48c390b0fc2064c5544f60c49
   branch: feature/half_signup_and_budgets_booth
   specs:
     decidim-half_signup (0.27.0)

--- a/app/services/decidim/sms_gateway_service.rb
+++ b/app/services/decidim/sms_gateway_service.rb
@@ -40,7 +40,7 @@ module Decidim
       value = Rails.application.secrets.dig(:decidim, :sms_gateway, key.to_sym)
       if required && value.blank?
         Rails.logger.error "Decidim::SmsGatewayService is missing a configuration value for :#{key}, " \
-                           "please check Rails.application.secrets(\"decidim.sms_gateway.#{key}\") " \
+                           "please check Rails.application.secrets.dig(:decidim, :sms_gateway, :#{key}) " \
                            "or environment variable SMS_GATEWAY_#{key.to_s.upcase}"
       end
       value

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -69,7 +69,6 @@ Decidim.configure do |config|
   # take over user accounts.
   #
   config.enable_html_header_snippets = true
-  config.sms_gateway_service = "Decidim::Verifications::Sms::ExampleGateway"
 
   # SMS gateway configuration
   #
@@ -92,7 +91,7 @@ Decidim.configure do |config|
   #   end
   # end
   #
-  config.sms_gateway_service = Rails.application.secrets.dig(:decidim, :sms_gateway_service) if Rails.application.secrets.dig(:decidim, :sms_gateway_service).present?
+  config.sms_gateway_service = Rails.application.secrets.dig(:decidim, :sms_gateway, :service)
 
   # Etherpad configuration
   #

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -41,7 +41,12 @@ default: &default
       throttle:
         max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
         period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
-    sms_gateway_service: <%= ENV["SMS_GATEWAY_SERVICE"] %>
+    sms_gateway: 
+      service: <%= ENV.fetch("SMS_GATEWAY_SERVICE", "Decidim::Verifications::Sms::ExampleGateway") %>
+      url: <%= ENV["SMS_GATEWAY_URL"] %>
+      username: <%= ENV["SMS_GATEWAY_USERNAME"] %>
+      password: <%= ENV["SMS_GATEWAY_PASSWORD"] %>
+      platform: <%= ENV["SMS_GATEWAY_PLATFORM"] %>
     newsletters_unsubscribe_timeout: <%=  ENV.fetch("NEWSLETTERS_UNSUBSCRIBE_TIMEOUT", 365).to_i %>
   modules:
     gallery:


### PR DESCRIPTION
Just a few clean up for the SMS Gateway Service configuration vars : 
- load env vars as secrets
- add errors message (non blocking) in `Decidim::SmsGatewayService` when required vars are missing
- bump [decidim-module-half_sign_up](https://github.com/OpenSourcePolitics/decidim-module-half_sign_up) to initialize the service with the code instead of the message
