### PR TITLE
fix: JS incompatibility between budgets-category & budget-booth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-initiatives", "~> #{DECIDIM_VERSION}.0"
 gem "decidim-templates", "~> #{DECIDIM_VERSION}.0"
 
 # Load Budgets Booth to avoid errors
-gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/javascript_category_compat"
+gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp"
 
 # External Decidim gems
 gem "decidim-budget_category_voting", git: "https://github.com/alecslupu-pfa/decidim-budget_category_voting.git", branch: DECIDIM_BRANCH

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-initiatives", "~> #{DECIDIM_VERSION}.0"
 gem "decidim-templates", "~> #{DECIDIM_VERSION}.0"
 
 # Load Budgets Booth to avoid errors
-gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp"
+gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/javascript_category_compat"
 
 # External Decidim gems
 gem "decidim-budget_category_voting", git: "https://github.com/alecslupu-pfa/decidim-budget_category_voting.git", branch: DECIDIM_BRANCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: cc6f1f3d281849291530f0b8bee4733f120bde5c
-  branch: fix/javascript_category_compat
+  revision: 347e46f850ea47772d2c9fe7fd7a10405b38011b
   specs:
     decidim-budgets_booth (0.27.0)
       decidim-budgets (~> 0.27.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: 025a22755afc4ca3cec4c6fef65adebe1b26110c
+  revision: cc6f1f3d281849291530f0b8bee4733f120bde5c
+  branch: fix/javascript_category_compat
   specs:
     decidim-budgets_booth (0.27.0)
       decidim-budgets (~> 0.27.0)

--- a/app/views/decidim/budgets/line_items/update_budget.js.erb
+++ b/app/views/decidim/budgets/line_items/update_budget.js.erb
@@ -1,0 +1,34 @@
+var $orderTotalBudget = $('#order-total-budget');
+var $orderSelectedProjects = $('#order-selected-projects');
+var $orderProgress = $('#order-progress');
+var $projectItem = $('#project-<%= project.id %>-item');
+var $budgetConfirm = $('#budget-confirm');
+var $projectModal = $('#project-modal-<%= project.id %>');
+
+morphdom($orderTotalBudget[0], '<%= j(render partial: "decidim/budgets/projects/order_total_budget").strip.html_safe %>');
+morphdom($orderSelectedProjects[0], '<%= j(render partial: "decidim/budgets/projects/order_selected_projects").strip.html_safe %>');
+morphdom($orderProgress[0], '<%= j(render partial: "decidim/budgets/projects/order_progress").strip.html_safe %>');
+morphdom($budgetConfirm[0], '<%= j(render partial: "decidim/budgets/projects/budget_confirm").strip.html_safe %>')
+
+$("#order-progress").foundation();
+$(".budget-summary__selected").foundation();
+if ($projectItem.length > 0) {
+    morphdom($projectItem[0], '<%= j(render partial: "decidim/budgets/projects/project", locals: { project: project }).strip.html_safe %>');
+}
+
+if ($projectModal.length > 0) {
+    var $projectModalButtonForm = $(".project-vote-button", $projectModal).parent();
+    morphdom($projectModalButtonForm[0], '<%= j(cell("decidim/budgets/project_vote_button", project, scale_up: true)).strip.html_safe %>');
+}
+
+if ($projectModal.length > 0 && $projectModal.attr("aria-hidden") === "false") {
+    $(".project-vote-button", $projectModal).focus();
+} else {
+    $(".project-vote-button", $projectItem).focus();
+}
+
+<% if @show_help_modal %>
+$("#voting-help").foundation("open");
+<% end %>
+
+window.DecidimBudgets.checkProgressPosition();

--- a/app/views/decidim/budgets/line_items/update_budget.js.erb
+++ b/app/views/decidim/budgets/line_items/update_budget.js.erb
@@ -2,18 +2,29 @@ var $orderTotalBudget = $('#order-total-budget');
 var $orderSelectedProjects = $('#order-selected-projects');
 var $orderProgress = $('#order-progress');
 var $projectItem = $('#project-<%= project.id %>-item');
+var $projectBudgetButton = $('#project-<%= project.id %>-budget-button');
 var $budgetConfirm = $('#budget-confirm');
 var $projectModal = $('#project-modal-<%= project.id %>');
 
 morphdom($orderTotalBudget[0], '<%= j(render partial: "decidim/budgets/projects/order_total_budget").strip.html_safe %>');
 morphdom($orderSelectedProjects[0], '<%= j(render partial: "decidim/budgets/projects/order_selected_projects").strip.html_safe %>');
 morphdom($orderProgress[0], '<%= j(render partial: "decidim/budgets/projects/order_progress").strip.html_safe %>');
-morphdom($budgetConfirm[0], '<%= j(render partial: "decidim/budgets/projects/budget_confirm").strip.html_safe %>')
+morphdom($budgetConfirm[0], '<%= j(render partial: "decidim/budgets/projects/budget_confirm").strip.html_safe %>');
+
+<% current_order.categories.each do |category| %>
+var $votingSummary = $(`.vote_by_category[data-category-id=<%= category.id %>]`);
+morphdom($votingSummary[0], '<%= j(cell(category.card_class, category)).strip.html_safe %>');
+<% end %>
 
 $("#order-progress").foundation();
 $(".budget-summary__selected").foundation();
+
 if ($projectItem.length > 0) {
     morphdom($projectItem[0], '<%= j(render partial: "decidim/budgets/projects/project", locals: { project: project }).strip.html_safe %>');
+}
+
+if ($projectBudgetButton.length > 0) {
+    morphdom($projectBudgetButton[0], '<%= j(render partial: "decidim/budgets/projects/project_budget_button", locals: { project: project }).strip.html_safe %>');
 }
 
 if ($projectModal.length > 0) {


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

As a user, when I click on _read more_ on projects list, a modal open with a button "Add to your vote", on click an infinite loader is spinning 

It is related to an incompatibility between budgets-category & budget-booth.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Notion card](https://www.notion.so/opensourcepolitics/Angers-Infinite-loader-on-Details-vote-button-e9e655a9c6e8486d8247fa8df227c9f8?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Run application with deface enabled `DEFACE_ENABLED=true bundle exec rails s`
* Log in as admin
* Access Backoffice
* Access Participatory Process
* Create a budget
* Define categories
* Go to the budget booth

#### Tasks

Merge of 2 overrides from different modules into a single file : `app/views/decidim/budgets/line_items/update_budget.js.erb`

* https://github.com/OpenSourcePolitics/decidim-module-ptp/blob/main/decidim-budgets_booth/app/views/decidim/budgets/line_items/update_budget.js.erb
* https://github.com/alecslupu-pfa/decidim-budget_category_voting/blob/main/app/views/decidim/budgets/line_items/update_budget.js.erb

