### PR TITLE
Fix parent scope filter

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module DevelopmentApp
       require "extends/forms/decidim/initiatives/admin/initiative_form_extends"
       require "extends/commands/decidim/budgets/admin/import_proposals_to_budgets_extends"
       require "extends/controllers/decidim/newsletters_controller_extends"
+      require "extends/controllers/decidim/proposals/proposals_controller_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module ProposalsControllerExtends
+  extend ActiveSupport::Concern
+  included do
+    private
+
+    def default_filter_scope_params
+      return "all" unless current_component.scopes.any?
+
+      if (scope = current_component.scope)
+        scope_children = scope.children
+        scope_children_ids = scope_children.present? ? scope_children.map(&:id) : []
+        ids = ["all", scope.id] + scope_children_ids
+        while Decidim::Scope.where(parent_id: scope_children_ids).present?
+          sub_ids = Decidim::Scope.where(parent_id: scope_children_ids).pluck(:id)
+          ids += sub_ids
+          scope_children_ids = sub_ids
+        end
+        ids.map(&:to_s)
+      else
+        %w(all global) + current_component.scopes.pluck(:id).map(&:to_s)
+      end
+    end
+  end
+end
+
+Decidim::Proposals::ProposalsController.include(ProposalsControllerExtends)

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
@@ -9,19 +9,22 @@ module ProposalsControllerExtends
     def default_filter_scope_params
       return "all" unless current_component.scopes.any?
 
-      if (scope = current_component.scope)
-        scope_children = scope.children
-        scope_children_ids = scope_children.present? ? scope_children.map(&:id) : []
-        ids = ["all", scope.id] + scope_children_ids
-        while Decidim::Scope.where(parent_id: scope_children_ids).present?
-          sub_ids = Decidim::Scope.where(parent_id: scope_children_ids).pluck(:id)
-          ids += sub_ids
-          scope_children_ids = sub_ids
-        end
-        ids.map(&:to_s)
-      else
-        %w(all global) + current_component.scopes.pluck(:id).map(&:to_s)
+      scope = current_component.scope
+      return current_component_scope_ids if scope.blank?
+
+      scope_children_ids = scope.children&.map(&:id)
+      ids = ["all", scope.id] + scope_children_ids
+      while Decidim::Scope.where(parent_id: scope_children_ids).present?
+        sub_ids = Decidim::Scope.where(parent_id: scope_children_ids).pluck(:id)
+        ids += sub_ids
+        scope_children_ids = sub_ids
       end
+      ids.map(&:to_s)
+    end
+
+    def current_component_scope_ids
+      component_scopes = current_component.scopes.pluck(:id).map(&:to_s)
+      %w(all global) + component_scopes
     end
   end
 end

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -43,7 +43,7 @@ module Decidim
 
           context "and subscopes" do
             let!(:subscope_one) { create(:scope, organization: component.organization, parent: scope) }
-            let!(:subscope_two) { create(:scope, organization: component.organization, parent: scope) }
+            let!(:subscope_two) { create(:scope, organization: component.organization, parent: subscope_one) }
 
             it "returns an array containing all and scope id and subscopes ids" do
               component.update!(settings: { scopes_enabled: true, scope_id: scope.id })


### PR DESCRIPTION
#### :tophat: Description
In an assembly on proposals index view, sometimes  in the filters, a scope is not checked because its children are not checked while they should be all checked when loading the page.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=1988f63b9b3e4cb6abd1e2b4bcbc53cc&pm=c)

#### Testing
*Describe the best way to test or validate your PR.*

1. As an admin, create an assembly with scopes enabled, choose a scope that has subscopes (like "Indiana"), or choose one assembly that has scopes enabled and a scope.
2. As an admin, go to parameters > scopes > Indiana, click on one of its subscopes (like [Grimesstad) and  add subscopes to it
3. As a user, go to the assemblies > assembly > proposals and see in the filters that all the scopes and their children are checked



#### Tasks
- [X ] Add specs


### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
