### PR TITLE
fix(exports): add safe navigation operator on answer param

### DIFF
--- a/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
+++ b/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
@@ -17,8 +17,8 @@ module UserAnswersSerializerExtends
 
     def user_data(answer)
       {
-        answer_translated_attribute_name(:email) => answer.user&.email.presence || "",
-        answer_translated_attribute_name(:name) => answer.user&.name || ""
+        answer_translated_attribute_name(:email) => answer&.user&.email.presence || "",
+        answer_translated_attribute_name(:name) => answer&.user&.name || ""
       }
     end
 


### PR DESCRIPTION
#### :tophat: Description
When exporting a meeting without data in the registration form, answer can be `nil` in the `user_data` method. 
This was causing crash on the meeting participants export. 
