### PR TITLE
Backport initiatives exports pdf

### DIFF
--- a/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -1,0 +1,39 @@
+<% collect_user_extra_fields = model.initiative.type.collect_user_extra_fields %>
+<% cell_small_width = collect_user_extra_fields ? "9.4%" : "15.6%" %>
+<% style_initiatives_votes_table_row = "width: 100%; display: inline-block; min-height: 33pt; border-bottom: 1pt solid black;" %>
+<% style_initiatives_votes_table_cell = "width: #{cell_small_width}; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;" %>
+<br>
+<div class="initiatives-votes-table-row" style="<%= style_initiatives_votes_table_row %>">
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= initiative_id %>
+  </div>
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= initiative_title %>
+  </div>
+  <% if collect_user_extra_fields %>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+      <%= name_and_surname %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+      <%= document_number %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+      <%= date_of_birth %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+      <%= postal_code %>
+    </div>
+  <% end %>
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= time_and_date %>
+  </div>
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= timestamp %>
+  </div>
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= hash_id %>
+  </div>
+  <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell %>">
+    <%= scope %>
+  </div>
+</div>

--- a/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Decidim
+  module InitiativesVotes
+    class VoteCell < Decidim::ViewModel
+      include Decidim::SanitizeHelper
+
+      delegate :timestamp, :hash_id, to: :model
+
+      def show
+        render
+      end
+
+      def initiative_id
+        model.initiative.reference
+      end
+
+      def initiative_title
+        decidim_sanitize(translated_attribute(model.initiative.title))
+      end
+
+      def name_and_surname
+        metadata[:name_and_surname]
+      end
+
+      def document_number
+        metadata[:document_number]
+      end
+
+      def date_of_birth
+        metadata[:date_of_birth]
+      end
+
+      def postal_code
+        metadata[:postal_code]
+      end
+
+      def time_and_date
+        model.created_at
+      end
+
+      def scope
+        return I18n.t("decidim.scopes.global") if model.decidim_scope_id.nil?
+        return I18n.t("decidim.initiatives.unavailable_scope") if model.scope.blank?
+
+        translated_attribute(model.scope.name)
+      end
+
+      protected
+
+      def encryptor
+        @encryptor ||= Decidim::Initiatives::DataEncryptor.new(secret: "personal user metadata")
+      end
+
+      def metadata
+        @metadata ||= model.encrypted_metadata ? encryptor.decrypt(model.encrypted_metadata) : {}
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      require "csv"
+
+      # Controller used to manage the initiatives
+      class InitiativesController < Decidim::Initiatives::Admin::ApplicationController
+        include Decidim::Initiatives::NeedsInitiative
+        include Decidim::Initiatives::SingleInitiativeType
+        include Decidim::Initiatives::TypeSelectorOptions
+        include Decidim::Initiatives::Admin::Filterable
+        # include Decidim::Admin::ParticipatorySpaceAdminBreadcrumb
+
+        helper ::Decidim::Admin::ResourcePermissionsHelper
+        helper Decidim::Initiatives::InitiativeHelper
+        helper Decidim::Initiatives::SignatureTypeOptionsHelper
+
+        # GET /admin/initiatives
+        def index
+          enforce_permission_to :list, :initiative
+          @initiatives = filtered_collection
+        end
+
+        # GET /admin/initiatives/:id/edit
+        def edit
+          enforce_permission_to :edit, :initiative, initiative: current_initiative
+
+          form_attachment_model = form(AttachmentForm).from_model(current_initiative.attachments.first)
+          @form = form(Decidim::Initiatives::Admin::InitiativeForm)
+                  .from_model(
+                    current_initiative,
+                    initiative: current_initiative
+                  )
+          @form.attachment = form_attachment_model
+
+          render layout: "decidim/admin/initiative"
+        end
+
+        # PUT /admin/initiatives/:id
+        def update
+          enforce_permission_to :update, :initiative, initiative: current_initiative
+
+          params[:id] = params[:slug]
+          @form = form(Decidim::Initiatives::Admin::InitiativeForm)
+                  .from_params(params, initiative: current_initiative)
+
+          Decidim::Initiatives::Admin::UpdateInitiative.call(current_initiative, @form, current_user) do
+            on(:ok) do |initiative|
+              flash[:notice] = I18n.t("initiatives.update.success", scope: "decidim.initiatives.admin")
+              redirect_to edit_initiative_path(initiative)
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
+              render :edit, layout: "decidim/admin/initiative"
+            end
+          end
+        end
+
+        # POST /admin/initiatives/:id/publish
+        def publish
+          enforce_permission_to :publish, :initiative, initiative: current_initiative
+
+          PublishInitiative.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+            end
+          end
+        end
+
+        # DELETE /admin/initiatives/:id/unpublish
+        def unpublish
+          enforce_permission_to :unpublish, :initiative, initiative: current_initiative
+
+          UnpublishInitiative.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+            end
+          end
+        end
+
+        # DELETE /admin/initiatives/:id/discard
+        def discard
+          enforce_permission_to :discard, :initiative, initiative: current_initiative
+          current_initiative.discarded!
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+        end
+
+        # POST /admin/initiatives/:id/accept
+        def accept
+          enforce_permission_to :accept, :initiative, initiative: current_initiative
+          current_initiative.accepted!
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+        end
+
+        # DELETE /admin/initiatives/:id/reject
+        def reject
+          enforce_permission_to :reject, :initiative, initiative: current_initiative
+          current_initiative.rejected!
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+        end
+
+        # GET /admin/initiatives/:id/send_to_technical_validation
+        def send_to_technical_validation
+          enforce_permission_to :send_to_technical_validation, :initiative, initiative: current_initiative
+
+          SendInitiativeToTechnicalValidation.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to EngineRouter.main_proxy(current_initiative).initiatives_path(initiative_slug: nil), flash: {
+                notice: I18n.t(
+                  "success",
+                  scope: "decidim.initiatives.admin.initiatives.edit"
+                )
+              }
+            end
+          end
+        end
+
+        # GET /admin/initiatives/export
+        def export
+          enforce_permission_to :export, :initiatives
+
+          Decidim::Initiatives::ExportInitiativesJob.perform_later(
+            current_user,
+            current_organization,
+            params[:format] || default_format,
+            params[:collection_ids].presence&.map(&:to_i)
+          )
+
+          flash[:notice] = t("decidim.admin.exports.notice")
+
+          redirect_back(fallback_location: initiatives_path)
+        end
+
+        # GET /admin/initiatives/:id/export_votes
+        def export_votes
+          enforce_permission_to :export_votes, :initiative, initiative: current_initiative
+
+          votes = current_initiative.votes.map(&:sha1)
+          csv_data = CSV.generate(headers: false) do |csv|
+            votes.each do |sha1|
+              csv << [sha1]
+            end
+          end
+
+          respond_to do |format|
+            format.csv { send_data csv_data, file_name: "votes.csv" }
+          end
+        end
+
+        # GET /admin/initiatives/:id/export_pdf_signatures.pdf
+        def export_pdf_signatures
+          enforce_permission_to :export_pdf_signatures, :initiative, initiative: current_initiative
+
+          @votes = current_initiative.votes
+
+          output = render_to_string(
+            pdf: "votes_#{current_initiative.id}",
+            layout: "decidim/admin/initiatives_votes",
+            template: "decidim/initiatives/admin/initiatives/export_pdf_signatures",
+            format: [:pdf]
+          )
+          output = pdf_signature_service.new(pdf: output).signed_pdf if pdf_signature_service
+
+          respond_to do |format|
+            format.pdf do
+              send_data(output, filename: "votes_#{current_initiative.id}.pdf", type: "application/pdf")
+            end
+            format.html
+          end
+        end
+
+        private
+
+        def collection
+          @collection ||= ManageableInitiatives.for(current_user)
+        end
+
+        def pdf_signature_service
+          @pdf_signature_service ||= Decidim.pdf_signature_service.to_s.safe_constantize
+        end
+
+        def default_format
+          "json"
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/initiatives/admin/initiatives/_signatures.html.erb
+++ b/app/views/decidim/initiatives/admin/initiatives/_signatures.html.erb
@@ -1,0 +1,87 @@
+<% cell_small_width = collect_user_extra_fields ? "9.4%" : "15.6%" %>
+<% style_initiative_title = "border: 1pt solid black; margin: 15pt 0; font-size: 12pt; font-weight: bold; text-transform: uppercase; text-align: center;" %>
+<% style_initiatives_votes_table = "width: 100%; display: block; border: 1pt solid black;" %>
+<% style_initiatives_votes_table_header = "background-color: lightgray; display: inline-block; width: 100%; font-size: 12pt; font-weight: bold; border-bottom: 1pt solid black;" %>
+<% style_initiatives_votes_table_row = "width: 100%; display: inline-block; min-height: 33pt;" %>
+<% style_initiatives_votes_table_cell = "width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;" %>
+<% style_initiatives_votes_table_cell_small = "width: #{cell_small_width}; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;" %>
+<div class="initiative-title" style="<%= style_initiative_title %>">
+  <%= translated_attribute(initiative.title) %>
+</div>
+<div class="initiatives-votes-table" style="<%= style_initiatives_votes_table %>">
+  <div class="initiatives-votes-table-header" style="<%= style_initiatives_votes_table_header %>">
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= t("models.initiatives_votes.fields.initiative_start_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= t("models.initiatives_votes.fields.initiative_end_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= t("models.initiatives_votes.fields.initiative_signatures_count", scope: "decidim.admin") %>
+    </div>
+  </div>
+  <div class="initiatives-votes-table-row" style="<%= style_initiatives_votes_table_row %>">
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= initiative.reference %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= translated_attribute(initiative.title) %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= initiative.signature_start_date %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= initiative.signature_end_date %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="<%= style_initiatives_votes_table_cell %>">
+      <%= votes.count %>
+    </div>
+  </div>
+</div>
+<br>
+<br>
+<div class="initiatives-votes-table" style="<%= style_initiatives_votes_table %>">
+  <div class="initiatives-votes-table-header" style="<%= style_initiatives_votes_table_header %>">
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %>
+    </div>
+    <% if collect_user_extra_fields %>
+      <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+        <%= t("models.initiatives_votes.fields.name_and_surname", scope: "decidim.admin") %>
+      </div>
+      <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+        <%= t("models.initiatives_votes.fields.document_number", scope: "decidim.admin") %>
+      </div>
+      <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+        <%= t("models.initiatives_votes.fields.date_of_birth", scope: "decidim.admin") %>
+      </div>
+      <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+        <%= t("models.initiatives_votes.fields.postal_code", scope: "decidim.admin") %>
+      </div>
+    <% end %>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.time_and_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.timestamp", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.hash", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="<%= style_initiatives_votes_table_cell_small %>">
+      <%= t("models.initiatives_votes.fields.scope", scope: "decidim.admin") %>
+    </div>
+  </div>
+  <% votes.each do |vote| %>
+    <%= cell "decidim/initiatives_votes/vote", vote %>
+  <% end %>
+</div>

--- a/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.html.erb
+++ b/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.html.erb
@@ -1,0 +1,8 @@
+<%# This page is for PDF signatures, but we have the HTML version so it is possible to
+    test without adding new dependencies just for this.
+    If there is a new API or method to test the PDF format then this HTML version can be deleted. %>
+<%= render partial: "signatures", locals: {
+  collect_user_extra_fields: current_initiative.type.collect_user_extra_fields,
+  votes: @votes,
+  initiative: current_initiative
+} %>

--- a/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.pdf.erb
+++ b/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.pdf.erb
@@ -1,0 +1,5 @@
+<%= render partial: "signatures.html.erb", locals: {
+  collect_user_extra_fields: current_initiative.type.collect_user_extra_fields,
+  votes: @votes,
+  initiative: current_initiative
+} %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -104,6 +104,7 @@ ignore_missing:
  - decidim.initiatives.actions.answer
  - decidim.admin.titles.initiatives
  - decidim.admin.models.initiatives.fields.*
+ - decidim.admin.models.initiatives_votes.*
  - decidim.admin.actions.configure
  - decidim.account.email_change.*
  - decidim.account.show.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
         file: importing file
   decidim:
     admin:
+      exports:
+        notice: Your export is currently in progress. You'll receive an email when it's complete.
       participatory_space_private_users:
         create:
           error: Error
@@ -85,17 +87,23 @@ en:
     initiatives:
       admin:
         initiatives:
+          edit:
+            success: The initiative has been sent to technical validation
           form:
             attachments: Attachments
             settings: Settings
             title: General information
           index:
             warning: Initiatives are not used for now. When you create an initiative type, it will be displayed in front-office.
+          update:
+            error: An error has occurred
+            success: The initiative has been successfully updated
       pages:
         home:
           highlighted_initiatives:
             active_initiatives: Active initiatives
             see_all_initiatives: See all initiatives
+      unavailable_scope: Unavailable scope
     meetings:
       directory:
         meetings:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -16,6 +16,8 @@ fr:
         file: importer un fichier d'utilisateurs
   decidim:
     admin:
+      exports:
+        notice: Votre exportation est en cours. Vous recevrez un e-mail quand elle sera terminée.
       menu:
         admin_accountability: Admin accountability
       participatory_space_private_users:
@@ -87,17 +89,23 @@ fr:
     initiatives:
       admin:
         initiatives:
+          edit:
+            success: La pétition a été envoyée à la validation technique
           form:
             attachments: Pièces jointes
             settings: Paramètres
             title: Informations générales
           index:
             warning: Attention, lorsque vous créez un type de pétition, ce dernier est automatiquement visible pour les utilisateurs.
+          update:
+            error: Une erreur est survenue
+            success: La pétition a été mise à jour avec succès
       pages:
         home:
           highlighted_initiatives:
             active_initiatives: Pétitions actives
             see_all_initiatives: Voir toutes les pétitions
+      unavailable_scope: Portée indisponible
     meetings:
       directory:
         meetings:

--- a/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
+++ b/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::InitiativesVotes::VoteCell, type: :cell do
+  subject { cell("decidim/initiatives_votes/vote", vote).call }
+
+  include Decidim::SanitizeHelper
+
+  controller Decidim::PagesController
+
+  context "when there are no user extra fields" do
+    let(:vote) { create(:initiative_user_vote, initiative: create(:initiative)) }
+
+    context "when rendering" do
+      it "shows title and reference of initiative" do
+        expect(subject.to_s).to include(vote.initiative.reference)
+        expect(subject.to_s).to include(decidim_sanitize(translated(vote.initiative.title)))
+      end
+
+      it "does not have personal data" do
+        expect(subject).to have_css(".initiatives-votes-table-cell", count: 6)
+      end
+    end
+  end
+
+  context "when there is user extra fields" do
+    let(:vote) do
+      create(:initiative_user_vote,
+             initiative: create(:initiative, :with_user_extra_fields_collection),
+             encrypted_metadata: Decidim::Initiatives::DataEncryptor.new(secret: "personal user metadata").encrypt(personal_data_params))
+    end
+
+    let(:personal_data_params) do
+      {
+        name_and_surname: Faker::Name.name,
+        document_number: Faker::IDNumber.spanish_citizen_number,
+        date_of_birth: Faker::Date.birthday(min_age: 18, max_age: 40),
+        postal_code: Faker::Address.zip_code
+      }
+    end
+
+    context "when rendering" do
+      it "shows title and reference of initiative" do
+        expect(subject.to_s).to include(vote.initiative.reference)
+        expect(subject.to_s).to include(decidim_sanitize(translated(vote.initiative.title)))
+      end
+
+      it "shows decrypted data" do
+        expect(subject).to have_css(".initiatives-votes-table-cell", count: 10)
+        expect(subject).to have_content(personal_data_params[:name_and_surname])
+        expect(subject).to have_content(personal_data_params[:document_number])
+        expect(subject).to have_content(personal_data_params[:date_of_birth])
+        expect(subject).to have_content(personal_data_params[:postal_code])
+      end
+    end
+  end
+end

--- a/spec/system/admin/export_initiative_signatures_spec.rb
+++ b/spec/system/admin/export_initiative_signatures_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin export initiatives' signature" do
+describe "Admin export initiatives' signature", type: :system do
   include_context "when admins initiative"
 
   let!(:votes) { create_list(:initiative_user_vote, 5, initiative: initiative) }
@@ -20,8 +20,8 @@ describe "Admin export initiatives' signature" do
     end
 
     click_link "Export PDF of signatures"
-    within "#confirm-modal-content" do
-      click_button "OK"
+    within ".confirm-modal-footer" do
+      click_on "OK"
     end
 
     expect(File.basename(download_path)).to include("votes_#{initiative.id}.pdf")


### PR DESCRIPTION
#### :tophat: Description
Currently all the initiatives signatures PDF file have always the columns "Name and surname", "Document number" and "Date of birth". This doesn't make much sense as this should depend if the Intiative Type has the " Collect participant personal data on signature " setting enabled.

This PR takes into account this setting to show these columns in the export PDF file.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=016bfb32d01f4373be6c0c53bb6ce6e5&pm=c)

#### Testing
1. As an admin, go to http://localhost:3000/admin/initiatives
2. Then, click in "Edit' (pencil) of an initiative, check which Initiative type this Initiative has. Go to that Initiative type and check that " Collect participant personal data on signature " setting is not checked.
3. Click in the "Export PDF of signatures" button. See that you don't have the columns "Name and surname, Date of birth, document number, postal code"
4. Go back to Initiative type and edit it to enable the " Collect participant personal data on signature " setting. 
5. Export the PDF again and see that you have those columns.


### :camera: Screenshots
Pdf with Collect participant personal data on signature not checked => 
<img width="1003" alt="Capture d’écran 2024-06-19 à 15 55 30" src="https://github.com/OpenSourcePolitics/decidim-app/assets/61418966/f6f39456-a7b2-49fc-8e17-4aec139019e7">

Pdf with Collect participant personal data on signature checked =>
<img width="1006" alt="Capture d’écran 2024-06-19 à 15 54 30" src="https://github.com/OpenSourcePolitics/decidim-app/assets/61418966/3cd68438-ea42-427b-b67e-dce91c0cd57f">

