### PR TITLE
Fix/rake decidim migrate

### DIFF
--- a/lib/migrations_fixer.rb
+++ b/lib/migrations_fixer.rb
@@ -16,13 +16,12 @@ class MigrationsFixer
     raise "Undefined logger" if @logger.blank?
 
     validate_migration_path
-    validate_env_vars
     validate_osp_app_path
   end
 
   # Build osp-app path and returns osp-app path ending with '/*'
   def osp_app_path
-    osp_app_path ||= File.expand_path(ENV.fetch("MIGRATIONS_PATH", nil))
+    osp_app_path ||= File.expand_path(ENV.fetch("MIGRATIONS_PATH", "db/migrate"))
     if osp_app_path.end_with?("/")
       osp_app_path
     else
@@ -31,16 +30,6 @@ class MigrationsFixer
   end
 
   private
-
-  # Ensure MIGRATIONS_PATH is correctly set
-  def validate_env_vars
-    if ENV["MIGRATIONS_PATH"].blank?
-      @logger.error("You must specify ENV var 'MIGRATIONS_PATH'")
-
-      @logger.fatal(helper)
-      validation_failed
-    end
-  end
 
   # Ensure osp_app path exists
   def validate_osp_app_path

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'migrations_fixer'
-require 'rails_migrations'
+require "migrations_fixer"
+require "rails_migrations"
 
 # :nocov:
 namespace :decidim do

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'migrations_fixer'
+require 'rails_migrations'
+
 # :nocov:
 namespace :decidim do
   namespace :db do

--- a/spec/lib/migrations_fixer_spec.rb
+++ b/spec/lib/migrations_fixer_spec.rb
@@ -39,16 +39,6 @@ RSpec.describe MigrationsFixer do
       end
     end
 
-    context "with missing environment" do
-      let(:migration_path_env) { nil }
-
-      it "raises an exception" do
-        expect do
-          described_class.new logger
-        end.to raise_error "Invalid configuration, aborting"
-      end
-    end
-
     context "with non-existing MIGRATIONS_PATH variable" do
       let(:migration_path_env) { "/some/inexistant/dir" }
 


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Fix decidim k8s upgrade task when rescueing error. 

Set default `MIGRATIONS_PATH` to `db/migrate`

#### How to test

* Run : `bundle exec rake db:drop db:create db:schema:load && bundle exec rake decidim:db:migrate` 