### PR TITLE
feat: Change SMS text to include terms & conditions

### DIFF
--- a/app/views/decidim/half_signup/quick_auth/sms.html.erb
+++ b/app/views/decidim/half_signup/quick_auth/sms.html.erb
@@ -1,0 +1,28 @@
+<div class="content">
+  <div class="wrapper">
+    <div class="row">
+      <div class="columns small-12 smallmedium-10 medium-8 large-6 small-centered margin-bottom-3" id="select-wrapper">
+        <div class="card">
+          <div class="card__content">
+            <h2 class="text-center"><%= t(".enter_phone") %></h2>
+            <p class="text-center"><%= t("instruction", scope:"decidim.half_signup.quick_auth.sms") %></p>
+            <p class="text-center"><%= t("click_here", scope:"decidim.half_signup.quick_auth.sms") %> <a href="/pages/terms-and-conditions"><%= t("cgu", scope:"decidim.half_signup.quick_auth.sms") %></a></p>
+            <%= decidim_form_for(@form, url: users_quick_auth_verification_path, method: :post) do |form| %>
+              <%= render partial: "phone_form", locals: { form: form } %>
+            <% end %>
+            <% if handlers_count > 1 && !current_user %>
+              <p class="text-center">
+                <%= link_to t("another_method", scope:"decidim.half_signup.quick_auth"), decidim_half_signup.users_quick_auth_path, class: "text-center" %>
+              </p>
+            <% end %>
+            <% if current_user.present? %>
+              <p class="text-center">
+                <%= link_to t("back", scope:"decidim.half_signup.quick_auth"), decidim.account_path, class: "text-center" %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -112,7 +112,8 @@ ignore_missing:
  - decidim.newsletters.unsubscribe.error
  - decidim.newsletters.unsubscribe.token_error
  - activemodel.errors.models.assembly.attributes.document.invalid_document_type
- - decidim.half_signup.quick_auth.sms_verification.text_message
+ - decidim.half_signup.quick_auth.*
+
 
 # Consider these keys used:
 ignore_unused:
@@ -151,4 +152,4 @@ ignore_unused:
   - decidim.newsletters.unsubscribe.error
   - decidim.newsletters.unsubscribe.token_error
   - activemodel.errors.models.assembly.attributes.document.invalid_document_type
-  - decidim.half_signup.quick_auth.sms_verification.text_message
+  - decidim.half_signup.quick_auth.*

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -86,6 +86,13 @@ fr:
         name: Nom
     half_signup:
       quick_auth:
+        another_method: Utiliser une autre méthode
+        back: Retour au compte
+        sms:
+          cgu: conditions générales d'utilisation
+          click_here: Cliquez ici pour retrouver l'intégralité des
+          enter_phone: 'Veuillez saisir votre numéro de téléphone :'
+          instruction: Dans le cadre de votre vote au Budget Participatif, votre numéro de téléphone est uniquement utilisé pour vérifier et sécuriser votre participation, sans qu'aucun compte ne soit créé. Il ne sera pas réutilisé à d'autres fins par la Ville de Marseille.
         sms_verification:
           text_message: Bonjour, %{verification} est le code pour voter sur participons.marseille.fr. Votez et faites voter vos voisins pour les projets du 1er Budget participatif marseillais !
     initiatives:


### PR DESCRIPTION
#### :tophat: Description

This PR changes the text on the sms authentication method for Marseille and also adds a link to the terms and conditions to replace the appearance of it after the creation of the account.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Marseille-CGU-1ed988bbd0d14a7886620bec320eeccc?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to organization settings
* Go to authentication settings
* Enable SMS method and save your organization
* Log out 
* Change your locale to french
* Try to login
* Make sure that you have the translation and that you can access the Terms&Conditions by clicking on the link

#### Tasks
- [x] Override the authentication page from Half Signup
- [x] Add locales
- [x] Modify the rules of I18N tasks as Marseille only operates in French
