### PR TITLE
bump fix notifications and mails send after voting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: 32b0f9a29499768cf6783a0026badaed33f025ab
+  revision: 46bb834a68d52cd7d1d4bba6182cca55f2495125
   specs:
     decidim-budgets_booth (0.27.0)
       decidim-budgets (~> 0.27.0)


### PR DESCRIPTION
🎩 Description
Budget Booth, the vote confirmation is neither notified or sent by email.

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/Lyon-Dev-Budget-Booth-la-confirmation-du-vote-n-est-pas-notifi-e-ni-envoy-e-par-mail-9f649dc61dd14ac0b58ae3693231f4ca?pvs=4)

Testing

**Dashboard**

1. As an admin, go to a process.
2. Go to the budget setting (in components, click on the settings icon).
3. Click on **“Vote in one: allows participants to vote in any budget, but only in one.”** and **“Voting enabled.”**
4. 
<img width="596" alt="Capture d’écran 2024-07-29 à 13 10 53" src="https://github.com/user-attachments/assets/2a962e26-8e98-4107-8bd5-8fe9b2faa7c0">
<img width="1183" alt="Capture d’écran 2024-07-29 à 15 45 36" src="https://github.com/user-attachments/assets/aa9517e5-8ef9-4306-a59f-e9f7c5901f4d">

5. Update.

**Front-end**

1. Go to the process you changed.
2. Go to budgets.
3. Start voting (enter the budget booth).
4. Vote.
5. Go to your notifications and confirm that you received one about your vote.
6. Go to [http://localhost:3000/letter_opener](http://localhost:3000/letter_opener) and confirm that you received an email about your vote.
7.
<img width="1487" alt="Capture d’écran 2024-07-31 à 12 05 41" src="https://github.com/user-attachments/assets/13810348-4e8d-4869-9125-a4e5a678029c">
