### PR TITLE
Fix: add missing translations for export dropdown in proposals admin

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -89,13 +89,10 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
-          sudo apt-get update
           sudo apt-get install -y libu2f-udev
           sudo apt-get remove -y google-chrome-stable
           sudo apt-get purge -y google-chrome-stable
           sudo rm -rf /opt/google/chrome
-          sudo rm /usr/bin/google-chrome
-          sudo rm /usr/local/bin/google-chrome
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           sudo apt-mark hold google-chrome-stable

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -6,7 +6,6 @@ env:
   SIMPLECOV: "true"
   RSPEC_FORMAT: "documentation"
   RUBY_VERSION: 3.0.6
-  CHROME_VERSION: 126.0.6478.182
   RAILS_ENV: test
   NODE_VERSION: 16.9.1
   RUBYOPT: '-W:no-deprecated'
@@ -88,11 +87,6 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - run: |
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
-          sudo dpkg -i /tmp/chrome.deb
-          rm /tmp/chrome.deb
-        name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -111,8 +105,6 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[exclude, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
@@ -179,8 +171,6 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[include, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,6 +91,7 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y libu2f-udev
+          sudo apt-get purge -y google-chrome-stable
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           sudo apt-mark hold google-chrome-stable

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -89,6 +89,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
+          sudo apt install libu2f-udev
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
@@ -161,6 +162,12 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+      - run: |
+          sudo apt install libu2f-udev
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+        name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -89,14 +89,8 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
-          sudo apt-get install -y libu2f-udev
-          sudo apt-get remove -y google-chrome-stable
-          sudo apt-get purge -y google-chrome-stable
-          sudo rm -rf /opt/google/chrome
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
-          sudo apt-mark hold google-chrome-stable
-          /opt/google/chrome/chrome --version
           rm /tmp/chrome.deb
         name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -95,6 +95,7 @@ jobs:
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           sudo apt-mark hold google-chrome-stable
+          google-chrome --version
           rm /tmp/chrome.deb
         name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -89,6 +89,8 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
+          sudo apt-get update
+          sudo apt-get install -y libu2f-udev
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,11 +91,15 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y libu2f-udev
+          sudo apt-get remove -y google-chrome-stable
           sudo apt-get purge -y google-chrome-stable
+          sudo rm -rf /opt/google/chrome
+          sudo rm /usr/bin/google-chrome
+          sudo rm /usr/local/bin/google-chrome
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           sudo apt-mark hold google-chrome-stable
-          google-chrome --version
+          /opt/google/chrome/chrome --version
           rm /tmp/chrome.deb
         name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -6,6 +6,7 @@ env:
   SIMPLECOV: "true"
   RSPEC_FORMAT: "documentation"
   RUBY_VERSION: 3.0.6
+  CHROME_VERSION: 126.0.6478.182
   RAILS_ENV: test
   NODE_VERSION: 16.9.1
   RUBYOPT: '-W:no-deprecated'
@@ -87,6 +88,11 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+      - run: |
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+        name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -105,6 +111,8 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[exclude, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
@@ -171,6 +179,8 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[include, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -93,6 +93,7 @@ jobs:
           sudo apt-get install -y libu2f-udev
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
+          sudo apt-mark hold google-chrome-stable
           rm /tmp/chrome.deb
         name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -125,6 +125,7 @@ ignore_unused:
   - faker.*
   - activemodel.attributes.osp_authorization_handler.*
   - activemodel.attributes.participatory_process.private_space
+  - decidim.admin.exports.export_as
   - decidim.amendments.emendation.announcement.evaluating
   - decidim.authorization_handlers.osp_authorization_handler.{explanation, name}
   - decidim.authorization_handlers.osp_authorization_handler.fields.*
@@ -135,6 +136,8 @@ ignore_unused:
   - decidim.meetings.meeting.not_allowed
   - decidim.meetings.directory.meetings.index.all
   - decidim.meetings.meetings.{create, update}.{invalid, success}
+  - decidim.proposals.admin.exports.awesome_private_proposals
+  - decidim.proposals.admin.exports.proposal_comments
   - decidim.scopes.global
   - decidim.scopes.picker.*
   - decidim.system.organizations.omniauth_settings.{france_connect, france_connect_profile, france_connect_uid}.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
   decidim:
     admin:
       exports:
+        export_as: "%{name} as %{export_format}"
         notice: Your export is currently in progress. You'll receive an email when it's complete.
       participatory_space_private_users:
         create:
@@ -130,6 +131,10 @@ en:
       show:
         local_area: Organization area
     proposals:
+      admin:
+        exports:
+          awesome_private_proposals: Proposals with private fields
+          proposal_comments: Comments
       collaborative_drafts:
         new:
           add_file: Add file

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -17,6 +17,7 @@ fr:
   decidim:
     admin:
       exports:
+        export_as: "%{name} au format %{export_format}"
         notice: Votre exportation est en cours. Vous recevrez un e-mail quand elle sera terminée.
       menu:
         admin_accountability: Admin accountability
@@ -132,6 +133,10 @@ fr:
       show:
         local_area: Espace d'organisation
     proposals:
+      admin:
+        exports:
+          awesome_private_proposals: Propositions avec champs privés
+          proposal_comments: Commentaires
       collaborative_drafts:
         new:
           add_file: Ajouter le fichier

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let!(:admin) { create(:user, :admin, organization: organization) }
       let!(:admin_of_the_process) { create(:user, organization: organization) }
       let!(:participatory_process) { create(:participatory_process, organization: organization) }
-      let(:proposal) { create(:proposal) }
+      let(:proposal) { create(:extended_proposal) }
       let(:collection) { [proposal] } # Use an array with the instance_double
       let(:export_manifest) do
         instance_double(


### PR DESCRIPTION
#### :tophat: Description
Addition of missing translations keys for the dropdown export button in admin proposals index.

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=fff5d39996a78063a0a8c6a37ff033d8&pm=c)

#### Testing

1. As an admin, go to a process
2. Got to proposals
3. Click on "Export" button and see that you have the needed translations fo the different types of exports.
4. Change the language for french and see that you have the needed translations

