### PR TITLE
Fix reflected XSS on meetings versions

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -1,4 +1,6 @@
 # Overrides 🍰
+* `app/cells/decidim/version_cell.rb`
+This override the default `VersionCell` from `decidim-core`, by adding sanitization for `version_number` to prevent XSS attacks.
 
 ## Proposal's draft (Decidim awesome overrides 0.26.7)
 * `app/views/decidim/proposals/collaborative_drafts/_edit_form_fields.html.erb`

--- a/app/cells/decidim/version_cell.rb
+++ b/app/cells/decidim/version_cell.rb
@@ -34,7 +34,11 @@ module Decidim
     end
 
     def i18n_version_number_out_of_total
-      i18n("version_number_out_of_total", current_version: sanitize(index.first), total_count: versioned_resource.versions.count)
+      i18n("version_number_out_of_total", current_version: sanitized_version_number, total_count: versioned_resource.versions.count)
+    end
+
+    def sanitized_version_number
+      sanitize(index.to_s[0])
     end
 
     def i18n_show_all_versions

--- a/app/cells/decidim/version_cell.rb
+++ b/app/cells/decidim/version_cell.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Decidim
+  class VersionCell < Decidim::ViewModel
+    include Decidim::TraceabilityHelper
+    include Decidim::SanitizeHelper
+
+    def resource_title
+      decidim_html_escape(translated_attribute(versioned_resource.title))
+    end
+
+    def current_version
+      model
+    end
+
+    def versioned_resource
+      options[:versioned_resource]
+    end
+
+    def versions_path
+      options[:versions_path].call
+    end
+
+    def i18n_changes_title
+      i18n("changes_at_title", title: resource_title)
+    end
+
+    def i18n_version_number
+      i18n("version_number")
+    end
+
+    def i18n_back_to_resource
+      i18n("back_to_resource")
+    end
+
+    def i18n_version_number_out_of_total
+      i18n("version_number_out_of_total", current_version: sanitize(index.first), total_count: versioned_resource.versions.count)
+    end
+
+    def i18n_show_all_versions
+      i18n("show_all_versions")
+    end
+
+    def i18n_version_author
+      i18n("version_author")
+    end
+
+    def i18n_version_created_at
+      i18n("version_created_at")
+    end
+
+    def i18n(string, **params)
+      t(string, **params, scope: i18n_scope, default: t(string, **params, scope: default_i18n_scope))
+    end
+
+    def i18n_scope
+      options[:i18n_scope]
+    end
+
+    def default_i18n_scope
+      "decidim.version.show"
+    end
+
+    def index
+      options[:index]
+    end
+
+    def resource_path
+      resource_locator(versioned_resource).path
+    end
+  end
+end

--- a/app/cells/decidim/version_cell.rb
+++ b/app/cells/decidim/version_cell.rb
@@ -38,7 +38,7 @@ module Decidim
     end
 
     def sanitized_version_number
-      sanitize(index.to_s[0])
+      sanitize(index[0])
     end
 
     def i18n_show_all_versions

--- a/spec/cells/decidim/version_cell_spec.rb
+++ b/spec/cells/decidim/version_cell_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::VersionCell, type: :cell do
   let!(:assembly) { create(:assembly, :published, slug: "introduction-transfer") }
   let!(:component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
   let!(:meeting) { create(:meeting, :published, title: { en: "Meeting test" }, component: component) }
-  let!(:version) { PaperTrail::Version.create!(item: meeting, event: "update", object_changes: "number: 2'%3Cmarquee%20onstart=alert(1)%3Ex") }
+  let!(:version) { PaperTrail::Version.create!(item: meeting, event: "update", object_changes: "number: 2") }
   let(:index) { "2'%3Cmarquee%20onstart=alert(1)%3Ex" }
   let(:versions_path) { "/assemblies/#{assembly.slug}/f/24/meetings/#{meeting.id}/versions/#{index}" }
 

--- a/spec/cells/decidim/version_cell_spec.rb
+++ b/spec/cells/decidim/version_cell_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::VersionCell, type: :cell do
+  controller Decidim::ApplicationController
+
+  subject do
+    cell("decidim/version", version, versioned_resource: meeting, index: index, versions_path: -> { versions_path }).call
+  end
+
+  let!(:assembly) { create(:assembly, :published, slug: "introduction-transfer") }
+  let!(:component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
+  let!(:meeting) { create(:meeting, :published, title: { en: "Meeting test" }, component: component) }
+  let!(:version) { PaperTrail::Version.create!(item: meeting, event: "update", object_changes: "number: 2'%3Cmarquee%20onstart=alert(1)%3Ex") }
+  let(:index) { "2'%3Cmarquee%20onstart=alert(1)%3Ex" }
+  let(:versions_path) { "/assemblies/#{assembly.slug}/f/24/meetings/#{meeting.id}/versions/#{index}" }
+
+  it "sanitizes the version number" do
+    expect(subject).to have_link("Show all versions", href: "/assemblies/introduction-transfer/f/24/meetings/#{meeting.id}/versions/2'%3Cmarquee%20onstart=alert(1)%3Ex")
+
+    expect(subject).not_to have_content("onstart=alert(1)")
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
On the meeting versioning show page, a reflected XSS injection vulnerability is present. 

https://github.com/user-attachments/assets/5c0d3276-434e-4538-8dfb-9f31d57fd346

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/CEA-Reflected-XSS-on-meetings-versions-e48ed34acf27407e97d35967b5c083f7?pvs=4)

#### Testing

1. Create a new meeting (make sure the option "users can create meetings" is enabled in the dashboard if needed) and edit it once.
2. Go to the public page of the meeting.
3. Select the second version of the meeting (e.g., https://localhost:3000/assemblies/exhibition-general/f/24/meetings/65/versions/2).
4. In the URL, add at the end: 'XSS%3Cmarquee%20onstart=alert(1)%3Ex or '%3Cmarquee%20onstart=alert(1)%3Ex.
5. You should not see any JavaScript animation (like in the video above) next to the version number. 🎉 

<img width="751" alt="Capture d’écran 2024-09-04 à 15 22 09" src="https://github.com/user-attachments/assets/3454a29e-cda8-4201-815b-54e17feed8b1">

#### Tasks
- [x] Add specs
- [x] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
