### PR TITLE
feat: Add simple proposal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-m
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-ludens", git: "https://github.com/OpenSourcePolitics/decidim-ludens.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
+gem "decidim-simple_proposal", git: "https://github.com/OpenSourcePolitics/decidim-module-simple_proposal", branch: DECIDIM_BRANCH
 gem "decidim-spam_detection"
 gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,15 @@ GIT
       decidim-core (~> 0.27.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-simple_proposal
+  revision: 0ba2624660c093fa8813f40803cfa278e59fae0d
+  branch: release/0.27-stable
+  specs:
+    decidim-simple_proposal (0.27.0)
+      decidim-core (~> 0.27.0)
+      decidim-proposals (~> 0.27.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers
   revision: 65ea83227f99d0f3d6237f98334ecc914a2a5597
   specs:
@@ -1176,6 +1185,7 @@ DEPENDENCIES
   decidim-initiatives (~> 0.27.0)
   decidim-ludens!
   decidim-phone_authorization_handler!
+  decidim-simple_proposal!
   decidim-spam_detection
   decidim-survey_multiple_answers!
   decidim-templates (~> 0.27.0)

--- a/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+module Decidim
+  module SimpleProposal
+    module ProposalsControllerOverride
+      extend ActiveSupport::Concern
+
+      included do
+        def index
+          if component_settings.participatory_texts_enabled?
+            @proposals = Decidim::Proposals::Proposal
+                         .where(component: current_component, deleted_at: nil)
+                         .published
+                         .not_hidden
+                         .only_amendables
+                         .includes(:category, :scope)
+                         .order(position: :asc)
+            render "decidim/proposals/proposals/participatory_texts/participatory_text"
+          else
+            @base_query = search
+                          .result
+                          .where(deleted_at: nil)
+                          .published
+                          .not_hidden
+
+            @proposals = @base_query.includes(:component, :coauthorships)
+            @all_geocoded_proposals = @base_query.geocoded
+
+            @voted_proposals = if current_user
+                                 Decidim::Proposals::ProposalVote.where(
+                                   author: current_user,
+                                   proposal: @proposals.pluck(:id)
+                                 ).pluck(:decidim_proposal_id)
+                               else
+                                 []
+                               end
+            @proposals = paginate(@proposals)
+            @proposals = reorder(@proposals)
+          end
+        end
+
+        def new
+          if proposal_draft.present?
+            redirect_to edit_draft_proposal_path(proposal_draft, component_id: proposal_draft.component.id, question_slug: proposal_draft.component.participatory_space.slug)
+          else
+            enforce_permission_to :create, :proposal
+            @step = Decidim::Proposals::ProposalsController::STEP1
+            @proposal ||= Decidim::Proposals::Proposal.new(component: current_component)
+            @form = form_proposal_model
+            @form.body = translated_proposal_body_template
+            @form.attachment = form_attachment_new
+          end
+        end
+
+        def create
+          enforce_permission_to :create, :proposal
+          @step = Decidim::Proposals::ProposalsController::STEP1
+          @form = form(Decidim::Proposals::ProposalForm).from_params(proposal_creation_params)
+
+          @proposal = Decidim::Proposals::Proposal.new(@form.attributes.except(
+            :user_group_id,
+            :category_id,
+            :scope_id,
+            :has_address,
+            :attachment,
+            :body_template,
+            :suggested_hashtags,
+            :photos,
+            :add_photos,
+            :documents,
+            :add_documents,
+            :require_category,
+            :require_scope
+          ).merge(
+            component: current_component
+          ))
+          user_group = Decidim::UserGroup.find_by(
+            organization: current_organization,
+            id: params[:proposal][:user_group_id]
+          )
+          @proposal.add_coauthor(current_user, user_group: user_group)
+
+          # We could set these when creating proposal, but We want to call update because after that proposal becomes persisted
+          # and it adds coauthor correctly.
+          @proposal.update(title: { I18n.locale => @form.attributes[:title] })
+          @proposal.update(body: { I18n.locale => @form.attributes[:body] })
+
+          Decidim::Proposals::UpdateProposal.call(@form, current_user, @proposal) do
+            on(:ok) do |proposal|
+              flash[:notice] = I18n.t("proposals.update_draft.success", scope: "decidim")
+              redirect_to "#{Decidim::ResourceLocatorPresenter.new(proposal).path}/preview"
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals.update_draft.error", scope: "decidim")
+              render :new
+            end
+          end
+        end
+
+        # Overridden because of a core bug when the command posts the "invalid"
+        # signal and when rendering the form.
+        def update_draft
+          enforce_permission_to :edit, :proposal, proposal: @proposal
+          @step = Decidim::Proposals::ProposalsController::STEP1
+
+          @form = form_proposal_params
+          Decidim::Proposals::UpdateProposal.call(@form, current_user, @proposal) do
+            on(:ok) do |proposal|
+              flash[:notice] = I18n.t("proposals.update_draft.success", scope: "decidim")
+              redirect_to "#{Decidim::ResourceLocatorPresenter.new(proposal).path}/preview"
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals.update_draft.error", scope: "decidim")
+              fix_form_photos_and_documents
+              render :edit_draft
+            end
+          end
+        end
+
+        # On invalid render edit instead of edit_draft
+        def update
+          enforce_permission_to :edit, :proposal, proposal: @proposal
+
+          @form = form_proposal_params
+
+          Decidim::Proposals::UpdateProposal.call(@form, current_user, @proposal) do
+            on(:ok) do |proposal|
+              flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+              redirect_to Decidim::ResourceLocatorPresenter.new(proposal).path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
+              fix_form_photos_and_documents
+              render :edit
+            end
+          end
+        end
+
+        private
+
+        def form_proposal_params
+          form(Decidim::Proposals::ProposalForm).from_params(params)
+        end
+
+        def default_filter_params
+          {
+            search_text_cont: "",
+            with_any_origin: default_filter_origin_params,
+            activity: "all",
+            with_any_category: default_filter_category_params,
+            with_any_state: %w(accepted evaluating state_not_published not_answered rejected),
+            with_any_scope: default_filter_scope_params,
+            related_to: "",
+            type: "all"
+          }
+        end
+
+        def can_show_proposal?
+          return false if @proposal&.deleted_at.present?
+          return true if @proposal&.amendable? || current_user&.admin?
+
+          Decidim::Proposals::Proposal.only_visible_emendations_for(current_user, current_component).published.include?(@proposal)
+        end
+
+        def fix_form_photos_and_documents
+          return unless @form
+
+          @form.photos = map_attachment_objects(@form.photos)
+          @form.documents = map_attachment_objects(@form.documents)
+        end
+
+        # Maps the attachment objects for the proposal form in case there are errors
+        # on the form when it is being saved. Without this, the form would throw
+        # an exception because it expects these objects to be Attachment records.
+        def map_attachment_objects(attachments)
+          return attachments unless attachments.is_a?(Array)
+
+          attachments.map do |attachment|
+            if attachment.is_a?(String) || attachment.is_a?(Integer)
+              Decidim::Attachment.find_by(id: attachment)
+            else
+              attachment
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,12 @@ en:
         collaborative_drafts_list: Collaborative drafts list
         new_proposal: New proposal
         view_proposal: View proposal
+      update:
+        error: There was a problem saving the idea.
+        success: Idea successfully updated.
+      update_draft:
+        error: There was a problem saving the idea.
+        success: Idea draft successfully updated.
     scopes:
       global: Global
       picker:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,6 +145,12 @@ fr:
         collaborative_drafts_list: Accéder aux brouillons collaboratifs
         new_proposal: Nouvelle proposition
         view_proposal: Voir la proposition
+      update:
+        error: Il y a eu une erreur lors de la mise à jour de la proposition.
+        success: Proposition mise à jour avec succès.
+      update_draft:
+        error: Il y a eu une erreur lors de la sauvegarde de la proposition.
+        success: Brouillon de proposition mis à jour avec succès.
     scopes:
       global: Portée générale
       picker:

--- a/db/migrate/20240904084430_add_deleted_at_to_proposals.decidim_simple_proposal.rb
+++ b/db/migrate/20240904084430_add_deleted_at_to_proposals.decidim_simple_proposal.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_simple_proposal (originally 20220318112320)
+
+class AddDeletedAtToProposals < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_proposals_proposals, :deleted_at, :datetime
+    add_index :decidim_proposals_proposals, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_12_083118) do
+ActiveRecord::Schema.define(version: 2024_09_04_084430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1627,11 +1627,13 @@ ActiveRecord::Schema.define(version: 2024_08_12_083118) do
     t.integer "comments_count", default: 0, null: false
     t.integer "follows_count", default: 0, null: false
     t.integer "decidim_proposals_proposal_state_id", null: false
+    t.datetime "deleted_at"
     t.index "md5((body)::text)", name: "decidim_proposals_proposal_body_search"
     t.index "md5((title)::text)", name: "decidim_proposals_proposal_title_search"
     t.index ["created_at"], name: "index_decidim_proposals_proposals_on_created_at"
     t.index ["decidim_component_id"], name: "index_decidim_proposals_proposals_on_decidim_component_id"
     t.index ["decidim_scope_id"], name: "index_decidim_proposals_proposals_on_decidim_scope_id"
+    t.index ["deleted_at"], name: "index_decidim_proposals_proposals_on_deleted_at"
     t.index ["proposal_votes_count"], name: "index_decidim_proposals_proposals_on_proposal_votes_count"
     t.index ["state"], name: "index_decidim_proposals_proposals_on_state"
   end

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -270,7 +270,7 @@ module Decidim
           it "withdraws the proposal" do
             put :withdraw, params: params.merge(id: proposal.id)
 
-            expect(flash[:notice]).to eq("Proposal successfully updated.")
+            expect(flash[:notice]).to include("successfully updated.")
             expect(response).to have_http_status(:found)
             proposal.reload
             expect(proposal.withdrawn?).to be true
@@ -282,7 +282,7 @@ module Decidim
             it "is not able to withdraw the proposal" do
               put :withdraw, params: params.merge(id: proposal.id)
 
-              expect(flash[:alert]).to eq("This proposal can not be withdrawn because it already has supports.")
+              expect(flash[:alert]).to include("it already has supports.")
               expect(response).to have_http_status(:found)
               proposal.reload
               expect(proposal.withdrawn?).to be false

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -99,7 +99,7 @@ describe "Proposals", type: :system do
       end
 
       it "shows the author as official" do
-        expect(page).to have_content("Official proposal")
+        expect(page).to have_content("Official idea")
       end
 
       it_behaves_like "rendering safe content", ".columns.mediumlarge-8.large-9"
@@ -257,7 +257,7 @@ describe "Proposals", type: :system do
         expect(page).to have_content("Evaluating")
 
         within ".callout.warning" do
-          expect(page).to have_content("This proposal is being evaluated")
+          expect(page).to have_content("This idea is being evaluated")
           expect(page).to have_i18n_content(proposal.answer)
         end
       end
@@ -268,16 +268,16 @@ describe "Proposals", type: :system do
 
       it "shows the rejection reason" do
         visit_component
-        uncheck "Accepted"
+        uncheck "Proceeds to voting"
         uncheck "Evaluating"
         uncheck "Not answered"
         page.find_link(proposal_title, wait: 30)
         click_link proposal_title
 
-        expect(page).to have_content("Rejected")
+        expect(page).to have_content("Does not proceed to voting")
 
         within ".callout.alert" do
-          expect(page).to have_content("This proposal has been rejected")
+          expect(page).to have_content("This idea does not proceed to voting")
           expect(page).to have_i18n_content(proposal.answer)
         end
       end
@@ -290,10 +290,10 @@ describe "Proposals", type: :system do
         visit_component
         click_link proposal_title
 
-        expect(page).to have_content("Accepted")
+        expect(page).to have_content("Proceeds to voting")
 
         within ".callout.success" do
-          expect(page).to have_content("This proposal has been accepted")
+          expect(page).to have_content("This idea proceeds to voting")
           expect(page).to have_i18n_content(proposal.answer)
         end
       end
@@ -306,8 +306,8 @@ describe "Proposals", type: :system do
         visit_component
         click_link proposal_title
 
-        expect(page).not_to have_content("Accepted")
-        expect(page).not_to have_content("This proposal has been accepted")
+        expect(page).not_to have_content("Proceeds to voting")
+        expect(page).not_to have_content("This idea proceeds to voting")
         expect(page).not_to have_i18n_content(proposal.answer)
       end
     end
@@ -464,7 +464,7 @@ describe "Proposals", type: :system do
 
         expect(page).to have_no_button("Supports disabled", disabled: true)
         expect(page).to have_no_button("Vote")
-        expect(page).to have_link("View proposal", count: 2)
+        expect(page).to have_link("View idea", count: 2)
       end
     end
 


### PR DESCRIPTION
#### :tophat: Description

This PR has been made to add the module simple_proposal to the DCD-App on the release 2.4

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Release Decidim-app 2.4 - Ajout module simple proposal](https://www.notion.so/opensourcepolitics/Release-Decidim-app-2-4-Ajout-module-simple-proposal-9b90cee7ccc142f195efae457a468d14?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

### *🚨  Please make sure you compiled Deface before launching your app using `bundle exec rake deface:precompile` !*

* Log in as an admin
* Access to backoffice to a process
* Access to the proposal component and update it selecting a scope and make sure category selection and scope selection are mandatory for creating proposals
* Apply changes
* Access to front office to the proposal component
* Create a new proposal
* Make sure you see two new mandatory selectors and make sure that you can still create proposal

#### Tasks
- [x] Add gem
- [x] Override the proposal controller changes to fix an issue making tests fail (method changed is can_show_proposal?)
- [x] Update some tests related to proposals

