### PR TITLE
fix: Wrong translation key displayed on projects counts

### DIFF
--- a/app/views/decidim/budgets/projects/_count.html.erb
+++ b/app/views/decidim/budgets/projects/_count.html.erb
@@ -1,3 +1,3 @@
 <span id="projects-count">
-  <b><%= t(".projects_count", count: projects.total_count) %></b>
+  <b><%= t(".projects_count.#{projects.total_count == 1 ? 'one' : 'other'}", count: projects.total_count) %></b>
 </span>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -142,6 +142,7 @@ ignore_unused:
   - decidim.proposals.collaborative_drafts.new.*
   - decidim.admin.menu.admin_accountability
   - decidim.anonymous_user
+  - decidim.budgets.projects.count.projects_count.*
   - decidim.events.initiatives.initiative_answered.*
   - decidim.initiatives.pages.home.highlighted_initiatives.*
   - activemodel.attributes.attachment.documents


### PR DESCRIPTION

#### :tophat: Description
*Please describe your pull request.*

#### :pushpin: Related Issues
- [Marseille - Affichage projets](https://www.notion.so/opensourcepolitics/Marseille-Affichage-projets-1ed968ac3dab4027a73735aec0378073?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Access your platform
* Change locale to french
* Access a process
* Go to a budget (find another one if it is locked using zipcode method
* Try to filter projects (with some results or not)
* Make sure that it shows the right translation everytime


#### Tasks
- [ ] Modify the count html to ensure to have the right translation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
