### PR TITLE
fix: Change order_reminder translation to match Marseille's request

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,7 +47,7 @@ fr:
         name: Procédure d'autorisation
     budgets:
       order_reminder:
-        text_message: Votre vote au budget participatif n'est pas terminé. Pour le terminer, reconnectez-vous sur %{organization_host}
+        text_message: Votre vote au Budget participatif marseillais n'est pas terminé. Pour le valider, reconnectez-vous sur %{organization_host}
       projects:
         count:
           projects_count:


### PR DESCRIPTION
#### :tophat: Description
Change the order_reminder translation in the fr.yml
