### PR TITLE
hotfix: Fix proposal index filters that were not working (#595)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source "https://rubygems.org"
 
 DECIDIM_VERSION = "0.27"
 DECIDIM_BRANCH = "release/#{DECIDIM_VERSION}-stable".freeze
-DECIDIM_ANONYMOUS_PROPOSALS_VERSION = { git: "https://github.com/PopulateTools/decidim-module-anonymous_proposals", branch: "anonymous_proposals_for_registered_users" }.freeze
+DECIDIM_ANONYMOUS_PROPOSALS_VERSION = { git: "https://github.com/OpenSourcePolitics/decidim-module-anonymous_proposals",
+                                        branch: "feat/disable_override_from_index_proposals" }.freeze
 
 ruby RUBY_VERSION
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-anonymous_proposals
+  revision: ea7c828c82fabb1c35e161095082f15ba63b6eaf
+  branch: feat/disable_override_from_index_proposals
+  specs:
+    decidim-anonymous_proposals (0.27.0)
+      decidim-core (>= 0.27.0)
+      deface (~> 1.5)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git
   revision: adec5e66cd07b5e5fdce5562453a7e8d6de88013
   branch: release/0.27-stable
@@ -111,15 +120,6 @@ GIT
     omniauth-publik (0.1.1)
       omniauth (~> 2.0)
       omniauth-oauth2 (>= 1.7.2, < 2.0)
-
-GIT
-  remote: https://github.com/PopulateTools/decidim-module-anonymous_proposals
-  revision: b44a938500716dbfd99e8615769045701137c82e
-  branch: anonymous_proposals_for_registered_users
-  specs:
-    decidim-anonymous_proposals (0.27.0)
-      decidim-core (>= 0.27.0)
-      deface (~> 1.5)
 
 GIT
   remote: https://github.com/alecslupu-pfa/decidim-budget_category_voting.git

--- a/app/views/decidim/proposals/proposals/index.html.erb
+++ b/app/views/decidim/proposals/proposals/index.html.erb
@@ -28,13 +28,17 @@
   <% end %>
 <% end %>
 <%= render partial: "voting_rules" %>
+
+<%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_announcement" %>
 <div class="row columns">
   <div class="title-action">
     <h2 id="proposals-count" class="title-action__title section-heading">
       <%= render partial: "count" %>
     </h2>
     <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
-      <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
+
+      <%= link_to new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
+
         <%= t(".new_proposal") %>
         <%= icon "plus", role: "img", "aria-hidden": true %>
       <% end %>

--- a/app/views/decidim/proposals/proposals/index.js.erb
+++ b/app/views/decidim/proposals/proposals/index.js.erb
@@ -1,0 +1,10 @@
+var $proposals = $('#proposals');
+var $proposalsCount = $('#proposals-count');
+var $orderFilterInput = $('.order_filter');
+
+$proposals.html('<%= j(render partial: "proposals").strip.html_safe %>');
+$proposalsCount.html('<%= j(render partial: "count").strip.html_safe %>');
+$orderFilterInput.val('<%= order %>');
+
+var $dropdownMenu = $('.dropdown.menu', $proposals);
+$dropdownMenu.foundation();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,10 +139,11 @@ en:
         new:
           add_file: Add file
           edit_file: Edit file
-      index:
-        collaborative_drafts_list: Collaborative drafts list
-        new_proposal: New proposal
-        view_proposal: View proposal
+      proposals:
+        index:
+          collaborative_drafts_list: Collaborative drafts list
+          new_proposal: New proposal
+          view_proposal: View proposal
       update:
         error: There was a problem saving the idea.
         success: Idea successfully updated.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,10 +141,11 @@ fr:
         new:
           add_file: Ajouter le fichier
           edit_file: Editer le fichier
-      index:
-        collaborative_drafts_list: Accéder aux brouillons collaboratifs
-        new_proposal: Nouvelle proposition
-        view_proposal: Voir la proposition
+      proposals:
+        index:
+          collaborative_drafts_list: Accéder aux brouillons collaboratifs
+          new_proposal: Nouvelle proposition
+          view_proposal: Voir la proposition
       update:
         error: Il y a eu une erreur lors de la mise à jour de la proposition.
         success: Proposition mise à jour avec succès.


### PR DESCRIPTION
* fix: Disable deface override from proposals' index to reenable filters

* fix: Move the file to the right place

* fix: Add missing js file and fix tests

* fix: Add missing feature about caching geocoded proposals

* fix: Update to fix the encoding of the link for geocoded proposals

