### PR TITLE
Fix xss vulnerability on initiatives

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,8 @@ module DevelopmentApp
       require "extends/controllers/decidim/newsletters_controller_extends"
       require "extends/commands/decidim/admin/destroy_participatory_space_private_user_extends"
       require "extends/controllers/decidim/proposals/proposals_controller_extends"
+      require "extends/forms/decidim/initiatives/initiative_form_extends"
+      require "extends/models/decidim/initiative_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,8 @@ en:
       links:
         forgot_your_password: Forgot your password
         sign_in_with_france_connect: Sign in with france connect
+  errors:
+    no_img_tag_in_description: Images are not allowed
   faker:
     address:
       country_code:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -220,6 +220,8 @@ fr:
       links:
         forgot_your_password: Mot de passe oublié ?
         sign_in_with_france_connect: FranceConnect
+  errors:
+    no_img_tag_in_description: Les images ne sont pas autorisées
   faker:
     address:
       country_code:

--- a/lib/extends/forms/decidim/initiatives/initiative_form_extends.rb
+++ b/lib/extends/forms/decidim/initiatives/initiative_form_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module NoAdminInitiativeFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+    validate :no_img_tag_in_description
+
+    private
+
+    def no_img_tag_in_description
+      errors.add :description, I18n.t("errors.no_img_tag_in_description") if description =~ /(&lt;img|<img)/
+    end
+  end
+end
+
+Decidim::Initiatives::InitiativeForm.include(NoAdminInitiativeFormExtends)

--- a/lib/extends/models/decidim/initiative_extends.rb
+++ b/lib/extends/models/decidim/initiative_extends.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module InitiativeExtends
+  extend ActiveSupport::Concern
+
+  included do
+    validate :no_img_tag_in_description
+
+    private
+
+    def no_img_tag_in_description
+      errors.add :description, I18n.t("errors.no_img_tag_in_description") if description.values.any? { |elem| elem =~ /(&lt;img|<img)/ }
+    end
+  end
+end
+
+Decidim::Initiative.include(InitiativeExtends)

--- a/spec/forms/initiative_form_spec.rb
+++ b/spec/forms/initiative_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    describe InitiativeForm do
+      subject { described_class.from_params(attributes).with_context(context) }
+
+      let(:organization) { create(:organization) }
+      let(:initiatives_type) { create(:initiatives_type, organization: organization) }
+      let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
+      let(:attachment_params) { nil }
+
+      let(:title) { ::Faker::Lorem.sentence(word_count: 5) }
+      let(:my_description) { "" }
+      let(:attributes) do
+        {
+          title: title,
+          description: my_description,
+          type_id: initiatives_type.id,
+          scope_id: scope&.scope&.id,
+          signature_type: "offline",
+          attachment: attachment_params
+        }.merge(custom_signature_end_date).merge(area)
+      end
+      let(:custom_signature_end_date) { {} }
+      let(:area) { {} }
+      let(:context) do
+        {
+          current_organization: organization,
+          current_component: nil,
+          initiative_type: initiatives_type
+        }
+      end
+      let(:state) { "validating" }
+      let(:initiative) { create(:initiative, organization: organization, state: state, scoped_type: scope) }
+
+      context "when everything is OK" do
+        let(:my_description) { ::Faker::Lorem.sentence(word_count: 25) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when description contains an img tag" do
+        let(:my_description) { '<p>description&lt;img src=\"invalid.jpg\" onerror=\"alert();\"&gt;</p>' }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/spec/models/decidim/initiative_spec.rb
+++ b/spec/models/decidim/initiative_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Initiative do
+    subject { initiative }
+
+    let(:organization) { create(:organization) }
+
+    context "when validating an initiative" do
+      context "and description contains an img tag" do
+        let(:validating_initiative) do
+          build(:initiative,
+                description: { en: 'description<img src="invalid.jpg" onerror="alert();">' },
+                state: "validating")
+        end
+
+        it "is not valid" do
+          expect(validating_initiative).not_to be_valid
+        end
+      end
+
+      context "and description is valid" do
+        let(:validating_initiative) do
+          build(:initiative,
+                description: { en: "description" },
+                state: "validating")
+        end
+
+        it "is valid" do
+          expect(validating_initiative).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
There is an XSS vulnerability on the initiative form where a user can execute arbitrary Javascript code through the img html tag.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Odoo card](https://opensourcepolitics.odoo.com/web#id=2580&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Testing
1. As a user, go to initiatives and click on "new initiative" 
2. In the description field, add `<img src="invalid.jpg" onerror="alert('Image failed to load!');">`, and then click on continue.
3. Add a scope in the next step and click on continue
4. See you have an error message "Images are not allowed"
5. if you remove the img tag, see that you can access next step.


To check the model validation, you can go to config/application.rb and comment the line `require "extends/forms/decidim/initiatives/initiative_form_extends"`
Then proceed to the same steps than above, and see in the logs that you have a message "Failed creating initiative: Description ..."

#### Tasks
- [ x] Add specs
- [ ] Add note about overrides in OVERLOADS.md


### :camera: Screenshots

<img width="990" alt="Capture d’écran 2024-09-30 à 11 52 06" src="https://github.com/user-attachments/assets/9df89e32-3470-43dd-9d96-48e9c676ccbe">
