### PR TITLE
feat(bordeaux): Create rake task to import bilans and decisions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "decidim-extended_socio_demographic_authorization_handler", git: "https://gi
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "temp/twilio-compatibility-0.27"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 gem "decidim-gallery", git: "https://github.com/OpenSourcePolitics/decidim-module-gallery.git", branch: "fix/nokogiri_deps"
-gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "fix/sign-in-link-if-disabled"
+gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "feature/half_signup_and_budgets_booth"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "fix/geojson-parsing"
 gem "decidim-ludens", git: "https://github.com/OpenSourcePolitics/decidim-ludens.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
@@ -64,7 +64,6 @@ gem "sys-filesystem"
 gem "wicked_pdf", "2.6.3"
 
 gem "composite_primary_keys"
-gem "mysql2"
 
 group :development do
   gem "listen", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: 26c437571e847259d80741c52d16349a50436cfc
-  branch: fix/sign-in-link-if-disabled
+  revision: 5bee2b5422e4131f933ad854ab872e049dcf7b54
+  branch: feature/half_signup_and_budgets_booth
   specs:
     decidim-half_signup (0.27.0)
       countries (~> 5.1, >= 5.1.2)
@@ -759,7 +759,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.4.1)
     mustache (1.1.1)
-    mysql2 (0.5.6)
     net-http (0.4.1)
       uri
     net-imap (0.4.11)
@@ -1187,7 +1186,6 @@ DEPENDENCIES
   listen (~> 3.1)
   lograge
   multipart-post
-  mysql2
   net-smtp (~> 0.4.0)
   nokogiri (= 1.13.4)
   omniauth-france_connect!

--- a/app/jobs/drupal_decisions_job.rb
+++ b/app/jobs/drupal_decisions_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DrupalDecisionsJob < ApplicationJob
+  queue_as :exports
+
+  def perform(*args)
+    Decidim::DrupalDecisionsImporterService.run(*args)
+  end
+end

--- a/app/models/drupal/abstract_record.rb
+++ b/app/models/drupal/abstract_record.rb
@@ -3,7 +3,6 @@
 module Drupal
   class AbstractRecord < ApplicationRecord
     self.abstract_class = true
-    establish_connection :drupal
 
     def self.instance_method_already_implemented?(method_name)
       return true if %w(changed changed?).include? method_name

--- a/app/services/decidim/drupal_decisions_importer_service.rb
+++ b/app/services/decidim/drupal_decisions_importer_service.rb
@@ -36,11 +36,13 @@ module Decidim
         if drupal_page.blank?
           warn_message "URL #{row['url']} not found..."
           @errors << "URL not found: #{row["url"]}"
+          next
         end
 
         pp = Decidim::ParticipatoryProcess.find_by(slug: "projet-#{drupal_page.drupal_node_id}")
         if pp.blank?
           @errors << "ParticipatoryProcess not found: #{row["url"]}"
+          next
         end
 
         if (error = edit_decision_page!(drupal_page, pp)).present?

--- a/app/services/decidim/drupal_decisions_importer_service.rb
+++ b/app/services/decidim/drupal_decisions_importer_service.rb
@@ -12,10 +12,11 @@ module Decidim
     end
 
     def initialize(**args)
-      warn_message "initializing..."
       @path = args[:path]
       @organization = args[:organization]
       @errors = []
+      @logger = Logger.new("log/import-decisions-#{Time.zone.now.strftime "%Y-%m-%d-%H-%M-%S"}.log")
+      warn_message "initializing..."
     end
 
     def execute
@@ -73,7 +74,7 @@ module Decidim
     end
 
     def warn_message(msg)
-      Rails.logger.warn "Rake(#{RAKE_NAME})> #{msg}"
+      @logger.warn "Rake(#{RAKE_NAME})> #{msg}"
     end
   end
 end

--- a/app/services/decidim/drupal_decisions_importer_service.rb
+++ b/app/services/decidim/drupal_decisions_importer_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/PerceivedComplexity
+# rubocop:disable Security/Open
+module Decidim
+  class DrupalDecisionsImporterService
+    RAKE_NAME = "import:bdx:decisions"
+
+    def self.run(**args)
+      new(**args).execute
+    end
+
+    def initialize(**args)
+      Rails.logger.warn "Rake(#{RAKE_NAME})> initializing..."
+      @path = args[:path]
+      @organization = args[:organization]
+      @errors = []
+    end
+
+    def execute
+      Rails.logger.warn "Rake(#{RAKE_NAME})> executing..."
+      rows = CSV.read(@path, headers: true)
+
+      if rows.blank?
+        Rails.logger.warn "Rake(#{RAKE_NAME})> No rows found"
+        return
+      end
+
+      rows.each do |row|
+        drupal_page = Decidim::DrupalPage.scrape(url: row["url"])
+        if drupal_page.blank?
+          @errors << "URL not found: #{row["url"]}"
+        end
+        pp = Decidim::ParticipatoryProcess.find_by(slug: "projet-#{drupal_page.drupal_node_id}")
+        if pp.blank?
+          @errors << "ParticipatoryProcess not found: #{drupal_page.drupal_node_id}"
+        end
+
+        if (error = edit_decision_page!(drupal_page, pp)).present?
+          @errors << error
+        end
+
+        sleep 0.75
+      end
+
+      Rails.logger.warn "Rake(#{RAKE_NAME})> #{@errors.count} errors: #{@errors.join(" | ")}"
+      Rails.logger.warn "Rake(#{RAKE_NAME})> terminated"
+    end
+
+    private
+
+    def edit_decision_page!(drupal_page, pp)
+      component = Decidim::Component.find_by(name: "BILANS & DÉCISIONS", manifest_name: "pages", participatory_space: pp)
+      if component.blank?
+        Rails.logger.warn "Rake(#{RAKE_NAME})> :not_found: component for '#{drupal_page.url}' not found"
+        return ":not_found: component for '#{drupal_page.url}' not found"
+      end
+
+      page = Decidim::Pages::Page.find_by(component: component)
+      if page.blank?
+        Rails.logger.warn "Rake(#{RAKE_NAME})> :not_found: page for '#{drupal_page.url}' not found"
+        return "not_found: page for '#{drupal_page.url}' not found"
+      end
+      page.body = { "fr" => drupal_page.get_bilan.presence || "." }
+      page.save!
+      return
+    end
+  end
+end
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Security/Open

--- a/app/services/decidim/drupal_importer_service.rb
+++ b/app/services/decidim/drupal_importer_service.rb
@@ -25,9 +25,13 @@ module Decidim
         return
       end
 
+      Rails.logger.warn "Rake(import:pps)> processing #{rows.size} rows..."
       rows.each do |row|
         drupal_page = Decidim::DrupalPage.scrape(url: row["url"])
-        raise if drupal_page.errors.present?
+        Rails.logger.warn "Rake(import:pps)> Retrieving #{row["url"]}..."
+        if drupal_page.errors.present?
+          Rails.logger.warn "Rake(import:pps)> Error: #{drupal_page.errors} for '#{rows["url"]}'"
+        end
 
         pp = Decidim::ParticipatoryProcess.find_by(slug: "projet-#{drupal_page.drupal_node_id}")
         if pp.blank?
@@ -111,7 +115,7 @@ module Decidim
             human_filesize: human_filesize,
             limit: limit
           )
-          sleep 2
+          sleep 0.75
         end
 
         drupal_page.set_decidim_participatory_process_id(pp.id)

--- a/app/services/decidim/drupal_importer_service.rb
+++ b/app/services/decidim/drupal_importer_service.rb
@@ -31,6 +31,7 @@ module Decidim
         Rails.logger.warn "Rake(import:pps)> Retrieving #{row["url"]}..."
         if drupal_page.errors.present?
           Rails.logger.warn "Rake(import:pps)> Error: #{drupal_page.errors} for '#{rows["url"]}'"
+          next
         end
 
         pp = Decidim::ParticipatoryProcess.find_by(slug: "projet-#{drupal_page.drupal_node_id}")

--- a/app/services/decidim/drupal_page.rb
+++ b/app/services/decidim/drupal_page.rb
@@ -139,8 +139,12 @@ module Decidim
       @bilan = @nokogiri_document.css("div.bilan-wrapper .left").children.to_s.strip
     end
 
+    # set_decision defines @decision but without the documents links
     def set_decision
-      @decision = @nokogiri_document.css("div.prop-decision .left").children.reject { |dec| dec.classes.include?("documents") }.to_s_strip
+      children = @nokogiri_document.css("div.prop-decision .left").children.children
+      children_without_documents = children.reject { |el| el.classes.include?("documents") }
+      node = Nokogiri::XML::NodeSet.new(@nokogiri_document, children_without_documents)
+      @decision = node.to_s.strip
     end
 
     def set_calendars

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,16 +29,6 @@ default: &default
     password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
     database: <%= ENV.fetch("DATABASE_NAME") { "osp_app" } %>
     prepared_statements: <%= ENV.fetch("DATABASE_PREPARED_STATEMENTS") { true } %>
-  drupal:
-    adapter: mysql2
-    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-    encoding: utf8
-    host: <%= ENV.fetch("DRUPAL_DATABASE_HOST") { "" } %>
-    port: <%= ENV.fetch("DRUPAL_DATABASE_PORT") { "3306" } %>
-    username: <%= ENV.fetch("DRUPAL_DATABASE_USERNAME") { "" } %>
-    password: <%= ENV.fetch("DRUPAL_DATABASE_PASSWORD") { "" } %>
-    database: <%= ENV.fetch("DRUPAL_DATABASE_NAME") { "" } %>
-    database_tasks: false
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,18 +17,17 @@
 # On Linux, the 'host: "localhost"' line below should be commented out to avoid 'password required' error.
 #
 default: &default
-  primary:
-    adapter: postgresql
-    encoding: unicode
-    # For details on connection pooling, see rails configuration guide
-    # http://guides.rubyonrails.org/configuring.html#database-pooling
-    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-    host: <%= ENV.fetch("DATABASE_HOST") { "" } %>
-    port: <%= ENV.fetch("DATABASE_PORT") { "5432" } %>
-    username: <%= ENV.fetch("DATABASE_USERNAME") { "" } %>
-    password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
-    database: <%= ENV.fetch("DATABASE_NAME") { "osp_app" } %>
-    prepared_statements: <%= ENV.fetch("DATABASE_PREPARED_STATEMENTS") { true } %>
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { "" } %>
+  port: <%= ENV.fetch("DATABASE_PORT") { "5432" } %>
+  username: <%= ENV.fetch("DATABASE_USERNAME") { "" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
+  database: <%= ENV.fetch("DATABASE_NAME") { "osp_app" } %>
+  prepared_statements: <%= ENV.fetch("DATABASE_PREPARED_STATEMENTS") { true } %>
 
 development:
   <<: *default

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -230,7 +230,7 @@ namespace :import do
     raise "Organization not found for '#{host}'" unless organization
 
     path = ENV["CSV_FILE"].presence || "tmp/links.csv"
-    DrupalJob.perform_now(organization: organization, path: path)
+    DrupalJob.perform_later(organization: organization, path: path)
   end
 
   namespace :bdx do

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -230,7 +230,7 @@ namespace :import do
     raise "Organization not found for '#{host}'" unless organization
 
     path = ENV["CSV_FILE"].presence || "tmp/links.csv"
-    DrupalJob.perform_later(organization: organization, path: path)
+    DrupalJob.perform_now(organization: organization, path: path)
   end
 
   namespace :bdx do
@@ -267,6 +267,15 @@ namespace :import do
 
       path = ENV["CSV_FILE"].presence || "tmp/drupal_import/resume.csv"
       DrupalPpsCheckJob.perform_later(organization: organization, path: path)
+    end
+
+    task decisions: :environment do
+      host = ENV["ORGANIZATION_HOST"].presence || Decidim::Organization.first.host
+      organization = Decidim::Organization.find_by(host: host)
+      raise "Organization not found for '#{host}'" unless organization
+
+      path = ENV["CSV_FILE"].presence || "tmp/links.csv"
+      DrupalDecisionsJob.perform_now(organization: organization, path: path)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Add bilans and decisions for each url.


#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Add file `tmp/links.csv` with a single column header `url`
* Create all processes : (You can seed with this command) `BASIC_AUTH_USER=... BASIC_AUTH_PASSWORD=... bundle exec rake import:pps`
* Edit all existing decisions pages : `BASIC_AUTH_USER=... BASIC_AUTH_PASSWORD=... bundle exec rake import:bdx:decisions` 
* Access Backoffice
* Go to processes
* See decisions components

#### Tasks
- [x] Remove `mysql` and `Drupal` deprecated adapter
- [x] Add decisions import rake task
- [x] Store logs in `log/import-decisions-*.log`
- [x] ⚙️ Add env var `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` for htaccess

