### PR TITLE
fix error message displaying when reaching proposition add limit

### DIFF
--- a/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
@@ -56,6 +56,12 @@ module Decidim
           enforce_permission_to :create, :proposal
           @step = Decidim::Proposals::ProposalsController::STEP1
           @form = form(Decidim::Proposals::ProposalForm).from_params(proposal_creation_params)
+          if proposal_limit_reached?
+            @form.errors.add(:base, I18n.t("decidim.proposals.new.limit_reached"))
+            flash.now[:alert] = I18n.t("proposals.create.error", scope: "decidim")
+            render :new
+            return
+          end
 
           @proposal = Decidim::Proposals::Proposal.new(@form.attributes.except(
             :user_group_id,
@@ -185,6 +191,17 @@ module Decidim
               attachment
             end
           end
+        end
+
+        def proposal_limit_reached?(form = form_proposal_params)
+          proposal_limit = form.current_component.settings.proposal_limit
+          return false if proposal_limit.zero?
+
+          current_user_proposals(form).count >= proposal_limit
+        end
+
+        def current_user_proposals(form)
+          Decidim::Proposals::Proposal.from_author(current_user).where(component: form.current_component).except_withdrawn
         end
       end
     end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,6 +119,8 @@ ignore_missing:
  - decidim.term_customizer.admin.actions.*
  - decidim.term_customizer.admin.add_translations.index.*
  - decidim.term_customizer.admin.models.translations.fields.*
+ - decidim.proposals.new.limit_reached
+ - decidim.proposals.create.error
 
 # Consider these keys used:
 ignore_unused:

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -164,6 +164,18 @@ module Decidim
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)
           end
+
+          context "and proposals limit is reached" do
+            before do
+              allow(controller).to receive(:proposal_limit_reached?).and_return(true)
+            end
+
+            it "does not create a proposal and raises an error" do
+              post :create, params: params
+              expect(response).to have_http_status(:ok)
+              expect(flash[:alert]).not_to be_empty
+            end
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: Description
When a user tried to add a new proposal, the appropriate error message* was not displayed when the proposals limit was reached.

#### :pushpin: Related Issues
- Fixes #?
- [Odoo card](https://opensourcepolitics.odoo.com/mail/view?model=project.task&res_id=3095&access_token=1837be14-8706-47c9-987c-f6fea516c7b7)

#### Testing

- As admin go to a participatory process
- Go to the settings proposals component 
- Add a poposal limit 
<img width="1171" alt="Capture d’écran 2024-10-09 à 10 23 41" src="https://github.com/user-attachments/assets/dd6c467c-fb82-43d9-9bea-e3b10ae974c2">
-

- On the frontend, create a new proposal in the correct process
- You should see an error alert "You can't create new proposals since you've exceeded the limit." *
-
<img width="903" alt="Capture d’écran 2024-10-11 à 16 06 32" src="https://github.com/user-attachments/assets/c10984bf-a147-4e1e-8aa6-a058ea0699b2">


#### Tasks
- [x] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
