### PR TITLE
Fix/questions order in survey export

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2024_10_10_092645) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2024_10_10_092645) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"

--- a/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
+++ b/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
@@ -6,6 +6,20 @@ module UserAnswersSerializerExtends
   included do
     private
 
+    def questions_hash
+      questionnaire_id = @answers.first&.decidim_questionnaire_id
+      return {} unless questionnaire_id
+
+      questions = Decidim::Forms::Question.where(decidim_questionnaire_id: questionnaire_id).order(:position)
+      return {} if questions.none?
+
+      questions.each.inject({}) do |serialized, question|
+        serialized.update(
+          translated_question_key(question.position, question.body) => ""
+        )
+      end
+    end
+
     def hash_for(answer)
       {
         answer_translated_attribute_name(:id) => answer&.session_token,

--- a/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -67,7 +67,6 @@ module Decidim
       end
 
       describe "#serialize" do
-
         let(:serialized) { subject.serialize }
 
         it "includes the answer for each question" do
@@ -87,7 +86,7 @@ module Decidim
           end
 
           serialized_files_answer = files_answer.attachments.map(&:url)
-          
+
           expect(serialized).to include(
             "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
@@ -103,7 +102,6 @@ module Decidim
           expect(serialized).to include(
             "#{files_question.position + 1}. #{translated(files_question.body, locale: I18n.locale)}" => serialized_files_answer
           )
-
         end
 
         context "and includes the attributes" do
@@ -213,10 +211,9 @@ module Decidim
       end
 
       describe "questions_hash" do
-
         it "generates a hash of questions ordered by position" do
           questions.shuffle!
-          expect(subject.instance_eval { questions_hash }.keys.map{|key| key[0].to_i}.uniq).to eq(questions.sort_by{|q| q.position}.map{|question| question.position + 1})
+          expect(subject.instance_eval { questions_hash }.keys.map { |key| key[0].to_i }.uniq).to eq(questions.sort_by(&:position).map { |question| question.position + 1 })
         end
       end
     end

--- a/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -67,6 +67,7 @@ module Decidim
       end
 
       describe "#serialize" do
+
         let(:serialized) { subject.serialize }
 
         it "includes the answer for each question" do
@@ -86,7 +87,7 @@ module Decidim
           end
 
           serialized_files_answer = files_answer.attachments.map(&:url)
-
+          
           expect(serialized).to include(
             "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
@@ -102,6 +103,7 @@ module Decidim
           expect(serialized).to include(
             "#{files_question.position + 1}. #{translated(files_question.body, locale: I18n.locale)}" => serialized_files_answer
           )
+
         end
 
         context "and includes the attributes" do
@@ -207,6 +209,14 @@ module Decidim
           def memory_usage
             `ps -o rss #{Process.pid}`.lines.last.to_i
           end
+        end
+      end
+
+      describe "questions_hash" do
+
+        it "generates a hash of questions ordered by position" do
+          questions.shuffle!
+          expect(subject.instance_eval { questions_hash }.keys.map{|key| key[0].to_i}.uniq).to eq(questions.sort_by{|q| q.position}.map{|question| question.position + 1})
         end
       end
     end


### PR DESCRIPTION
#### :tophat: Description
When we export the answers to a survey, the questions are now ordered by position to avoid wrong order.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Issue Decidim](https://github.com/decidim/decidim/issues/13201) 
- [Odoo card](https://opensourcepolitics.odoo.com/web#id=2411&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Testing

1. As an admin, go to a process, and add a new survey component (allow answers and multiple answers).
2. Go to the edit of the survey and add questions, separators, titles and description... and save at the end.
3. After save, modify the order of questions, add a new question..and save again.
4. Publish the survey
5. As a user, answer the survey.
6. As an admin, go back to the edit of the survey and export the answers.
7. See in the file that the columns are in good order.



#### Tasks
- [X] Add specs
