### PR TITLE
Fix/missing image in survey question

### DIFF
--- a/app/packs/src/decidim/decidim_awesome/editors/editor.js
+++ b/app/packs/src/decidim/decidim_awesome/editors/editor.js
@@ -1,0 +1,214 @@
+/* eslint-disable require-jsdoc, func-style */
+
+/*
+* Since version 0.25 we follow a different strategy and opt to destroy and override completely the original editor
+* That's because editors are instantiated directly instead of creating a global function to instantiate them
+*/
+
+import lineBreakButtonHandler from "src/decidim/editor/linebreak_module"
+import InscrybMDE from "inscrybmde"
+import Europa from "europa"
+import "inline-attachment/src/inline-attachment";
+import "inline-attachment/src/codemirror-4.inline-attachment";
+import "inline-attachment/src/jquery.inline-attachment";
+import hljs from "highlight.js";
+import "highlight.js/styles/github.css";
+import "src/decidim/editor/clipboard_override"
+import "src/decidim/vendor/image-resize.min"
+import "src/decidim/vendor/image-upload.min"
+import { marked } from "marked";
+
+const DecidimAwesome = window.DecidimAwesome || {};
+const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width", "style", "code", "blockquote", "indent"];
+
+// A tricky way to destroy the quill editor
+export function destroyQuillEditor(container) {
+    if (container) {
+        const content = $(container).find(".ql-editor").html();
+        $(container).html(content);
+        $(container).siblings(".ql-toolbar").remove();
+        $(container).find("*[class*='ql-']").removeClass((index, className) => (className.match(/(^|\s)ql-\S+/g) || []).join(" "));
+        $(container).removeClass((index, className) => (className.match(/(^|\s)ql-\S+/g) || []).join(" "));
+        if ($(container).next().is("p.help-text")) {
+            $(container).next().remove();
+        }
+    }
+    else {
+        console.error(`editor [${container}] not exists`);
+    }
+}
+
+export function createQuillEditor(container) {
+    const toolbar = $(container).data("toolbar");
+    const disabled = $(container).data("disabled");
+    const allowedEmptyContentSelector = "iframe,img";
+
+    let quillToolbar = [
+        ["bold", "italic", "underline", "linebreak"],
+        [{ list: "ordered" }, { list: "bullet" }],
+        ["link", "clean"],
+        ["code", "blockquote"],
+        [{ "indent": "-1"}, { "indent": "+1" }]
+    ];
+
+    let addImage = false;
+
+    if (toolbar === "full") {
+        quillToolbar = [
+            [{ header: [2, 3, 4, 5, 6, false] }],
+            ...quillToolbar
+        ];
+        if (DecidimAwesome.allow_images_in_full_editor) {
+            quillToolbar.push(["video", "image"]);
+            addImage = true;
+        } else {
+            quillToolbar.push(["video"]);
+        }
+    } else if (toolbar === "basic") {
+        if (DecidimAwesome.allow_images_in_small_editor) {
+            quillToolbar.push(["video", "image"]);
+            addImage = true;
+        } else {
+            quillToolbar.push(["video"]);
+        }
+    } else if (DecidimAwesome.allow_images_in_small_editor) {
+        quillToolbar.push(["image"]);
+        addImage = true;
+    }
+
+    let modules = {
+        linebreak: {},
+        toolbar: {
+            container: quillToolbar,
+            handlers: {
+                "linebreak": lineBreakButtonHandler
+            }
+        }
+    };
+
+    const $input = $(container).siblings('input[type="hidden"]');
+    container.innerHTML = $input.val() || "";
+    const token = $('meta[name="csrf-token"]').attr("content");
+    if (addImage) {
+        modules.imageResize = {
+            modules: ["Resize", "DisplaySize"]
+        }
+        modules.imageUpload = {
+            url: DecidimAwesome.editor_uploader_path,
+            method: "POST",
+            name: "image",
+            withCredentials: false,
+            headers: { "X-CSRF-Token": token },
+            callbackOK: (serverResponse, next) => {
+                $("div.ql-toolbar").last().removeClass("editor-loading")
+                next(serverResponse.url);
+            },
+            callbackKO: (serverError) => {
+                $("div.ql-toolbar").last().removeClass("editor-loading")
+                let msg = serverError && serverError.body;
+                try {
+                    msg = JSON.parse(msg).message;
+                } catch (evt) { console.error("Parsing error", evt); }
+                console.error(`Image upload error: ${msg}`);
+                let $p = $(`<p class="text-alert help-text">${msg}</p>`);
+                $(container).after($p)
+                setTimeout(() => {
+                    $p.fadeOut(1000, () => {
+                        $p.destroy();
+                    });
+                }, 3000);
+            },
+            checkBeforeSend: (file, next) => {
+                $("div.ql-toolbar").last().addClass("editor-loading")
+                next(file);
+            }
+        }
+    }
+    const quill = new Quill(container, {
+        modules: modules,
+        formats: quillFormats,
+        theme: "snow"
+    });
+
+    if (disabled) {
+        quill.disable();
+    }
+
+    quill.on("text-change", () => {
+        const text = quill.getText();
+
+        // Triggers CustomEvent with the cursor position
+        // It is required in input_mentions.js
+        let event = new CustomEvent("quill-position", {
+            detail: quill.getSelection()
+        });
+        container.dispatchEvent(event);
+
+        if ((text === "\n" || text === "\n\n") && quill.root.querySelectorAll(allowedEmptyContentSelector).length === 0
+            && !$input.val().match(/img/)) {
+            $input.val("");
+        } else {
+            const emptyParagraph = "<p><br></p>";
+            const cleanHTML = quill.root.innerHTML.replace(
+                new RegExp(`^${emptyParagraph}|${emptyParagraph}$`, "g"),
+                ""
+            );
+            $input.val(cleanHTML);
+        }
+    });
+    // After editor is ready, linebreak_module deletes two extraneous new lines
+    quill.emitter.emit("editor-ready");
+
+    if (addImage) {
+        const text = $(container).data("dragAndDropHelpText") || DecidimAwesome.texts.drag_and_drop_image;
+        $(container).after(`<p class="help-text" style="margin-top:-1.5rem;">${text}</p>`);
+    }
+
+    // After editor is ready, linebreak_module deletes two extraneous new lines
+    quill.emitter.emit("editor-ready");
+
+    return quill;
+}
+
+export function createMarkdownEditor(container) {
+    const text = DecidimAwesome.texts.drag_and_drop_image;
+    const token = $('meta[name="csrf-token"]').attr("content");
+    const $input = $(container).siblings('input[type="hidden"]');
+    const $faker = $('<textarea name="faker-inscrybmde"/>');
+    const $form = $(container).closest("form");
+    const europa = new Europa();
+    $faker.val(europa.convert($input.val()));
+    $faker.insertBefore($(container));
+    $(container).hide();
+    const inscrybmde = new InscrybMDE({
+        element: $faker[0],
+        spellChecker: false,
+        renderingConfig: {
+            codeSyntaxHighlighting: true,
+            hljs: hljs
+        }
+    });
+    $faker[0].InscrybMDE = inscrybmde;
+
+    // Allow image upload
+    if (DecidimAwesome.allow_images_in_markdown_editor) {
+        $(inscrybmde.gui.statusbar).prepend(`<span class="help-text" style="float:left;margin:0;text-align:left;">${text}</span>`);
+        window.inlineAttachment.editors.codemirror4.attach(inscrybmde.codemirror, {
+            uploadUrl: DecidimAwesome.editor_uploader_path,
+            uploadFieldName: "image",
+            jsonFieldName: "url",
+            extraHeaders: { "X-CSRF-Token": token }
+        });
+    }
+
+    // Allow linebreaks
+    marked.setOptions({
+        breaks: true
+    });
+
+    // convert to html on submit
+    $form.on("submit", () => {
+        // e.preventDefault();
+        $input.val(marked(inscrybmde.value()));
+    });
+}

--- a/app/packs/src/decidim/editor.js
+++ b/app/packs/src/decidim/editor.js
@@ -1,0 +1,152 @@
+/* eslint-disable require-jsdoc */
+
+import lineBreakButtonHandler from "src/decidim/editor/linebreak_module";
+import "src/decidim/editor/clipboard_override";
+import "src/decidim/vendor/image-resize.min";
+import "src/decidim/vendor/image-upload.min";
+
+const quillFormats = [
+    "bold",
+    "italic",
+    "link",
+    "underline",
+    "header",
+    "list",
+    "alt",
+    "break",
+    "width",
+    "style",
+    "code",
+    "blockquote",
+    "indent"
+];
+
+export default function createQuillEditor(container) {
+    const toolbar = $(container).data("toolbar");
+    const disabled = $(container).data("disabled");
+
+    const allowedEmptyContentSelector = "iframe";
+    let quillToolbar = [
+        ["bold", "italic", "underline", "linebreak"],
+        [{ list: "ordered" }, { list: "bullet" }],
+        ["link", "clean"],
+        ["code", "blockquote"],
+        [{ indent: "-1" }, { indent: "+1" }]
+    ];
+
+    let addImage = false;
+    let addVideo = false;
+
+    /**
+     * - basic = only basic controls without titles
+     * - content = basic + headings
+     * - full = basic + headings + image + video
+     */
+    if (toolbar === "content") {
+        quillToolbar = [[{ header: [2, 3, 4, 5, 6, false] }], ...quillToolbar];
+    } else if (toolbar === "full") {
+        addImage = true;
+        addVideo = true;
+        quillToolbar = [
+            [{ header: [2, 3, 4, 5, 6, false] }],
+            ...quillToolbar,
+            ["video"],
+            ["image"]
+        ];
+    }
+
+    let modules = {
+        linebreak: {},
+        toolbar: {
+            container: quillToolbar,
+            handlers: {
+                linebreak: lineBreakButtonHandler
+            }
+        }
+    };
+
+    const $input = $(container).siblings('input[type="hidden"]');
+    container.innerHTML = $input.val() || "";
+    const token = $('meta[name="csrf-token"]').attr("content");
+
+    if (addVideo) {
+        quillFormats.push("video");
+    }
+
+    if (addImage) {
+        // Attempt to allow images only if the image support is enabled at editor support.
+        // see: https://github.com/quilljs/quill/issues/1108
+        quillFormats.push("image");
+
+        modules.imageResize = {
+            modules: ["Resize", "DisplaySize"]
+        };
+        modules.imageUpload = {
+            url: $(container).data("uploadImagesPath"),
+            method: "POST",
+            name: "image",
+            withCredentials: false,
+            headers: { "X-CSRF-Token": token },
+            callbackOK: (serverResponse, next) => {
+                $("div.ql-toolbar").last().removeClass("editor-loading");
+                next(serverResponse.url);
+            },
+            callbackKO: (serverError) => {
+                $("div.ql-toolbar").last().removeClass("editor-loading");
+                console.log(`Image upload error: ${serverError.message}`);
+            },
+            checkBeforeSend: (file, next) => {
+                $("div.ql-toolbar").last().addClass("editor-loading");
+                next(file);
+            }
+        };
+
+        const text = $(container).data("dragAndDropHelpText");
+        $(container).after(
+            `<p class="help-text" style="margin-top:-1.5rem;">${text}</p>`
+        );
+    }
+    const quill = new Quill(container, {
+        modules: modules,
+        formats: quillFormats,
+        theme: "snow"
+    });
+
+    if (addImage === false) {
+        // Firefox natively implements image drop in contenteditable which is why we need to disable that
+        quill.root.addEventListener("drop", (ev) => ev.preventDefault());
+    }
+
+    if (disabled) {
+        quill.disable();
+    }
+
+    quill.on("text-change", () => {
+
+        const text = quill.getText();
+        // Triggers CustomEvent with the cursor position
+        // It is required in input_mentions.js
+        let event = new CustomEvent("quill-position", {
+            detail: quill.getSelection()
+        });
+        container.dispatchEvent(event);
+
+        if (
+            (text === "\n" || text === "\n\n") &&
+            quill.root.querySelectorAll(allowedEmptyContentSelector).length === 0 && !$input.val().match(/img/)
+        ) {
+            $input.val("");
+        } else {
+            const emptyParagraph = "<p><br></p>";
+            const cleanHTML = quill.root.innerHTML.replace(
+                new RegExp(`^${emptyParagraph}|${emptyParagraph}$`, "g"),
+                ""
+            );
+            $input.val(cleanHTML);
+        }
+    });
+    // After editor is ready, linebreak_module deletes two extraneous new lines
+    quill.emitter.emit("editor-ready");
+
+    return quill;
+}

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -39,12 +39,12 @@ describe "Admin manages survey question with image", type: :system do
       click_button "Save"
       click_button "Expand all"
       expect(page).to have_selector("img[src='#{image_url}']")
-      #within "#questionnaire_question_#{question.id}-field" do
-      #  within "#questionnaire_question_#{question.id}-description-panel-0" do
-      #    input = page.find("#questionnaire_questions_#{question.id}_description_en")
-      #    expect(input.value).to eq("<p><img src=\"#{image_url}\"></p>")
-      #  end
-      #end
+      within "#questionnaire_question_#{question.id}-field" do
+        within "#questionnaire_question_#{question.id}-description-panel-0" do
+          input = page.find("#questionnaire_questions_#{question.id}_description_en")
+          expect(input.value).to eq("<p><img src=\"#{image_url}\"></p>")
+        end
+      end
     end
   end
 

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -39,7 +39,7 @@ describe "Admin manages survey question with image", type: :system do
       within "#questionnaire_question_#{question.id}-field" do
         within "#questionnaire_question_#{question.id}-description-panel-0" do
           description = find(".ql-editor p")
-          expect(description).to have_xpath('//img[@src="http://mon_image.png"]')
+          expect(description).to have_css("img[src='http://mon_image.png']")
           input = page.find("#questionnaire_questions_#{question.id}_description_en")
           expect(input.value).to eq('<p><img src="http://mon_image.png"></p>')
         end

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -19,16 +19,15 @@ describe "Admin manages survey question with image", type: :system do
     before do
       component.unpublish!
     end
-
+    let(:image_url) { "https://unsplash.com/fr/photos/une-trainee-detoiles-est-vue-dans-le-ciel-au-dessus-de-locean-pjHseB_JLpg" }
+    let(:router) { Decidim::EngineRouter.main_proxy(component) }
     let(:description_with_image) do
       {
-        en:
-          <<~HTML
-            <p><img src="http://mon_image.png"></p>
-          HTML
+        "en" => "<p><img src=\"#{image_url}\"</p>",
+        "ca" => "<p><img src=\"#{image_url}\"</p>",
+        "es" => "<p><img src=\"#{image_url}\"</p>"
       }
     end
-
     let!(:question) { create(:questionnaire_question, description: description_with_image, questionnaire: questionnaire) }
 
     it "after save, it renders description with hidden input value filled" do
@@ -36,10 +35,11 @@ describe "Admin manages survey question with image", type: :system do
       visit questionnaire_edit_path
       click_button "Save"
       click_button "Expand all"
+      expect(page).to have_selector("img[src='#{image_url}']")
       within "#questionnaire_question_#{question.id}-field" do
         within "#questionnaire_question_#{question.id}-description-panel-0" do
           input = page.find("#questionnaire_questions_#{question.id}_description_en")
-          expect(input.value).to eq('<p><img src="http://mon_image.png"></p>')
+          expect(input.value).to eq("<p><img src=\"#{image_url}\"></p>")
         end
       end
     end

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -19,6 +19,7 @@ describe "Admin manages survey question with image", type: :system do
     before do
       component.unpublish!
     end
+
     let(:image_url) { "https://unsplash.com/fr/photos/une-trainee-detoiles-est-vue-dans-le-ciel-au-dessus-de-locean-pjHseB_JLpg" }
     let(:router) { Decidim::EngineRouter.main_proxy(component) }
     let(:description_with_image) do
@@ -33,15 +34,17 @@ describe "Admin manages survey question with image", type: :system do
     it "after save, it renders description with hidden input value filled" do
       Capybara.ignore_hidden_elements = false
       visit questionnaire_edit_path
-      click_button "Save"
       click_button "Expand all"
       expect(page).to have_selector("img[src='#{image_url}']")
-      within "#questionnaire_question_#{question.id}-field" do
-        within "#questionnaire_question_#{question.id}-description-panel-0" do
-          input = page.find("#questionnaire_questions_#{question.id}_description_en")
-          expect(input.value).to eq("<p><img src=\"#{image_url}\"></p>")
-        end
-      end
+      #click_button "Save"
+      #click_button "Expand all"
+      #expect(page).to have_selector("img[src='#{image_url}']")
+      #within "#questionnaire_question_#{question.id}-field" do
+      #  within "#questionnaire_question_#{question.id}-description-panel-0" do
+      #    input = page.find("#questionnaire_questions_#{question.id}_description_en")
+      #    expect(input.value).to eq("<p><img src=\"#{image_url}\"></p>")
+      #  end
+      #end
     end
   end
 

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -31,12 +31,11 @@ describe "Admin manages survey question with image", type: :system do
 
     let!(:question) { create(:questionnaire_question, description: description_with_image, questionnaire: questionnaire) }
 
-    it "after save, it renders image in description with hidden input value filled" do
+    it "after save, it renders description with hidden input value filled" do
       Capybara.ignore_hidden_elements = false
       visit questionnaire_edit_path
       click_button "Save"
       click_button "Expand all"
-      expect(page).to have_css("img[src$='mon_image.png']")
       within "#questionnaire_question_#{question.id}-field" do
         within "#questionnaire_question_#{question.id}-description-panel-0" do
           input = page.find("#questionnaire_questions_#{question.id}_description_en")

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -36,10 +36,9 @@ describe "Admin manages survey question with image", type: :system do
       visit questionnaire_edit_path
       click_button "Save"
       click_button "Expand all"
+      expect(page).to have_xpath('//img[@src="http://mon_image.png"]')
       within "#questionnaire_question_#{question.id}-field" do
         within "#questionnaire_question_#{question.id}-description-panel-0" do
-          description = find(".ql-editor p")
-          expect(description).to have_css("img[src='http://mon_image.png']")
           input = page.find("#questionnaire_questions_#{question.id}_description_en")
           expect(input.value).to eq('<p><img src="http://mon_image.png"></p>')
         end

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages survey question with image", type: :system do
+  let(:manifest_name) { "surveys" }
+  let!(:component) do
+    create(:component,
+           manifest: manifest,
+           participatory_space: participatory_space,
+           published_at: nil)
+  end
+  let!(:questionnaire) { create(:questionnaire) }
+  let!(:survey) { create :survey, component: component, questionnaire: questionnaire }
+
+  include_context "when managing a component as an admin"
+
+  context "when survey is not published" do
+    before do
+      component.unpublish!
+    end
+
+    let(:description_with_image) do
+      {
+        en:
+          <<~HTML
+            <p><img src="http://mon_image.png"></p>
+          HTML
+      }
+    end
+
+    let!(:question) { create(:questionnaire_question, description: description_with_image, questionnaire: questionnaire) }
+
+    it "after save, it renders image in description with hidden input value filled" do
+      Capybara.ignore_hidden_elements = false
+      visit questionnaire_edit_path
+      click_button "Save"
+      click_button "Expand all"
+      within "#questionnaire_question_#{question.id}-field" do
+        within "#questionnaire_question_#{question.id}-description-panel-0" do
+          description = find(".ql-editor p")
+          expect(description).to have_xpath('//img[@src="http://mon_image.png"]')
+          input = page.find("#questionnaire_questions_#{question.id}_description_en")
+          expect(input.value).to eq('<p><img src="http://mon_image.png"></p>')
+        end
+      end
+    end
+  end
+
+  def questionnaire_edit_path
+    manage_component_path(component)
+  end
+end

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -36,9 +36,9 @@ describe "Admin manages survey question with image", type: :system do
       visit questionnaire_edit_path
       click_button "Expand all"
       expect(page).to have_selector("img[src='#{image_url}']")
-      #click_button "Save"
-      #click_button "Expand all"
-      #expect(page).to have_selector("img[src='#{image_url}']")
+      click_button "Save"
+      click_button "Expand all"
+      expect(page).to have_selector("img[src='#{image_url}']")
       #within "#questionnaire_question_#{question.id}-field" do
       #  within "#questionnaire_question_#{question.id}-description-panel-0" do
       #    input = page.find("#questionnaire_questions_#{question.id}_description_en")

--- a/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
+++ b/spec/system/admin/admin_manages_survey_question_with_image_spec.rb
@@ -36,7 +36,7 @@ describe "Admin manages survey question with image", type: :system do
       visit questionnaire_edit_path
       click_button "Save"
       click_button "Expand all"
-      expect(page).to have_xpath('//img[@src="http://mon_image.png"]')
+      expect(page).to have_css("img[src$='mon_image.png']")
       within "#questionnaire_question_#{question.id}-field" do
         within "#questionnaire_question_#{question.id}-description-panel-0" do
           input = page.find("#questionnaire_questions_#{question.id}_description_en")

--- a/spec/system/admin/admin_updates_question_in_questionnaire_templates_spec.rb
+++ b/spec/system/admin/admin_updates_question_in_questionnaire_templates_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin adds display condition to template's questionniaire question", type: :system do
+describe "Admin adds display condition to template's questionnaire question", type: :system do
   let!(:organization) { create(:organization) }
   let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
   let(:template) { create(:questionnaire_template, organization: organization) }
@@ -23,14 +23,16 @@ describe "Admin adds display condition to template's questionniaire question", t
     # expand question two
     find("[data-toggle$=button--expand-question-questionnaire_question_#{question_two.id}]").click
     # add display condition
-    find(".add-display-condition").click
-    # select question
-    select translated(question_one.body), from: "questionnaire[questions][#{question_two.id}][display_conditions][questionnaire-display-condition-id][decidim_condition_question_id]"
-    # select equal
-    select "Equal", from: "questionnaire[questions][#{question_two.id}][display_conditions][questionnaire-display-condition-id][condition_type]"
-    # validate we have the 2 answer options from question one in the select
-    select = find("#questionnaire_questions_#{question_two.id}_display_conditions_questionnaire-display-condition-id_decidim_answer_option_id")
-    expect(select).to have_content(translated(question_one.answer_options.first.body))
-    expect(select).to have_content(translated(question_one.answer_options.last.body))
+    within "#questionnaire_question_#{question_two.id}-question-card" do
+      find(".add-display-condition").click
+      # select question
+      select translated(question_one.body), from: "questionnaire[questions][#{question_two.id}][display_conditions][questionnaire-display-condition-id][decidim_condition_question_id]"
+      # select equal
+      select "Equal", from: "questionnaire[questions][#{question_two.id}][display_conditions][questionnaire-display-condition-id][condition_type]"
+      # validate we have the 2 answer options from question one in the select
+      select = find("#questionnaire_questions_#{question_two.id}_display_conditions_questionnaire-display-condition-id_decidim_answer_option_id")
+      expect(select).to have_content(translated(question_one.answer_options.first.body))
+      expect(select).to have_content(translated(question_one.answer_options.last.body))
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
When adding an image without text in a question's description of a survey, the image is visible in the description after save, and when you save again, the image is still present.
To fix the disappearance of the image, we override a javascript file (modified code is on line 136 in app/packs/src/decidim/editor.js).

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/Rillieux-Decidim-app-Probl-me-avec-l-ajout-des-photos-dans-la-partie-description-des-questions-d-0cdc0b986018457e95f5de547ecddc8b)

#### Testing

1. As an admin, go to a survey.
2. Add a question and drag and drop an image in the description of the question (do not add text in description)
3. Save
4. See that the image is displayed in the description
5. Modify the title of the question and save again
6. See that the image is still displayed in the description

#### Tasks
- [X ] Add specs

