### PR TITLE
bump: Module Spam Detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-m
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
 gem "decidim-simple_proposal", git: "https://github.com/OpenSourcePolitics/decidim-module-simple_proposal", branch: DECIDIM_BRANCH
-gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", tag: "4.1.1"
+gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", tag: "4.1.2"
 gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,10 +108,10 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
-  revision: fb2ee4624b728ce6f73603bfb84eda1d9b4e04d4
-  tag: 4.1.1
+  revision: 5e4f92f19b903228b8349fb002d735e900d63ed4
+  tag: 4.1.2
   specs:
-    decidim-spam_detection (4.1.1)
+    decidim-spam_detection (4.1.2)
       decidim-core (~> 0.27.0)
 
 GIT
@@ -1226,4 +1226,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.10
+   2.5.22


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

- Allow to reduce the spam probability score using env var `SPAM_DETECTION_BLOCKING_LEVEL`

Used in `bundle exec rake decidim:spam_detection:block_users`

## Environment

* `SPAM_DETECTION_BLOCKING_LEVEL` (default: 0.99) OPTIONAL