### PR TITLE
Fix/backport decidim awesome slowness on proposals index page

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -77,7 +77,9 @@ DECIDIM_ADMIN_PASSWORD_STRONG="false"
 ## Generate values with: bin/rails decidim:pwa:generate_vapid_keys
 # VAPID_PUBLIC_KEY
 # VAPID_PRIVATE_KEY
-RAILS_LOG_LEVEL=warn
+# RAILS_LOG_LEVEL=warn
+
+# DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED=disabled # or enabled
 
 # Default notifications sending frequency : (daily, weekly, none, real_time)
 # NOTIFICATIONS_SENDING_FREQUENCY=daily

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,5 @@ Rails.application.configure do
   # Setting this to 100 years should be enough
   config.global_id.expires_in = 100.years
   config.deface.enabled = ENV.fetch("DEFACE_ENABLED", nil) == "true"
+  config.log_tags = [:uuid, :remote_ip]
 end

--- a/config/initializers/decidim_awesome.rb
+++ b/config/initializers/decidim_awesome.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Decidim::DecidimAwesome.configure do |config|
+  config.weighted_proposal_voting = Rails.application.secrets.dig(:decidim, :decidim_awesome, :weighted_proposal_voting_enabled)&.to_sym
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,8 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    decidim_awesome:
+      weighted_proposal_voting_enabled: <%= ENV.fetch("DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED", "disabled") %>
     admin_password:
       expiration_days: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 365).to_i %>
       min_length: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_MIN_LENGTH", 15).to_i %>

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -10,13 +10,6 @@ module Decidim::DecidimAwesome
     let(:proposal) { create(:extended_proposal) }
     let(:component) { create(:component, settings: { awesome_voting_manifest: "default" }) }
 
-    before do
-      puts "Extra Fields Before Save: #{proposal.extra_fields.inspect}"
-      # create(:proposal_vote, proposal: proposal, weight: 1)
-      # create(:proposal_vote, proposal: proposal, weight: 2)
-      puts "Extra Fields Before Save: #{proposal.extra_fields.inspect}"
-    end
-
     it { is_expected.to be_valid }
 
     it "has a proposal associated" do
@@ -199,7 +192,6 @@ module Decidim::DecidimAwesome
       let!(:votes) do
         vote = create(:proposal_vote, proposal: proposal, author: create(:user, organization: proposal.organization))
         create(:awesome_vote_weight, vote: vote, weight: 1)
-        vote.update(weight: 1)
       end
       let!(:other_votes) do
         vote = create(:proposal_vote, proposal: another_proposal, author: create(:user, organization: proposal.organization))
@@ -211,25 +203,6 @@ module Decidim::DecidimAwesome
         expect(another_proposal.reload.all_vote_weights).to contain_exactly(1, 2)
         expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })
         expect(another_proposal.vote_weights).to eq({ "1" => 0, "2" => 1 })
-      end
-
-      context "when wrong cache exists" do
-        before do
-          # rubocop:disable Rails/SkipsModelValidations:
-          # we don't want to trigger the active record hooks
-          extra_fields.update_columns(vote_weight_totals: { "3" => 1, "4" => 1 })
-          # rubocop:enable Rails/SkipsModelValidations:
-        end
-
-        it "returns all vote weights for a component" do
-          expect(proposal.reload.extra_fields.vote_weight_totals).to eq({ "3" => 1, "4" => 1 })
-          expect(proposal.vote_weights).to eq({ "1" => 0, "2" => 0 })
-          proposal.update_vote_weights!
-          expect(proposal.reload.vote_weights).to eq({ "1" => 1, "2" => 0 })
-          expect(another_proposal.reload.vote_weights).to eq({ "1" => 0, "2" => 1 })
-          expect(proposal.extra_fields.vote_weight_totals).to eq({ "1" => 1 })
-          expect(another_proposal.extra_fields.vote_weight_totals).to eq({ "2" => 1 })
-        end
       end
     end
 

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -199,6 +199,7 @@ module Decidim::DecidimAwesome
       let!(:votes) do
         vote = create(:proposal_vote, proposal: proposal, author: create(:user, organization: proposal.organization))
         create(:awesome_vote_weight, vote: vote, weight: 1)
+        vote.update(weight: 1)
       end
       let!(:other_votes) do
         vote = create(:proposal_vote, proposal: another_proposal, author: create(:user, organization: proposal.organization))

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -184,25 +184,10 @@ module Decidim::DecidimAwesome
       end
     end
 
-    describe "all_vote_weights" do
-      let!(:extra_fields) { create(:awesome_proposal_extra_fields, proposal: proposal) }
-      let!(:another_extra_fields) { create(:awesome_proposal_extra_fields, proposal: another_proposal) }
-      let!(:unrelated_another_extra_fields) { create(:awesome_proposal_extra_fields, :with_votes, proposal: create(:extended_proposal)) }
-      let(:another_proposal) { create(:proposal, component: proposal.component) }
-      let!(:votes) do
-        vote = create(:proposal_vote, proposal: proposal, author: create(:user, organization: proposal.organization))
-        create(:awesome_vote_weight, vote: vote, weight: 1)
-      end
-      let!(:other_votes) do
-        vote = create(:proposal_vote, proposal: another_proposal, author: create(:user, organization: proposal.organization))
-        create(:awesome_vote_weight, vote: vote, weight: 2)
-      end
-
-      it "returns all vote weights for a component" do
-        expect(proposal.reload.all_vote_weights).to contain_exactly(1, 2)
-        expect(another_proposal.reload.all_vote_weights).to contain_exactly(1, 2)
-        expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })
-        expect(another_proposal.vote_weights).to eq({ "1" => 0, "2" => 1 })
+    describe "weighted_proposal_voting_enabled" do
+      it "is disabled by default" do
+        default_value = Rails.application.secrets.dig(:decidim, :decidim_awesome, :weighted_proposal_voting_enabled)
+        expect(default_value).to eq("disabled")
       end
     end
 

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -8,8 +8,14 @@ module Decidim::DecidimAwesome
 
     let(:extra_fields) { create(:awesome_proposal_extra_fields, proposal: create(:extended_proposal)) }
     let(:proposal) { create(:extended_proposal) }
+    let(:component) { create(:component, settings: { awesome_voting_manifest: "default" }) }
 
     it { is_expected.to be_valid }
+
+    before do
+      create(:proposal_vote, proposal: proposal, weight: 1)
+      create(:proposal_vote, proposal: proposal, weight: 2)
+    end
 
     it "has a proposal associated" do
       expect(extra_fields.proposal).to be_a(Decidim::Proposals::Proposal)

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -10,12 +10,14 @@ module Decidim::DecidimAwesome
     let(:proposal) { create(:extended_proposal) }
     let(:component) { create(:component, settings: { awesome_voting_manifest: "default" }) }
 
-    it { is_expected.to be_valid }
-
     before do
-      create(:proposal_vote, proposal: proposal, weight: 1)
-      create(:proposal_vote, proposal: proposal, weight: 2)
+      puts "Extra Fields Before Save: #{proposal.extra_fields.inspect}"
+      # create(:proposal_vote, proposal: proposal, weight: 1)
+      # create(:proposal_vote, proposal: proposal, weight: 2)
+      puts "Extra Fields Before Save: #{proposal.extra_fields.inspect}"
     end
+
+    it { is_expected.to be_valid }
 
     it "has a proposal associated" do
       expect(extra_fields.proposal).to be_a(Decidim::Proposals::Proposal)
@@ -219,7 +221,12 @@ module Decidim::DecidimAwesome
         end
 
         it "returns all vote weights for a component" do
+          allow(component.settings).to receive(:awesome_voting_manifest).and_return("default")
           expect(proposal.reload.extra_fields.vote_weight_totals).to eq({ "3" => 1, "4" => 1 })
+          # update_vote_weights!
+          proposal.update_vote_weights!
+          # puts "Vote Weights After Update: #{proposal.vote_weights}"
+          # puts "Vote Weight Totals: #{proposal.extra_fields.vote_weight_totals}"
           expect(proposal.vote_weights).to eq({ "1" => 0, "2" => 0 })
           proposal.update_vote_weights!
           expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })

--- a/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
+++ b/spec/models/decidim/decidim_awesome/proposal_extra_field_spec.rb
@@ -222,15 +222,10 @@ module Decidim::DecidimAwesome
         end
 
         it "returns all vote weights for a component" do
-          allow(component.settings).to receive(:awesome_voting_manifest).and_return("default")
           expect(proposal.reload.extra_fields.vote_weight_totals).to eq({ "3" => 1, "4" => 1 })
-          # update_vote_weights!
-          proposal.update_vote_weights!
-          # puts "Vote Weights After Update: #{proposal.vote_weights}"
-          # puts "Vote Weight Totals: #{proposal.extra_fields.vote_weight_totals}"
           expect(proposal.vote_weights).to eq({ "1" => 0, "2" => 0 })
           proposal.update_vote_weights!
-          expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })
+          expect(proposal.reload.vote_weights).to eq({ "1" => 1, "2" => 0 })
           expect(another_proposal.reload.vote_weights).to eq({ "1" => 0, "2" => 1 })
           expect(proposal.extra_fields.vote_weight_totals).to eq({ "1" => 1 })
           expect(another_proposal.extra_fields.vote_weight_totals).to eq({ "2" => 1 })


### PR DESCRIPTION
#### :tophat: Description
Backport
Disable by default the feature Weighted proposal voting.

Add environment variable to configure it :

DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED: Val "disabled" (default) or "enabled"
Enhance dev mode logs

#### Testing

- In console, verify if the env variable is disabled
`Decidim::DecidimAwesome.weighted_proposal_voting` should return `:disabled`
- Exit the console
- configure the env variable to `enable`and start the console
`DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED=enabled bundle exec rails c `
- verify if the env variable is updated to enabled
`Decidim::DecidimAwesome.weighted_proposal_voting` should return `:enabled`
🎉 

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
