### PR TITLE
Revert: "fix error message displaying when reaching proposition add limit"

### DIFF
--- a/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
@@ -56,12 +56,6 @@ module Decidim
           enforce_permission_to :create, :proposal
           @step = Decidim::Proposals::ProposalsController::STEP1
           @form = form(Decidim::Proposals::ProposalForm).from_params(proposal_creation_params)
-          if proposal_limit_reached?
-            @form.errors.add(:base, I18n.t("decidim.proposals.new.limit_reached"))
-            flash.now[:alert] = I18n.t("proposals.create.error", scope: "decidim")
-            render :new
-            return
-          end
 
           @proposal = Decidim::Proposals::Proposal.new(@form.attributes.except(
             :user_group_id,
@@ -191,17 +185,6 @@ module Decidim
               attachment
             end
           end
-        end
-
-        def proposal_limit_reached?(form = form_proposal_params)
-          proposal_limit = form.current_component.settings.proposal_limit
-          return false if proposal_limit.zero?
-
-          current_user_proposals(form).count >= proposal_limit
-        end
-
-        def current_user_proposals(form)
-          Decidim::Proposals::Proposal.from_author(current_user).where(component: form.current_component).except_withdrawn
         end
       end
     end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,8 +119,6 @@ ignore_missing:
  - decidim.term_customizer.admin.actions.*
  - decidim.term_customizer.admin.add_translations.index.*
  - decidim.term_customizer.admin.models.translations.fields.*
- - decidim.proposals.new.limit_reached
- - decidim.proposals.create.error
 
 # Consider these keys used:
 ignore_unused:

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -164,18 +164,6 @@ module Decidim
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)
           end
-
-          context "and proposals limit is reached" do
-            before do
-              allow(controller).to receive(:proposal_limit_reached?).and_return(true)
-            end
-
-            it "does not create a proposal and raises an error" do
-              post :create, params: params
-              expect(response).to have_http_status(:ok)
-              expect(flash[:alert]).not_to be_empty
-            end
-          end
         end
       end
 


### PR DESCRIPTION
Reverts OpenSourcePolitics/decidim-app#609 
Due to the following error: 
```
2024-11-20 15:43:08.377	[781a53a85e201ca2e4d0f0ca02a9febb] app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb:59:in `create'
2024-11-20 15:43:08.377	[781a53a85e201ca2e4d0f0ca02a9febb] app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb:200:in `proposal_limit_reached?'
2024-11-20 15:43:08.377	[781a53a85e201ca2e4d0f0ca02a9febb] app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb:204:in `current_user_proposals'
2024-11-20 15:43:08.377	[781a53a85e201ca2e4d0f0ca02a9febb]   
2024-11-20 15:43:08.377	[781a53a85e201ca2e4d0f0ca02a9febb] NoMethodError (undefined method `id' for nil:NilClass):
2024-11-20 15:43:08.377	F, [2024-11-20T14:43:08.377149 #1] FATAL -- : [781a53a85e201ca2e4d0f0ca02a9febb]   
```
