### PR TITLE
fix: Map not displaying when refreshing

### DIFF
--- a/app/views/decidim/proposals/proposals/index.html.erb
+++ b/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,30 +1,28 @@
 <%= render partial: "decidim/shared/component_announcement" %>
 
 <% if component_settings.geocoding_enabled? %>
-  <% cache @all_geocoded_proposals do %>
-    <%= dynamic_map_for proposals_data_for_map(@all_geocoded_proposals) do %>
-      <template id="marker-popup">
-        <div class="map-info__content">
-          <h3>${title}</h3>
-          <div id="bodyContent">
-            <p>{{html body}}</p>
-            <div class="map__date-address">
-              <div class="address card__extra">
-                <div class="address__icon">{{html icon}}</div>
-                <div class="address__details">
-                  <span>${address}</span><br>
-                </div>
+  <%= dynamic_map_for proposals_data_for_map(@all_geocoded_proposals) do %>
+    <template id="marker-popup">
+      <div class="map-info__content">
+        <h3>${title}</h3>
+        <div id="bodyContent">
+          <p>{{html body}}</p>
+          <div class="map__date-address">
+            <div class="address card__extra">
+              <div class="address__icon">{{html icon}}</div>
+              <div class="address__details">
+                <span>${address}</span><br>
               </div>
             </div>
-            <div class="map-info__button">
-              <a href="${link}" class="button button--sc">
-                <%= t(".view_proposal") %>
-              </a>
-            </div>
+          </div>
+          <div class="map-info__button">
+            <a href="${link}" class="button button--sc">
+              <%= t(".view_proposal") %>
+            </a>
           </div>
         </div>
-      </template>
-    <% end %>
+      </div>
+    </template>
   <% end %>
 <% end %>
 <%= render partial: "voting_rules" %>


### PR DESCRIPTION
#### :tophat: Description
This PR removes the cache from the proposals index related to geocoded proposals because it caused when the app has a cache mechanism, to create an issue where the map wasn't reloading anymor when index of the proposals is cached.

#### :pushpin: Related Issues
- [Release 2.5.1 - Geocoding map is not displayed](https://opensourcepolitics.odoo.com/web?db=opensourcepolitics&signup_email=guillaume%40opensourcepolitics.eu&token=ixqNZ9S5lGRCj9ADpsQq#id=3425&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Testing

## Please note that you'll need to have an app cached so please use one of the following lines
#### - You can use Docker using the command `make run`
#### - You can use a local instance but run when running the app `bundle exec rails dev:cache && bundle exec rails s`

----------------

* Log in as admin
* Access Backoffice
* Go to participatory processes
* Access PP and a "Components"
* Access to the options of a Proposals component
* Enable Geocoding 

---

* Access this proposals index on front-office
* Make sure the map is appearing the first time 
* Refresh a few times and make sure it doesn't disappear
* Add few proposals geocoded
* Make sure the points are appearing on the page
* Make sure they're no issues related to it

---

Please for an other issue test this scenario

- Click on one pin on the map
- Make sure you're redirected to the correct proposal

#### Tasks

- [x] Remove caching from Proposals Index
