### PR TITLE
backport: Reorder scopes in meetings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,7 @@ module DevelopmentApp
       # Services
       require "extends/services/decidim/iframe_disabler_extends"
       # Helpers
+      require "extends/helpers/decidim/meetings/directory/application_helper_extends"
       require "extends/helpers/decidim/icon_helper_extends"
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       # Forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,9 @@ en:
             see_all_initiatives: See all initiatives
       unavailable_scope: Unavailable scope
     meetings:
+      application_helper:
+        filter_scope_values:
+          all: All
       directory:
         meetings:
           index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -147,6 +147,9 @@ fr:
             see_all_initiatives: Voir toutes les pétitions
       unavailable_scope: Portée indisponible
     meetings:
+      application_helper:
+        filter_scope_values:
+          all: Tous
       directory:
         meetings:
           index:

--- a/lib/extends/helpers/decidim/meetings/directory/application_helper_extends.rb
+++ b/lib/extends/helpers/decidim/meetings/directory/application_helper_extends.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module ApplicationHelperExtends
+  extend ActiveSupport::Concern
+  include Decidim::CheckBoxesTreeHelper
+
+  included do
+    def directory_filter_scopes_values
+      main_scopes = current_organization.scopes.top_level
+      scopes_values = main_scopes.includes(:scope_type, :children).sort_by(&:weight).flat_map do |scope|
+        TreeNode.new(
+          TreePoint.new(scope.id.to_s, translated_attribute(scope.name, current_organization)),
+          scope_children_to_tree(scope)
+        )
+      end
+
+      scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global")))
+
+      TreeNode.new(
+        TreePoint.new("", t("decidim.meetings.application_helper.filter_scope_values.all")),
+        scopes_values
+      )
+    end
+
+    def scope_children_to_tree(scope)
+      return unless scope.children.any?
+
+      scope.children.includes(:scope_type, :children).sort_by(&:weight).flat_map do |child|
+        TreeNode.new(
+          TreePoint.new(child.id.to_s, translated_attribute(child.name, current_organization)),
+          scope_children_to_tree(child)
+        )
+      end
+    end
+  end
+end
+
+Decidim::Meetings::Directory::ApplicationHelper.include(ApplicationHelperExtends)

--- a/spec/helpers/decidim/meetings/directory/application_helper_spec.rb
+++ b/spec/helpers/decidim/meetings/directory/application_helper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    module Directory
+      describe ApplicationHelper do
+        let(:helper) do
+          Class.new(ActionView::Base) do
+            include ApplicationHelper
+            include CheckBoxesTreeHelper
+            include TranslatableAttributes
+          end.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, [])
+        end
+        let!(:organization) { create(:organization) }
+        let!(:parent_scope) { create(:scope, organization: organization) }
+        let!(:scope_one) { create(:scope, organization: organization, parent: parent_scope, weight: 1) }
+        let!(:scope_two) { create(:scope, organization: organization, parent: parent_scope, weight: 2) }
+        let!(:scope_three) { create(:scope, organization: organization, parent: parent_scope, weight: 3) }
+
+        before do
+          allow(helper).to receive(:current_organization).and_return(organization)
+        end
+
+        describe "#directory_filter_scopes_values" do
+          let(:root) { helper.directory_filter_scopes_values }
+          let(:leaf) { root.leaf }
+          let(:nodes) { root.node }
+
+          context "when the organization has a scope with children" do
+            it "returns all the children ordered by weight" do
+              expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
+              expect(nodes.last.node.count).to eq(3)
+              expect(nodes.last.node.first.leaf.label).to eq(scope_one.name["en"])
+              expect(nodes.last.node.last.leaf.label).to eq(scope_three.name["en"])
+            end
+
+            context "and the weight of scope's children changes" do
+              it "returns the children ordered by the new weight" do
+                scope_one.update(weight: 4)
+                expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
+                expect(nodes.last.node.count).to eq(3)
+                expect(nodes.last.node.first.leaf.label).to eq(scope_two.name["en"])
+                expect(nodes.last.node.last.leaf.label).to eq(scope_one.name["en"])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This backport allows scopes to be sorted in the filters of meetings index page

#### :pushpin: Related Issues
- [#200 decidim-tou](https://github.com/OpenSourcePolitics/decidim-tou/pull/200)

#### Testing

#### Back-Office

* Log in as admin
* Access Backoffice
* Go to settings
* Access to scopes
* Check that you can sort them (sort and refresh to make sure everything stays in place)
* Access onto a scope and try to sort the subscopes (same tests as above)

* Access to participatory processes
* Access a PP and its meetings component page
* Make sure scopes are enabled on the global scopes to ensure every scopes are displayed

----

* Go to the meetings index page of the PP
* Check in the filters that the scopes are sorted in the same order as the one chosen by admin
* You can repeat the process multiple times to check that it's always sorted correctly

#### Tasks

- [x] Extends the Application Helper of the meetings
- [x] Add few locales
- [x] Add some specs