### PR TITLE
fix: Scopes not updatable in the back-office

### DIFF
--- a/app/helpers/concerns/decidim/simple_proposal/scopes_helper_override.rb
+++ b/app/helpers/concerns/decidim/simple_proposal/scopes_helper_override.rb
@@ -4,9 +4,8 @@ module Decidim
   module SimpleProposal
     module ScopesHelperOverride
       extend ActiveSupport::Concern
-
       included do
-        def scopes_picker_field(form, name, root: false, options: { checkboxes_on_top: true, sort_by_weight: true })
+        def scopes_picker_field(form, name, root: false, options: { checkboxes_on_top: true })
           options.merge!(selected: selected_scope(form)) if selected_scope(form)
           form.select(name, simple_scope_options(root: root, options: options), include_blank: t("decidim.scopes.prompt"))
         end
@@ -23,11 +22,9 @@ module Decidim
         def simple_scope_options(root: false, options: {})
           scopes_array = []
           roots = root ? root.children : ancestors
-
           roots.sort_by { |ancestor| ancestor.weight || 0 }.each do |ancestor|
             children_after_parent(ancestor, scopes_array, "")
           end
-
           selected = options.has_key?(:selected) ? options[:selected] : params.dig(:filter, :decidim_scope_id)
           options_for_select(scopes_array, selected)
         end
@@ -37,7 +34,7 @@ module Decidim
         end
 
         def children_after_parent(ancestor, array, prefix)
-          array << ["#{prefix} #{translated_attribute(ancestor.name)}", ancestor.id, ancestor.weight]
+          array << ["#{prefix} #{translated_attribute(ancestor.name)}", ancestor.id]
           ancestor.children.sort_by { |child| child.weight || 0 }.each do |child|
             children_after_parent(child, array, "#{prefix}-")
           end


### PR DESCRIPTION
#### :tophat: Description
This PR fixes a behavior where we couldn't update the scopes in the Participatory Process

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Release 2.5.1 - Cannot add scope in PP](https://opensourcepolitics.odoo.com/web?db=opensourcepolitics&signup_email=guillaume%40opensourcepolitics.eu&token=ixqNZ9S5lGRCj9ADpsQq#id=3483&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Testing
* Log in as admin
* Access Backoffice
* Access scopes settings
* Shuffle them and their subscopes to make sure it will be displayed correctly
* Go to a participatory process settings
* Try to enable scopes and choose a scope
* Update it
* Try the process a few times
* Make sure everything related to it works correctly

#### Tasks
- [ ] Remove unnecessary changes in the override
