### PR TITLE
fix: Add authentication only if user_name & password

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,16 +94,18 @@ Rails.application.configure do
     config.action_mailer.default_url_options = { port: 3000 }
   else
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = {
+    smtp_settings = {
       address: Rails.application.secrets.smtp_address,
       port: Rails.application.secrets.smtp_port,
-      authentication: Rails.application.secrets.smtp_authentication,
       user_name: Rails.application.secrets.smtp_username,
       password: Rails.application.secrets.smtp_password,
       domain: Rails.application.secrets.smtp_domain,
       enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
       openssl_verify_mode: "none"
     }
+    smtp_settings = smtp_settings.merge(authentication: Rails.application.secrets.smtp_authentication) if smtp_settings[:user_name].present? && smtp_settings[:password].present?
+
+    config.action_mailer.smtp_settings = smtp_settings
 
     if Rails.application.secrets.sendgrid
       config.action_mailer.default_options = {


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

If smtp user_name or smtp password is not defined, then smtp_settings "Authentication" key must not be defined

Related to [card](https://opensourcepolitics.odoo.com/web#id=3557&cids=1&model=project.task&view_type=form)
