### PR TITLE
Clear versions in database

### DIFF
--- a/app/controllers/decidim/system/dashboard_controller.rb
+++ b/app/controllers/decidim/system/dashboard_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    class DashboardController < Decidim::System::ApplicationController
+      before_action :check_organizations_presence
+
+      def show
+        @organizations = Organization.all
+        @db_size = db_size
+      end
+
+      def check_organizations_presence
+        return if Organization.exists?
+
+        redirect_to new_organization_path
+      end
+
+      private
+
+      def db_size
+        dbname = ActiveRecord::Base.connection.current_database
+        sql = "SELECT pg_size_pretty(pg_database_size('#{dbname}'));"
+        ActiveRecord::Base.connection.execute(sql)[0]["pg_size_pretty"]
+      end
+    end
+  end
+end

--- a/app/jobs/concerns/decidim/logging.rb
+++ b/app/jobs/concerns/decidim/logging.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Logging
+    private
+
+    def log!(msg, level = :warn)
+      msg = "(#{self.class}) #{Time.current.strftime("%d-%m-%Y %H:%M")}> #{msg}"
+      case level
+      when :info
+        Rails.logger.info msg
+      else
+        Rails.logger.warn msg
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -8,7 +8,10 @@ module Decidim
 
     def perform(expiration = 6.months.ago)
       log! "Cleaning versions in database..."
-      elements = ["Decidim::UserBaseEntity", "Decidim::Comments::Comment", "Decidim::Attachment", "Decidim::Blogs::Post"]
+      elements = ["Decidim::UserBaseEntity",
+                  "Decidim::Comments::Comment",
+                  "Decidim::Attachment",
+                  "Decidim::Blogs::Post"]
       log! "Cleaning item_types : #{elements.join(", ")}"
 
       total = 0

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -6,7 +6,7 @@ module Decidim
 
     include Decidim::Logging
 
-    def perform(expiration = 6.months.ago)
+    def perform(retention = 6.months.ago)
       log! "Cleaning versions in database..."
       elements = [
                   "Decidim::Accountability::TimelineEntry",
@@ -27,7 +27,7 @@ module Decidim
       log! "Cleaning item_types : #{elements.join(", ")}"
 
       total = 0
-      PaperTrail::Version.where(item_type: elements).where("created_at <= ?", expiration).in_batches do |versions|
+      PaperTrail::Version.where(item_type: elements).where("created_at <= ?", retention).in_batches do |versions|
         total += versions.size
         versions.destroy_all
       end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -13,7 +13,7 @@ module Decidim
       log! "Cleaning item_types : #{item_types.join(", ")}"
 
       total = 0
-      PaperTrail::Version.where(item_type: item_types).where("created_at <= ?", ret).in_batches do |versions|
+      PaperTrail::Version.where(item_type: item_types).where("created_at <= ?", ret).in_batches(of: 5000) do |versions|
         total += versions.size
         versions.destroy_all
       end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -6,33 +6,48 @@ module Decidim
 
     include Decidim::Logging
 
-    def perform(retention = 6.months.ago)
+    def perform(ret = nil)
+      ret = retention(ret)
+
       log! "Cleaning versions in database..."
-      elements = [
-                  "Decidim::Accountability::TimelineEntry",
-                  "Decidim::Accountability::Result",
-                  "Decidim::Attachment",
-                  "Decidim::AttachmentCollection",
-                  "Decidim::Blogs::Post",
-                  "Decidim::Budgets::Project",
-                  "Decidim::Comments::Comment",
-                  "Decidim::Conferences::MediaLink",
-                  "Decidim::Conferences::Partner",
-                  "Decidim::Debates::Debate",
-                  "Decidim::Categorization",
-                  "Decidim::Categorization",
-                  "Decidim::Forms::Questionnaire",
-                  "Decidim::UserBaseEntity",
-      ]
-      log! "Cleaning item_types : #{elements.join(", ")}"
+      log! "Cleaning item_types : #{item_types.join(", ")}"
 
       total = 0
-      PaperTrail::Version.where(item_type: elements).where("created_at <= ?", retention).in_batches do |versions|
+      PaperTrail::Version.where(item_type: item_types).where("created_at <= ?", ret).in_batches do |versions|
         total += versions.size
         versions.destroy_all
       end
 
       log! "#{total} versions have been removed"
+    end
+
+    private
+
+    def retention(ret)
+      return ret if ret.present? && ret.is_a?(Time)
+
+      ret = Rails.application.secrets.dig(:decidim, :database, :versions, :clean, :retention)
+      ret.months.ago
+    end
+
+    # Exhaustive list of item_types to remove from versions table
+    def item_types
+      @item_types ||= %w(
+        Decidim::Accountability::TimelineEntry
+        Decidim::Accountability::Result
+        Decidim::Attachment
+        Decidim::AttachmentCollection
+        Decidim::Blogs::Post
+        Decidim::Budgets::Project
+        Decidim::Comments::Comment
+        Decidim::Conferences::MediaLink
+        Decidim::Conferences::Partner
+        Decidim::Debates::Debate
+        Decidim::Categorization
+        Decidim::Categorization
+        Decidim::Forms::Questionnaire
+        Decidim::UserBaseEntity
+      )
     end
   end
 end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  class PapertrailVersionsJob < ApplicationJob
+    queue_as :default
+
+    include Decidim::Logging
+
+    def perform(expiration = 6.months.ago)
+      log! "Cleaning versions in database..."
+      elements = ["Decidim::UserBaseEntity", "Decidim::Comments::Comment", "Decidim::Attachment", "Decidim::Blogs::Post"]
+      log! "Cleaning item_types : #{elements.join(", ")}"
+
+      total = 0
+      PaperTrail::Version.where(item_type: elements).where("created_at <= ?", expiration).in_batches do |versions|
+        total += versions.size
+        versions.destroy_all
+      end
+
+      log! "#{total} users have been removed"
+    end
+  end
+end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -8,10 +8,22 @@ module Decidim
 
     def perform(expiration = 6.months.ago)
       log! "Cleaning versions in database..."
-      elements = ["Decidim::UserBaseEntity",
-                  "Decidim::Comments::Comment",
+      elements = [
+                  "Decidim::Accountability::TimelineEntry",
+                  "Decidim::Accountability::Result",
                   "Decidim::Attachment",
-                  "Decidim::Blogs::Post"]
+                  "Decidim::AttachmentCollection",
+                  "Decidim::Blogs::Post",
+                  "Decidim::Budgets::Project",
+                  "Decidim::Comments::Comment",
+                  "Decidim::Conferences::MediaLink",
+                  "Decidim::Conferences::Partner",
+                  "Decidim::Debates::Debate",
+                  "Decidim::Categorization",
+                  "Decidim::Categorization",
+                  "Decidim::Forms::Questionnaire",
+                  "Decidim::UserBaseEntity",
+      ]
       log! "Cleaning item_types : #{elements.join(", ")}"
 
       total = 0
@@ -20,7 +32,7 @@ module Decidim
         versions.destroy_all
       end
 
-      log! "#{total} users have been removed"
+      log! "#{total} versions have been removed"
     end
   end
 end

--- a/app/views/decidim/system/dashboard/show.html.erb
+++ b/app/views/decidim/system/dashboard/show.html.erb
@@ -1,0 +1,11 @@
+<% provide :title do %>
+  <h2><%= t("decidim.system.titles.dashboard.title") %></h2>
+  <h3><%= t ".current_organizations" %></h3>
+  <%= render partial: "decidim/system/shared/organizations_list", locals: { organizations: @organizations } %>
+  <div class="header">
+    <h3><%= I18n.t("decidim.system.titles.dashboard.info.title") %></h3>
+    <div>
+      <p><%= I18n.t("decidim.system.titles.dashboard.info.db_size", db_size: @db_size) %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/system/dashboard/show.html.erb
+++ b/app/views/decidim/system/dashboard/show.html.erb
@@ -2,10 +2,11 @@
   <h2><%= t("decidim.system.titles.dashboard.title") %></h2>
   <h3><%= t ".current_organizations" %></h3>
   <%= render partial: "decidim/system/shared/organizations_list", locals: { organizations: @organizations } %>
-  <div class="header">
-    <h3><%= I18n.t("decidim.system.titles.dashboard.info.title") %></h3>
-    <div>
-      <p><%= I18n.t("decidim.system.titles.dashboard.info.db_size", db_size: @db_size) %></p>
-    </div>
-  </div>
 <% end %>
+<div class="header">
+  <h3><%= I18n.t("decidim.system.titles.dashboard.info.title") %></h3>
+  <div>
+    <p><%= I18n.t("decidim.system.titles.dashboard.info.db_size", db_size: @db_size) %></p>
+    <p><%= I18n.t("decidim.system.titles.dashboard.info.decidim_version", version: Decidim.version) %></p>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -166,5 +166,7 @@ ignore_unused:
   - decidim.events.proposals.author_confirmation_proposal_event.email_intro
   - decidim.events.proposals.author_confirmation_proposal_event.email_outro
   - decidim.events.proposals.author_confirmation_proposal_event.notification_title
+  - decidim.system.titles.{dashboard,title}
+  - decidim.system.titles.info.*
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,12 @@ en:
             client_id: Client ID
             client_secret: Client secret
             site_url: Site URL
+      titles:
+        dashboard: Dashboard
+        info:
+          db_size: 'Database size: %{db_size}'
+          title: General informations
+        title:
     verifications:
       authorizations:
         create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
         dashboard: Dashboard
         info:
           db_size: 'Database size: %{db_size}'
+          decidim_version: 'Decidim version: v%{version}'
           title: General informations
         title:
     verifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,9 @@ en:
         please_sign_in: Please sign in
         sign_up: Sign up
     system:
+      dashboard:
+        show:
+          current_organizations: Current organizations
       organizations:
         omniauth_settings:
           france_connect:
@@ -242,12 +245,12 @@ en:
             client_secret: Client secret
             site_url: Site URL
       titles:
-        dashboard: Dashboard
-        info:
-          db_size: 'Database size: %{db_size}'
-          decidim_version: 'Decidim version: v%{version}'
-          title: General informations
-        title:
+        dashboard:
+          info:
+            db_size: 'Database size: %{db_size}'
+            decidim_version: 'Decidim version: v%{version}'
+            title: General informations
+          title: Dashboard
     verifications:
       authorizations:
         create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -208,6 +208,9 @@ fr:
         please_sign_in: Veuillez vous connecter
         sign_up: Créer un compte
     system:
+      dashboard:
+        show:
+          current_organizations: Organisations
       organizations:
         omniauth_settings:
           france_connect:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -247,6 +247,7 @@ fr:
         dashboard:
           info:
             db_size: 'Poids base de données: %{db_size}'
+            decidim_version: 'Decidim version: v%{version}'
             title: Informations générales
           title: Tableau de bord système
     verifications:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -243,6 +243,12 @@ fr:
             client_id: Client ID
             client_secret: Client secret
             site_url: Site URL
+      titles:
+        dashboard:
+          info:
+            db_size: 'Poids base de données: %{db_size}'
+            title: Informations générales
+          title: Tableau de bord système
     verifications:
       authorizations:
         create:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,6 +23,10 @@ default: &default
     authorizations:
       export_data_to_userdata_enabled_for: <%= ENV.fetch("AUTO_EXPORT_AUTHORIZATIONS_DATA_TO_USER_DATA_ENABLED_FOR", "") %>
     currency: <%= ENV["CURRENCY"] || "€" %>
+    database:
+      versions:
+        clean:
+          retention: <%= ENV.fetch("DECIDIM_DB_VERSIONS_RETENTION", "6")&.to_i %>
     half_signup:
       show_tos_page_after_signup: <%= ENV.fetch("DECIDIM_HALF_SIGNUP_SHOW_TOS_PAGE_AFTER_SIGNUP", "true") == "true" %>
     initiatives:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -79,3 +79,7 @@
       cron: "0 9 0 * * *"
       class: Decidim::Cleaner::CleanDeletedUsersDataJob
       queue: scheduled
+    PapertrailCleanVersions:
+      cron: '0 0 3 * * *'
+      class: Decidim::PapertrailVersionJob
+      queue: default

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,10 +42,10 @@ namespace :decidim do
       desc "Clean versions"
       task clean: :environment do
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Executing PapertrailVersionsJob..."
-        expiration = ENV.fetch("DECIDIM_DB_VERSIONS_EXPIRATION", "6")&.to_i
-        expiration = expiration.months.ago
-        puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Clean versions created before #{expiration.strftime("%d-%m-%Y %H:%M:%S")}..."
-        Decidim::PapertrailVersionsJob.perform_later(expiration)
+        retention = ENV.fetch("DECIDIM_DB_VERSIONS_RETENTION", "6")&.to_i
+        retention = retention.months.ago
+        puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Clean versions created before #{retention.strftime("%d-%m-%Y %H:%M:%S")}..."
+        Decidim::PapertrailVersionsJob.perform_later(retention)
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Job delayed to Sidekiq."
       end
     end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -37,5 +37,12 @@ namespace :decidim do
         Decidim::SurveysService.new(verbose: true).clear
       end
     end
+
+    namespace :versions do
+      desc "Clean versions"
+      task clean: :environment do
+        Decidim::PapertrailVersionsJob.perform_later
+      end
+    end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -41,7 +41,9 @@ namespace :decidim do
     namespace :versions do
       desc "Clean versions"
       task clean: :environment do
+        puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Executing PapertrailVersionsJob..."
         Decidim::PapertrailVersionsJob.perform_later
+        puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Job delayed to Sidekiq."
       end
     end
   end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,7 +42,7 @@ namespace :decidim do
       desc "Clean versions"
       task clean: :environment do
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Executing PapertrailVersionsJob..."
-        retention = ENV.fetch("DECIDIM_DB_VERSIONS_RETENTION", "6")&.to_i
+        retention = Rails.application.secrets.dig(:decidim, :database, :versions, :clean, :retention)
         retention = retention.months.ago
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Clean versions created before #{retention.strftime("%d-%m-%Y %H:%M:%S")}..."
         Decidim::PapertrailVersionsJob.perform_later(retention)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,7 +42,10 @@ namespace :decidim do
       desc "Clean versions"
       task clean: :environment do
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Executing PapertrailVersionsJob..."
-        Decidim::PapertrailVersionsJob.perform_later
+        expiration = ENV.fetch("DECIDIM_DB_VERSIONS_EXPIRATION", "6")&.to_i
+        expiration = expiration.months.ago
+        puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Clean versions created before #{expiration.strftime("%d-%m-%Y %H:%M:%S")}..."
+        Decidim::PapertrailVersionsJob.perform_later(expiration)
         puts "(decidim:db:versions:clean) #{Time.current.strftime("%d-%m-%Y %H:%M:%S")}> Job delayed to Sidekiq."
       end
     end

--- a/spec/jobs/decidim/papertrail_versions_job_spec.rb
+++ b/spec/jobs/decidim/papertrail_versions_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe PapertrailVersionsJob do
+    let!(:valid_versions) { create_list(:paper_trail_version, 10, item_id: 10) }
+    let!(:invalid_versions) { create_list(:paper_trail_version, 10, item_id: 10, item_type: item_type, created_at: created_at) }
+    let(:item_type) { "Decidim::UserBaseEntity" }
+    let(:created_at) { 8.months.ago }
+
+    it "removes invalid versions" do
+      expect do
+        described_class.perform_now
+      end.to change(PaperTrail::Version, :count).from(20).to(10)
+    end
+
+    it "allows to set the expiration limit" do
+      expect do
+        described_class.perform_now(11.months.ago)
+      end.not_to change(PaperTrail::Version, :count)
+    end
+
+    context "when no versions older than 6 months" do
+      let(:created_at) { 1.day.ago }
+
+      it "do not remove any papertrail version" do
+        expect do
+          described_class.perform_now
+        end.not_to change(PaperTrail::Version, :count)
+      end
+    end
+  end
+end

--- a/spec/jobs/decidim/papertrail_versions_job_spec.rb
+++ b/spec/jobs/decidim/papertrail_versions_job_spec.rb
@@ -30,5 +30,40 @@ module Decidim
         end.not_to change(PaperTrail::Version, :count)
       end
     end
+
+    describe "#retention" do
+      subject { described_class.new.send(:retention, retention) }
+      let(:retention) { 8.months.ago }
+
+      it "returns the defined retention" do
+        expect(subject).to eq(retention)
+      end
+
+      context "when retention isn't a Date" do
+        let(:retention) { 8 }
+
+        it "returns default value" do
+          expect(subject.strftime("%d-%m-%Y")).to eq(6.months.ago.strftime("%d-%m-%Y"))
+        end
+      end
+
+      context "when retention is blank" do
+        let(:retention) { nil }
+
+        it "returns default value" do
+          expect(subject.strftime("%d-%m-%Y")).to eq(6.months.ago.strftime("%d-%m-%Y"))
+        end
+      end
+    end
+
+    describe "#item_types" do
+      subject { described_class.new.send(:item_types) }
+
+      it "does not includes Proposals nor Initiatives" do
+        expect(subject).not_to include("Decidim::Proposals::Proposal")
+        expect(subject).not_to include("Decidim::Proposals::CollaborativeDraft")
+        expect(subject).not_to include("Decidim::Initiative")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

PaperTrail Versions are never cleaned in database. These versions are created whenever a resource is created or updated and Decidim.traceability configured.
These versions are accessible in front for proposals and initiatives.

This PR add a new rake task to be able to clear versions table and also a new Job configured to run every day at 3 AM with Sidekiq.

Command : `bundle exec rake decidim:db:versions:clean`

By default, retention period is set to 6 months. Newer version won't be removed.
It is editable through env var `DECIDIM_DB_VERSIONS_RETENTION=6`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to IndieHosters Database Weight

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Run rails console
* Get existing versions : `PaperTrail::Version.all.count`
* `Decidim::PapertrailVersionsJob.perform_now(1.minute.ago)`
* Check changes : `PaperTrail::Version.all.count`

#### Tasks
- [x] Add specs
- [x] Add rake task
- [x] Add Sidekiq cron task
