### PR TITLE
fix: Ensure coordinates from address field are not replaced

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -8,3 +8,4 @@ require "extends/lib/decidim/phone_authorization_handler/proposal_serializer_ext
 
 require "decidim/exporters/serializer"
 require "extends/lib/decidim/forms/user_answers_serializer_extend"
+require "extends/lib/decidim/geocoding/geocoder_coordinates_extends"

--- a/lib/extends/lib/decidim/geocoding/geocoder_coordinates_extends.rb
+++ b/lib/extends/lib/decidim/geocoding/geocoder_coordinates_extends.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GeocoderCoordinatesExtends
+  def coordinates(address, options = {})
+    if address.to_s.match?(/^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/)
+      address_parts = address.to_s.split(/\s*,\s*/)
+      [address_parts[0].to_f, address_parts[1].to_f]
+    elsif (results = search(address, options)).size.positive?
+      results.first.coordinates
+    end
+  end
+end
+
+Geocoder.singleton_class.class_eval do
+  prepend(GeocoderCoordinatesExtends)
+end

--- a/spec/lib/map/geocoding_spec.rb
+++ b/spec/lib/map/geocoding_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Map
+    module Provider
+      module Geocoding
+        # A dummy geocoding provider to test the geocoding utility.
+        class Test < ::Decidim::Map::Geocoding; end
+      end
+    end
+
+    describe Geocoding do
+      include_context "with map utility" do
+        subject { utility }
+
+        let(:utility_class) { Provider::Geocoding::Test }
+      end
+
+      after do
+        Geocoder::Lookup::Test.reset
+      end
+
+      describe "#initialize" do
+        let(:config) { { foo: "bar" } }
+
+        it "configures Geocoder with the correct lookup configuration" do
+          expected_config = {
+            foo: "bar",
+            http_headers: { "Referer" => organization.host }
+          }
+
+          expect(Geocoder).to receive(:configure).with(
+            test: expected_config
+          )
+          expect(subject).to be_a(described_class)
+          expect(subject.configuration).to eq(expected_config)
+        end
+      end
+
+      describe "#handle" do
+        it "returns the correct dummy provider's handle" do
+          expect(subject.handle).to eq(:test)
+        end
+      end
+
+      describe "#search" do
+        let(:query) { double }
+        let(:options) { { foo: "bar" } }
+
+        it "calls the Geocoder.search method with correct arguments" do
+          expect(Geocoder).to receive(:search).with(
+            query,
+            { lookup: :test, language: "en" }.merge(options)
+          )
+
+          subject.search(query, options)
+        end
+      end
+
+      describe "#coordinates" do
+        let(:query) { double }
+        let(:options) { { foo: "bar" } }
+
+        it "calls the Geocoder.coordinates method with correct arguments" do
+          expect(Geocoder).to receive(:coordinates).with(
+            query,
+            { lookup: :test, language: "en" }.merge(options)
+          )
+
+          subject.coordinates(query, options)
+        end
+      end
+
+      describe "#address" do
+        let(:query) { double }
+        let(:options) { { foo: "bar" } }
+
+        it "calls the Geocoder.search method with correct arguments" do
+          allow(Geocoder).to receive(:search).with(
+            query,
+            { lookup: :test, language: "en" }.merge(options)
+          ).and_return([])
+
+          subject.address(query, options)
+        end
+      end
+
+      context "with geocoder stubs" do
+        let(:geocoder_search) { "New York, NY" }
+        let(:geocoder_results) do
+          [
+            {
+              "coordinates" => [40.7143528, -74.0059731],
+              "address" => "New York, NY, USA",
+              "state" => "New York",
+              "state_code" => "NY",
+              "country" => "United States",
+              "country_code" => "US"
+            }
+          ]
+        end
+
+        before do
+          Geocoder::Lookup::Test.add_stub(geocoder_search, geocoder_results)
+        end
+
+        describe "#search" do
+          it "returns the geocoder stubbed results" do
+            results = subject.search(geocoder_search)
+            expect(results.length).to be(geocoder_results.length)
+
+            geocoder_results.each_with_index do |result_values, ind|
+              result = results[ind]
+              result_values.each do |key, value|
+                expect(result.public_send(key)).to eq(value)
+              end
+            end
+          end
+        end
+
+        describe "#coordinates" do
+          it "returns the geocoder stubbed first result" do
+            expect(
+              subject.coordinates(geocoder_search)
+            ).to eq([40.7143528, -74.0059731])
+          end
+
+          context "with coordinate strings" do
+            let(:geocoder_search) { "40.7143528, -74.0059731" }
+
+            it "parses the string and returns the correct coordinates" do
+              expect(subject.coordinates("40.7143528, -74.0059731")).to eq([40.7143528, -74.0059731])
+              expect(
+                subject.address(geocoder_search)
+              ).to eq("New York, NY, USA")
+            end
+
+            it "raises an error if the coordinates are not valid" do
+              expect { subject.coordinates("40.7143528,, -74.0059731") }.to raise_error(ArgumentError)
+              expect { subject.coordinates("40,7143528, -74,0059731") }.to raise_error(ArgumentError)
+            end
+          end
+        end
+
+        describe "#address" do
+          let(:geocoder_search) { [40.7143528, -74.0059731] }
+
+          it "returns the geocoder stubbed first result" do
+            expect(
+              subject.address(geocoder_search)
+            ).to eq("New York, NY, USA")
+          end
+
+          context "with multiple results" do
+            let(:geocoder_search) { [40.7143528, -74.0059731] }
+            let(:geocoder_results) do
+              [
+                {
+                  "coordinates" => [60.169857, 24.938379],
+                  "address" => "Helsinki, Finland",
+                  "state" => "Uusimaa",
+                  "state_code" => "",
+                  "country" => "Finland",
+                  "country_code" => "FI"
+                },
+                {
+                  "coordinates" => [41.385063, 2.173404],
+                  "address" => "Barcelona, Barcelona, Spain",
+                  "state" => "Barcelona",
+                  "state_code" => "",
+                  "country" => "Spain",
+                  "country_code" => "ES"
+                },
+                {
+                  "coordinates" => [40.7143520, -74.0059732],
+                  "address" => "Closest Result, New York, NY, USA",
+                  "state" => "New York",
+                  "state_code" => "NY",
+                  "country" => "United States",
+                  "country_code" => "US"
+                },
+                {
+                  "coordinates" => [52.520008, 13.404954],
+                  "address" => "Berlin, Berlin, Germany",
+                  "state" => "Berlin",
+                  "state_code" => "",
+                  "country" => "Germany",
+                  "country_code" => "DE"
+                }
+              ]
+            end
+
+            it "returns the closest result" do
+              expect(
+                subject.address(geocoder_search)
+              ).to eq("Closest Result, New York, NY, USA")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description

This PR fixes the behavior of the Geocoding gem, which automatically searches for the address provided in the address field even when it contains the coordinates being searched for. When you placed a point that was not named by the DB of OpenStreetMap you were directly redirected through a road or a place "known" by the Nominatim feature of the provider.

To address this issue, a condition has been added to the coordinates method in the geocoder helper. The condition uses a regex to check if the address matches the format of coordinates `latitude, longitude`. If it does, the method simply returns the coordinates as they are. Otherwise, it proceeds with the normal search behavior.

#### :pushpin: Related Issues
- [Problème avec les coordonées GPS dans les rencontres](https://opensourcepolitics.odoo.com/web?db=opensourcepolitics&signup_email=guillaume%40opensourcepolitics.eu&token=ixqNZ9S5lGRCj9ADpsQq#id=3323&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to participatory processes
* Go to a proposal component of the process and activate the geocoding

* Access this proposal on front-end
* Try to create a proposal with few scenarios

### Scenario 1 - With a plain address
* Put a plain address in the address field (not coordinates but the address)
* Try to create a draft from this proposal
* Make sure it's located correctly on the map
* Publish this proposal and make sure it appears correctly on the map on the index of the proposals

### Scenario 2 - With coordinates (with the "basic" format)
* Navigate to OpenStreetMap
* Choose a place you might now and choose a coordinate (to test the behavior you may want to choose a place which is not named by the DB of OpenStreetMap like the middle of a forest or the ocean)
* It might match the format `0.0, 0.0` otherwise it won't work but you still can try to break the feature
* Try to create the draft and verify that you were not replaced to a different place that you had on your OpenStreetMap
* Try to publish the proposal and make sure it appears correctly on the map on the index of the proposals

### Scenario 3 - With coordinates (but a "tricky" format)
* Navigate to OpenStreetMap
* Choose a place you might now and choose a coordinate but make sure this time to pick a place like `40, 3` (with plain coordinates, it can be one of them or both you can try everything)
* Try to create the draft and verify that you were not replaced to a different place that you had on your OpenStreetMap
* Try to publish the proposal and make sure it appears correctly on the map on the index of the proposals

#### Tasks
- [x] Add specs (L-130 to L-145)
- [x] Extend the Geocoder's gem coordinated method
