### PR TITLE
feat: Creation of a rake task to delete duplicated half signup users

### DIFF
--- a/app/jobs/clear_duplicated_half_signup_users_job.rb
+++ b/app/jobs/clear_duplicated_half_signup_users_job.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/Output
+class ClearDuplicatedHalfSignupUsersJob < ApplicationJob
+  include Decidim::Logging
+
+  def perform
+    duplicated_numbers = find_duplicated_phone_numbers
+    return puts("No duplicated phone numbers found") if duplicated_numbers.empty?
+
+    duplicated_numbers.each do |phone_info|
+      phone_number, phone_country = phone_info
+
+      users_with_phone = Decidim::User.where(phone_number: phone_number, phone_country: phone_country)
+      quick_auth_users = users_with_phone.select { |user| user.email.include?("quick_auth") }
+      other_users = users_with_phone.reject { |user| user.email.include?("quick_auth") }
+
+      quick_auth_users.each { |user| soft_delete_user(user, "Duplicated account") }
+
+      alert_about_duplicated_numbers(phone_number, other_users) if other_users.map(&:email).uniq.size > 1
+    end
+  end
+
+  private
+
+  def find_duplicated_phone_numbers
+    Decidim::User
+      .where.not(phone_number: [nil, ""])
+      .where.not(phone_country: [nil, ""])
+      .group(:phone_number, :phone_country)
+      .having("count(*) > 1")
+      .pluck(:phone_number, :phone_country)
+  end
+
+  def soft_delete_user(user, reason)
+    if user.email.include?("quick_auth")
+      user.update(phone_number: nil, phone_country: nil)
+
+      form = Decidim::DeleteAccountForm.from_params(delete_reason: reason)
+      previous_email = user.email
+      Decidim::DestroyAccount.call(user, form) do
+        on(:ok) do
+          log!("User #{user.id} (#{previous_email}) has been deleted", :info)
+          puts("User #{user.id} (#{previous_email}) has been deleted")
+        end
+        on(:invalid) do
+          log!("Failed to delete user #{user.id} (#{user.email}): #{form.errors.full_messages}", :warn)
+          puts("Failed to delete user #{user.id} (#{user.email}): #{form.errors.full_messages}")
+        end
+      end
+    else
+      log!("Not a Quick Auth account, skipping deletion", :info)
+      puts("Not a Quick Auth account, skipping deletion")
+    end
+  end
+
+  def alert_about_duplicated_numbers(phone_number, users)
+    obfuscated_number = obfuscate_phone_number(phone_number)
+    emails = users.map(&:email)
+    email_pairs = emails.each_slice(2).map { |pair| pair.join(" | ") }
+
+    message = <<~MSG
+      \nALERT: Duplicated Phone Number Detected!
+
+      Phone Number: #{obfuscated_number}
+      Users with this number:
+      #{email_pairs.join("\n")}
+    MSG
+
+    log!(message, :warn)
+    puts(message)
+  end
+
+  def obfuscate_phone_number(phone_number)
+    return "No phone number" if phone_number.blank?
+
+    visible_prefix = phone_number[0..1]
+    visible_suffix = phone_number[-2..]
+    obfuscated_middle = "*" * (phone_number.length - 4)
+
+    visible_prefix + obfuscated_middle + visible_suffix
+  end
+end
+# rubocop:enable Rails/Output

--- a/app/jobs/concerns/decidim/logging.rb
+++ b/app/jobs/concerns/decidim/logging.rb
@@ -5,13 +5,20 @@ module Decidim
     private
 
     def log!(msg, level = :warn)
-      msg = "(#{self.class}) #{Time.current.strftime("%d-%m-%Y %H:%M")}> #{msg}"
+      msg = "(#{self.class})> #{msg}"
+
       case level
       when :info
         Rails.logger.info msg
+        stdout_logger.info msg unless Rails.env.test?
       else
         Rails.logger.warn msg
+        stdout_logger.warn msg unless Rails.env.test?
       end
+    end
+
+    def stdout_logger
+      @stdout_logger ||= Logger.new($stdout)
     end
   end
 end

--- a/app/jobs/decidim/papertrail_versions_job.rb
+++ b/app/jobs/decidim/papertrail_versions_job.rb
@@ -18,7 +18,7 @@ module Decidim
         versions.destroy_all
       end
 
-      log! "#{total} versions have been removed"
+      log! "#{total} versions removed"
     end
 
     private

--- a/lib/tasks/clear_duplicated_users.rake
+++ b/lib/tasks/clear_duplicated_users.rake
@@ -3,6 +3,8 @@
 namespace :decidim do
   desc "Clear duplicated users with the same phone_numbers in the database"
   task clear_duplicated_users: :environment do
+    include Decidim::Logging
+
     ClearDuplicatedHalfSignupUsersJob.perform_now
   end
 end

--- a/lib/tasks/clear_duplicated_users.rake
+++ b/lib/tasks/clear_duplicated_users.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  desc "Clear duplicated users with the same phone_numbers in the database"
+  task clear_duplicated_users: :environment do
+    ClearDuplicatedHalfSignupUsersJob.perform_now
+  end
+end

--- a/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
+++ b/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ClearDuplicatedHalfSignupUsersJob do
+    let!(:user1) { create(:user, phone_number: "1234567890", phone_country: "US", email: "user1@example.com") }
+    let!(:user2) { create(:user, phone_number: "1234567890", phone_country: "US", email: "quick_auth_user@example.com") }
+    let!(:user3) { create(:user, phone_number: "1234567890", phone_country: "US", email: "user3@example.com") }
+    let!(:user4) { create(:user, phone_number: "9876543210", phone_country: "US", email: "user4@example.com") }
+
+    before do
+      allow_any_instance_of(Decidim::DestroyAccount).to receive(:call).and_return(true)
+    end
+
+    describe "#perform" do
+      context "when no duplicated phone numbers are found" do
+        it "prints that no duplicated phone numbers are found" do
+          allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:find_duplicated_phone_numbers).and_return([])
+
+          expect { ClearDuplicatedHalfSignupUsersJob.perform_now }.to output(/No duplicated phone numbers found/).to_stdout
+        end
+      end
+
+      context "when duplicated phone numbers are found" do
+        before do
+          user1
+          user2
+          user3
+        end
+
+        it "soft deletes quick_auth users" do
+          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:soft_delete_user).with(user2, "Duplicated account")
+
+          ClearDuplicatedHalfSignupUsersJob.perform_now
+        end
+
+        it "alerts about duplicated phone numbers for non-quick_auth users" do
+          expect(Rails.logger).to receive(:warn).with(/ALERT: Duplicated Phone Number Detected/)
+
+          ClearDuplicatedHalfSignupUsersJob.perform_now
+        end
+
+        it "does not soft delete non quick_auth users" do
+          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user1, "Duplicated account")
+
+          ClearDuplicatedHalfSignupUsersJob.perform_now
+        end
+
+        it "does not soft delete users with different phone numbers" do
+          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user4, "Duplicated account")
+
+          ClearDuplicatedHalfSignupUsersJob.perform_now
+        end
+      end
+    end
+
+    describe "#soft_delete_user" do
+      let(:user) { create(:user, phone_number: "1234567890", phone_country: "US", email: "quick_auth_user@example.com") }
+
+      it "updates the user to nullify the phone number and country" do
+        expect(user).to receive(:update).with(phone_number: nil, phone_country: nil)
+
+        subject.send(:soft_delete_user, user, "Duplicated account")
+      end
+
+      it "calls the Decidim::DestroyAccount service to delete the user" do
+        allow_any_instance_of(Decidim::DestroyAccount).to receive(:call).and_return(true)
+
+        subject.send(:soft_delete_user, user, "Duplicated account")
+      end
+
+      it "does not delete a non-quick_auth account" do
+        user_with_diff_email = create(:user, phone_number: "1234567890", phone_country: "US", email: "user_diff@example.com")
+
+        expect_any_instance_of(Decidim::DestroyAccount).not_to receive(:call)
+        expect(Rails.logger).to receive(:info).with(/Not a Quick Auth account, skipping deletion/)
+
+        subject.send(:soft_delete_user, user_with_diff_email, "Duplicated account")
+      end
+    end
+
+    describe "#alert_about_duplicated_numbers" do
+      let(:users) { [user1, user2, user3] }
+
+      it "obfuscates the phone number and logs an alert message" do
+        obfuscated_number = "12****90"
+        allow(subject).to receive(:obfuscate_phone_number).with("1234567890").and_return(obfuscated_number)
+        expect(Rails.logger).to receive(:warn).with(/ALERT: Duplicated Phone Number Detected/)
+
+        subject.send(:alert_about_duplicated_numbers, "1234567890", users)
+      end
+
+      it "logs the correct message with the obfuscated phone number" do
+        obfuscated_number = "12****90"
+        allow(subject).to receive(:obfuscate_phone_number).with("1234567890").and_return(obfuscated_number)
+
+        allow(Rails.logger).to receive(:warn) { |message|
+          expect(message).to include("Phone Number: #{obfuscated_number}")
+        }
+
+        subject.send(:alert_about_duplicated_numbers, "1234567890", users)
+      end
+    end
+
+    describe "#obfuscate_phone_number" do
+      it "returns an obfuscated phone number with visible prefix and suffix" do
+        result = subject.send(:obfuscate_phone_number, "1234567890")
+
+        expect(result).to eq("12******90")
+      end
+
+      it 'returns "No phone number" if the phone number is blank' do
+        result = subject.send(:obfuscate_phone_number, "")
+
+        expect(result).to eq("No phone number")
+      end
+
+      it 'returns "No phone number" when given nil' do
+        result = subject.send(:obfuscate_phone_number, nil)
+
+        expect(result).to eq("No phone number")
+      end
+    end
+
+    describe "#find_duplicated_phone_numbers" do
+      context "when there are duplicates" do
+        it "finds duplicated phone numbers" do
+          user1
+          user2
+          user3
+
+          result = subject.send(:find_duplicated_phone_numbers)
+
+          expect(result).to include(%w(1234567890 US))
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
+++ b/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
@@ -4,89 +4,115 @@ require "spec_helper"
 
 module Decidim
   describe ClearDuplicatedHalfSignupUsersJob do
-    let!(:user1) { create(:user, phone_number: "1234567890", phone_country: "US", email: "user1@example.com") }
-    let!(:user2) { create(:user, phone_number: "1234567890", phone_country: "US", email: "quick_auth_user@example.com") }
-    let!(:user3) { create(:user, phone_number: "1234567890", phone_country: "US", email: "user3@example.com") }
-    let!(:user4) { create(:user, phone_number: "9876543210", phone_country: "US", email: "user4@example.com") }
+    subject { described_class.perform_now }
+
+    let!(:dup_user1) { create(:user, phone_number: "1234", phone_country: "US", email: "user1@example.com") }
+    let!(:dup_user2) { create(:user, phone_number: "1234", phone_country: "US", email: "quick_auth_user@example.com") }
+    let!(:dup_user3) { create(:user, phone_number: "1234", phone_country: "US", email: "user3@example.com") }
+    let(:dup_user4) do
+      dup_user4 = build(:user, phone_number: "1234", phone_country: "US", email: "")
+      dup_user4.save(validate: false)
+      dup_user4
+    end
+    let!(:user5) { create(:user, phone_number: "6789", phone_country: "US", email: "user5@example.com") }
+    let(:delete_reason) { "HalfSignup duplicated account (#{current_date})" }
+    let(:current_date) { Date.current.strftime "%Y-%m-%d" }
 
     before do
-      allow_any_instance_of(Decidim::DestroyAccount).to receive(:call).and_return(true)
-      allow(Rails.logger).to receive(:warn)
-      allow(Rails.logger).to receive(:info)
+      allow(Decidim::Logging).to receive(:stdout_logger).and_return(Logger.new(StringIO.new))
     end
 
     describe "#perform" do
-      context "when no duplicated phone numbers are found" do
-        it "prints that no duplicated phone numbers are found" do
-          allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:find_duplicated_phone_numbers).and_return([])
-
-          expect { described_class.perform_now }.to output(/No duplicated phone numbers found/).to_stdout
-        end
+      it "soft deletes quick_auth users" do
+        expect(dup_user2.delete_reason).to be_nil
+        subject
+        dup_user1.reload
+        dup_user2.reload
+        dup_user3.reload
+        expect(dup_user1.delete_reason).to be_nil
+        expect(dup_user3.delete_reason).to be_nil
+        expect(dup_user2.delete_reason).to eq("HalfSignup duplicated account (#{current_date})")
+        expect(dup_user2.extended_data).to include("half_signup" => { "email" => "quick_auth_user@example.com", "phone_number" => "1234", "phone_country" => "US" })
       end
 
-      context "when duplicated phone numbers are found" do
-        before do
-          allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:find_duplicated_phone_numbers).and_return([%w(1234567890 US)])
-        end
+      it "does not soft delete non quick_auth users" do
+        expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(dup_user1, delete_reason)
 
-        it "soft deletes quick_auth users" do
-          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:soft_delete_user).with(user2, "Duplicated account")
+        subject
+      end
+    end
 
-          described_class.perform_now
-        end
+    describe "#clear_data" do
+      let(:object) do
+        obj = described_class.new
+        obj.instance_variable_set(:@dup_half_signup_count, 0)
+        obj.instance_variable_set(:@dup_decidim_users_count, 0)
+        obj
+      end
 
-        it "alerts about duplicated phone numbers for non-quick_auth users" do
-          expect(Rails.logger).to receive(:warn).with(/ALERT: Duplicated Phone Number Detected/)
+      it "clears the phone number and country of the users" do
+        expect(dup_user1.phone_number).to eq("1234")
+        expect(dup_user1.phone_country).to eq("US")
+        object.send(:clear_data, [dup_user1, dup_user3])
+        dup_user1.reload
 
-          described_class.perform_now
-        end
+        expect(dup_user1.phone_number).to be_nil
+        expect(dup_user1.phone_country).to be_nil
+        expect(dup_user1.extended_data).to include("half_signup" => {
+                                                     "phone_number" => "1234",
+                                                     "phone_country" => "US"
+                                                   })
+        expect(object.instance_variable_get(:@dup_half_signup_count)).to eq(0)
+        expect(object.instance_variable_get(:@dup_decidim_users_count)).to eq(2)
+      end
 
-        it "does not soft delete non quick_auth users" do
-          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user1, "Duplicated account")
+      context "when user is not half signup and email is empty" do
+        it "does clear the phone number and country of the user" do
+          expect(dup_user4.phone_number).to eq("1234")
+          expect(dup_user4.phone_country).to eq("US")
+          object.send(:clear_data, [dup_user4])
+          dup_user4.reload
 
-          described_class.perform_now
-        end
-
-        it "does not soft delete users with different phone numbers" do
-          expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user4, "Duplicated account")
-
-          described_class.perform_now
+          expect(dup_user4.phone_number).to be_nil
+          expect(dup_user4.phone_country).to be_nil
+          expect(dup_user4.extended_data).to include("half_signup" => {
+                                                       "phone_number" => "1234",
+                                                       "phone_country" => "US"
+                                                     })
+          expect(object.instance_variable_get(:@dup_half_signup_count)).to eq(0)
+          expect(object.instance_variable_get(:@dup_decidim_users_count)).to eq(1)
         end
       end
     end
 
     describe "#soft_delete_user" do
-      let(:user) { create(:user, phone_number: "1234567890", phone_country: "US", email: "quick_auth_user@example.com") }
-
       it "updates the user to nullify the phone number and country" do
-        expect(user).to receive(:update).with(phone_number: nil, phone_country: nil)
+        expect(dup_user2.phone_number).to eq("1234")
+        expect(dup_user2.phone_country).to eq("US")
+        described_class.new.send(:soft_delete_user, dup_user2, delete_reason)
+        dup_user2.reload
 
-        described_class.new.send(:soft_delete_user, user, "Duplicated account")
+        expect(dup_user2.phone_number).to be_nil
+        expect(dup_user2.phone_country).to be_nil
+        expect(dup_user2.extended_data).to include("half_signup" => {
+                                                     "email" => "quick_auth_user@example.com",
+                                                     "phone_number" => "1234",
+                                                     "phone_country" => "US"
+                                                   })
       end
 
-      it "calls the Decidim::DestroyAccount service to delete the user" do
+      it "calls the Decidim::DestroyAccount service to delete the half signup user" do
         expect_any_instance_of(Decidim::DestroyAccount).to receive(:call)
 
-        described_class.new.send(:soft_delete_user, user, "Duplicated account")
+        described_class.new.send(:soft_delete_user, dup_user2, delete_reason)
       end
 
       it "does not delete a non-quick_auth account" do
-        user_with_diff_email = create(:user, phone_number: "1234567890", phone_country: "US", email: "user_diff@example.com")
+        user_with_diff_email = create(:user, phone_number: "1234", phone_country: "US", email: "user_diff@example.com")
 
         expect_any_instance_of(Decidim::DestroyAccount).not_to receive(:call)
-        expect(Rails.logger).to receive(:info).with(/Not a Quick Auth account, skipping deletion/)
 
-        described_class.new.send(:soft_delete_user, user_with_diff_email, "Duplicated account")
-      end
-    end
-
-    describe "#alert_about_duplicated_numbers" do
-      let(:users) { [user1, user2, user3] }
-
-      it "obfuscates the phone number and logs an alert message" do
-        allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:obfuscate_phone_number).with("1234567890").and_return("12****90")
-
-        described_class.new.send(:generate_alert_message, "1234567890", users)
+        described_class.new.send(:soft_delete_user, user_with_diff_email, delete_reason)
       end
     end
 
@@ -110,15 +136,11 @@ module Decidim
       end
     end
 
-    describe "#find_duplicated_phone_numbers" do
+    describe "#duplicated_phone_numbers" do
       it "finds duplicated phone numbers" do
-        user1
-        user2
-        user3
+        result = described_class.new.send(:duplicated_phone_numbers)
 
-        result = described_class.new.send(:find_duplicated_phone_numbers)
-
-        expect(result).to include(%w(1234567890 US))
+        expect(result).to include(%w(1234 US))
       end
     end
   end

--- a/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
+++ b/spec/jobs/clear_duplicated_half_signup_users_job_spec.rb
@@ -11,6 +11,8 @@ module Decidim
 
     before do
       allow_any_instance_of(Decidim::DestroyAccount).to receive(:call).and_return(true)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:info)
     end
 
     describe "#perform" do
@@ -18,39 +20,37 @@ module Decidim
         it "prints that no duplicated phone numbers are found" do
           allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:find_duplicated_phone_numbers).and_return([])
 
-          expect { ClearDuplicatedHalfSignupUsersJob.perform_now }.to output(/No duplicated phone numbers found/).to_stdout
+          expect { described_class.perform_now }.to output(/No duplicated phone numbers found/).to_stdout
         end
       end
 
       context "when duplicated phone numbers are found" do
         before do
-          user1
-          user2
-          user3
+          allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:find_duplicated_phone_numbers).and_return([%w(1234567890 US)])
         end
 
         it "soft deletes quick_auth users" do
           expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:soft_delete_user).with(user2, "Duplicated account")
 
-          ClearDuplicatedHalfSignupUsersJob.perform_now
+          described_class.perform_now
         end
 
         it "alerts about duplicated phone numbers for non-quick_auth users" do
           expect(Rails.logger).to receive(:warn).with(/ALERT: Duplicated Phone Number Detected/)
 
-          ClearDuplicatedHalfSignupUsersJob.perform_now
+          described_class.perform_now
         end
 
         it "does not soft delete non quick_auth users" do
           expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user1, "Duplicated account")
 
-          ClearDuplicatedHalfSignupUsersJob.perform_now
+          described_class.perform_now
         end
 
         it "does not soft delete users with different phone numbers" do
           expect_any_instance_of(ClearDuplicatedHalfSignupUsersJob).not_to receive(:soft_delete_user).with(user4, "Duplicated account")
 
-          ClearDuplicatedHalfSignupUsersJob.perform_now
+          described_class.perform_now
         end
       end
     end
@@ -61,13 +61,13 @@ module Decidim
       it "updates the user to nullify the phone number and country" do
         expect(user).to receive(:update).with(phone_number: nil, phone_country: nil)
 
-        subject.send(:soft_delete_user, user, "Duplicated account")
+        described_class.new.send(:soft_delete_user, user, "Duplicated account")
       end
 
       it "calls the Decidim::DestroyAccount service to delete the user" do
-        allow_any_instance_of(Decidim::DestroyAccount).to receive(:call).and_return(true)
+        expect_any_instance_of(Decidim::DestroyAccount).to receive(:call)
 
-        subject.send(:soft_delete_user, user, "Duplicated account")
+        described_class.new.send(:soft_delete_user, user, "Duplicated account")
       end
 
       it "does not delete a non-quick_auth account" do
@@ -76,7 +76,7 @@ module Decidim
         expect_any_instance_of(Decidim::DestroyAccount).not_to receive(:call)
         expect(Rails.logger).to receive(:info).with(/Not a Quick Auth account, skipping deletion/)
 
-        subject.send(:soft_delete_user, user_with_diff_email, "Duplicated account")
+        described_class.new.send(:soft_delete_user, user_with_diff_email, "Duplicated account")
       end
     end
 
@@ -84,56 +84,41 @@ module Decidim
       let(:users) { [user1, user2, user3] }
 
       it "obfuscates the phone number and logs an alert message" do
-        obfuscated_number = "12****90"
-        allow(subject).to receive(:obfuscate_phone_number).with("1234567890").and_return(obfuscated_number)
-        expect(Rails.logger).to receive(:warn).with(/ALERT: Duplicated Phone Number Detected/)
+        allow_any_instance_of(ClearDuplicatedHalfSignupUsersJob).to receive(:obfuscate_phone_number).with("1234567890").and_return("12****90")
 
-        subject.send(:alert_about_duplicated_numbers, "1234567890", users)
-      end
-
-      it "logs the correct message with the obfuscated phone number" do
-        obfuscated_number = "12****90"
-        allow(subject).to receive(:obfuscate_phone_number).with("1234567890").and_return(obfuscated_number)
-
-        allow(Rails.logger).to receive(:warn) { |message|
-          expect(message).to include("Phone Number: #{obfuscated_number}")
-        }
-
-        subject.send(:alert_about_duplicated_numbers, "1234567890", users)
+        described_class.new.send(:generate_alert_message, "1234567890", users)
       end
     end
 
     describe "#obfuscate_phone_number" do
       it "returns an obfuscated phone number with visible prefix and suffix" do
-        result = subject.send(:obfuscate_phone_number, "1234567890")
+        result = described_class.new.send(:obfuscate_phone_number, "1234567890")
 
         expect(result).to eq("12******90")
       end
 
       it 'returns "No phone number" if the phone number is blank' do
-        result = subject.send(:obfuscate_phone_number, "")
+        result = described_class.new.send(:obfuscate_phone_number, "")
 
         expect(result).to eq("No phone number")
       end
 
       it 'returns "No phone number" when given nil' do
-        result = subject.send(:obfuscate_phone_number, nil)
+        result = described_class.new.send(:obfuscate_phone_number, nil)
 
         expect(result).to eq("No phone number")
       end
     end
 
     describe "#find_duplicated_phone_numbers" do
-      context "when there are duplicates" do
-        it "finds duplicated phone numbers" do
-          user1
-          user2
-          user3
+      it "finds duplicated phone numbers" do
+        user1
+        user2
+        user3
 
-          result = subject.send(:find_duplicated_phone_numbers)
+        result = described_class.new.send(:find_duplicated_phone_numbers)
 
-          expect(result).to include(%w(1234567890 US))
-        end
+        expect(result).to include(%w(1234567890 US))
       end
     end
   end


### PR DESCRIPTION
#### :tophat: Description

This PR adds a rake task that will delete duplicated half signup users, and alert the administrator about the decidim accounts that contains a phone number that might be duplicated in the DB (multiple decidim accounts with the same phone number)

#### Testing
*Describe the best way to test or validate your PR.*
### You might need to update manually your DB except if you have a dump that has the bug inside of it
- Generate your App
- Access to the db generated with your application
- Access the table decidim-users
- Target a dozen of users that you can easily update (that were not already deleted or blocked on the organization)
- For a multiple case scenarios I would recommend to change 6 users to match the "quick_auth" regex email and to let 6 decidim users with "classic" emails
- For 3 of each, add an identical phone_number with an identical phone_country
- For 1 of each, add an identical phone_number with a different phone_country
- For 2 of each, add a different phone number (different for each of them) regardless the phone_country

- Make sure that when you execute the rake task `bundle exec rake decidim:clear_duplicated_user` that you have every logs in your stdout
- If you followed the test scenario above : 
- Every quick_auth with the same phone_number and same phone_country should have been deleted.
- Decidim users  with the same phone_number and same phone_country should have been alerted to you with the last stdout
- Users with an identical phone_number with a different phone_country should not have been alerted to you
- Users with a different phone_number should not have been alerted to you

#### Tasks
- [x] Add specs
- [x] Create a job that will soft-delete quick_auth half signup accounts and alert about duplicated phone_numbers on decidim accounts if their phone number is duplicated through the DB
- [x] Create a task to execute the new job
