### PR TITLE
feat: Alphabetical order addition for Budgets' Projects

### DIFF
--- a/app/controllers/concerns/decidim/budgets/orderable.rb
+++ b/app/controllers/concerns/decidim/budgets/orderable.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Budgets
+    # Common logic to sorting resources
+    module Orderable
+      extend ActiveSupport::Concern
+
+      included do
+        include Decidim::Orderable
+
+        private
+
+        # Available orders based on enabled settings
+        def available_orders
+          @available_orders ||= begin
+            available_orders = []
+            available_orders << "random" if voting_open? || !votes_are_visible?
+            available_orders << "most_voted" if votes_are_visible?
+            available_orders += %w(alphabetical highest_cost lowest_cost)
+            available_orders
+          end
+        end
+
+        def default_order
+          available_orders.first
+        end
+
+        def votes_are_visible?
+          current_settings.show_votes?
+        end
+
+        def reorder(projects)
+          case order
+          when "alphabetical"
+            reorder_alphabetically(projects)
+          when "highest_cost"
+            reorder_by_highest_cost(projects)
+          when "lowest_cost"
+            reorder_by_lowest_cost(projects)
+          when "most_voted"
+            reorder_by_most_voted(projects)
+          when "random"
+            reorder_randomly(projects)
+          else
+            projects
+          end
+        end
+
+        def reorder_alphabetically(projects)
+          projects.ordered_ids(
+            projects.sort_by { |project| project.title[I18n.locale.to_s] || "" }.map(&:id)
+          )
+        end
+
+        def reorder_by_highest_cost(projects)
+          projects.order(budget_amount: :desc)
+        end
+
+        def reorder_by_lowest_cost(projects)
+          projects.order(budget_amount: :asc)
+        end
+
+        def reorder_by_most_voted(projects)
+          return projects unless votes_are_visible?
+
+          ids = projects.sort_by(&:confirmed_orders_count).map(&:id).reverse
+          projects.ordered_ids(ids)
+        end
+
+        def reorder_randomly(projects)
+          projects.order_randomly(random_seed)
+        end
+      end
+    end
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -168,5 +168,6 @@ ignore_unused:
   - decidim.events.proposals.author_confirmation_proposal_event.notification_title
   - decidim.system.titles.{dashboard,title}
   - decidim.system.titles.info.*
+  - decidim.budgets.projects.orders.*
 
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -169,5 +169,6 @@ ignore_unused:
   - decidim.system.titles.{dashboard,title}
   - decidim.system.titles.info.*
   - decidim.budgets.projects.orders.*
+  - decidim.components.budgets.settings.*
 
 

--- a/config/initializers/default_sort_order.rb
+++ b/config/initializers/default_sort_order.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# The component budgets already exists, we want to add a new settings to it to allow the user to configure the default order
+
+POSSIBLE_SORT_ORDERS = %w(default random most_voted alphabetical highest_cost lowest_cost).freeze
+
+Decidim.component_registry.find(:budgets).settings(:global) do |settings|
+  settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { POSSIBLE_SORT_ORDERS }
+end
+
+Decidim.component_registry.find(:budgets).settings(:step) do |settings|
+  settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
             one: 1 project
             other: "%{count} projects"
         orders:
-          alphabetical: Alphabetical order (A-Z)
+          alphabetical: A-Z (Alphabetical)
           highest_cost: Highest cost
           label: Order projects by
           lowest_cost: Lowest cost
@@ -93,6 +93,29 @@ en:
       comments:
         create:
           error: There was a problem creating the comment.
+    components:
+      budgets:
+        settings:
+          global:
+            default_sort_order: Default Projects sorting
+            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (Alphabetical)
+              default: Default
+              highest_cost: Highest cost
+              lowest_cost: Lowest cost
+              most_voted: Most supported
+              random: Random
+          step:
+            default_sort_order: Default Projects sorting
+            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (Alphabetical)
+              default: Default
+              highest_cost: Highest cost
+              lowest_cost: Lowest cost
+              most_voted: Most supported
+              random: Random
     devise:
       sessions:
         new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,14 @@ en:
           projects_count:
             one: 1 project
             other: "%{count} projects"
+        orders:
+          alphabetical: Alphabetical order (A-Z)
+          highest_cost: Highest cost
+          label: Order projects by
+          lowest_cost: Lowest cost
+          most_voted: Most voted
+          random: Random order
+          selected: Selected
     comments:
       comments:
         create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,8 +97,8 @@ en:
       budgets:
         settings:
           global:
-            default_sort_order: Default Projects sorting
-            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order: Default projects sorting
+            default_sort_order_help: Default means that if the supports are disabled, the projects will be shown sorted by random, and if the supports are enabled, then they will be sorted by the most supported.
             default_sort_order_options:
               alphabetical: A-Z (Alphabetical)
               default: Default
@@ -107,7 +107,7 @@ en:
               most_voted: Most supported
               random: Random
           step:
-            default_sort_order: Default Projects sorting
+            default_sort_order: Default projects sorting
             default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
             default_sort_order_options:
               alphabetical: A-Z (Alphabetical)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -99,8 +99,8 @@ fr:
       budgets:
         settings:
           global:
-            default_sort_order: Default Projects sorting
-            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order: Tri des projets par défaut
+            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les propositions seront affichées par ordre aléatoire, et si les votes sont activés, elles seront triées par ordre décroissant des votes.
             default_sort_order_options:
               alphabetical: A-Z (Alphabétique)
               default: Par défaut
@@ -109,8 +109,8 @@ fr:
               most_voted: Les plus votés
               random: Ordre aléatoire
           step:
-            default_sort_order: Default Projects sorting
-            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order: Tri des projets par défaut
+            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les propositions seront affichées par ordre aléatoire, et si les votes sont activés, elles seront triées par ordre décroissant des votes.
             default_sort_order_options:
               alphabetical: A-Z (alphabétique)
               default: Par défaut

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -83,6 +83,14 @@ fr:
           projects_count:
             one: 1 projet
             other: "%{count} projets"
+        orders:
+          alphabetical: Ordre Alphabétique (A-Z)
+          highest_cost: Prix décroissant
+          label: Trier les projets par
+          lowest_cost: Prix croissant
+          most_voted: Les plus votés
+          random: Ordre aléatoire
+          selected: Sélectionné
     comments:
       comments:
         create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -84,7 +84,7 @@ fr:
             one: 1 projet
             other: "%{count} projets"
         orders:
-          alphabetical: Ordre Alphabétique (A-Z)
+          alphabetical: A-Z (Alphabétique)
           highest_cost: Prix décroissant
           label: Trier les projets par
           lowest_cost: Prix croissant
@@ -95,6 +95,29 @@ fr:
       comments:
         create:
           error: Une erreur s'est produite lors du vote sur le commentaire.
+    components:
+      budgets:
+        settings:
+          global:
+            default_sort_order: Default Projects sorting
+            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (Alphabétique)
+              default: Par défaut
+              highest_cost: Prix décroissant
+              lowest_cost: Prix croissant
+              most_voted: Les plus votés
+              random: Ordre aléatoire
+          step:
+            default_sort_order: Default Projects sorting
+            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (alphabétique)
+              default: Par défaut
+              highest_cost: Prix décroissant
+              lowest_cost: Prix croissant
+              most_voted: Les plus votés
+              random: Ordre aléatoire
     devise:
       sessions:
         new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -100,7 +100,7 @@ fr:
         settings:
           global:
             default_sort_order: Tri des projets par défaut
-            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les propositions seront affichées par ordre aléatoire, et si les votes sont activés, elles seront triées par ordre décroissant des votes.
+            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les projets seront affichés par ordre aléatoire, et si les votes sont activés, ils seront triés par ordre décroissant des votes.
             default_sort_order_options:
               alphabetical: A-Z (Alphabétique)
               default: Par défaut
@@ -110,7 +110,7 @@ fr:
               random: Ordre aléatoire
           step:
             default_sort_order: Tri des projets par défaut
-            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les propositions seront affichées par ordre aléatoire, et si les votes sont activés, elles seront triées par ordre décroissant des votes.
+            default_sort_order_help: Par défaut signifie que si les votes sont désactivés, les projets seront affichés par ordre aléatoire, et si les votes sont activés, ils seront triés par ordre décroissant des votes.
             default_sort_order_options:
               alphabetical: A-Z (alphabétique)
               default: Par défaut

--- a/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
+  let!(:component) { create(:budgets_component) }
+  let(:organization) { component.organization }
+  let!(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+
+  let(:possible_orders) { %w(default random most_voted alphabetical highest_cost lowest_cost) }
+
+  describe "on update" do
+    let(:manifest) { component.manifest }
+    let(:participatory_space) { component.participatory_space }
+
+    let(:form) do
+      Decidim::Budgets::Admin::ComponentForm.from_params(
+        id: component.id,
+        weight: 0,
+        manifest: manifest,
+        participatory_space: participatory_space,
+        name: generate_localized_title,
+        default_step_settings: {},
+        settings: new_settings(:global, settings)
+      ).with_context(current_organization: organization)
+    end
+
+    let(:percent_enabled) { false }
+    let(:percent) { 70 }
+    let(:minimum_enabled) { false }
+    let(:projects_enabled) { false }
+    let(:geocoding_enabled) { false }
+    let(:minimum_number) { 3 }
+    let(:maximum_number) { 6 }
+
+    let(:settings) do
+      {
+        total_budget: 100_000_000,
+        vote_rule_threshold_percent_enabled: percent_enabled,
+        vote_threshold_percent: percent,
+        vote_rule_minimum_budget_projects_enabled: minimum_enabled,
+        vote_minimum_budget_projects_number: minimum_number,
+        vote_rule_selected_projects_enabled: projects_enabled,
+        vote_selected_projects_minimum: minimum_number,
+        vote_selected_projects_maximum: maximum_number,
+        geocoding_enabled: geocoding_enabled,
+        default_sort_order: "default"
+      }
+    end
+
+    def new_settings(name, data)
+      Decidim::Component.build_settings(manifest, name, data, organization)
+    end
+
+    describe "with geocoding enabled" do
+      let(:geocoding_enabled) { true }
+      # One budget rule must me activated
+      let(:percent_enabled) { true }
+
+      it "updates the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component, current_user)
+        end.to broadcast(:ok)
+      end
+    end
+
+    describe "with minimum projects number to vote" do
+      let(:minimum_enabled) { true }
+
+      context "when the minimum projects number is valid" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the minimum projects number is NOT valid" do
+        let(:minimum_number) { 0 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "with projects rule enabled" do
+      let(:projects_enabled) { true }
+
+      context "when the projects rule is valid" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the projects rule is NOT valid" do
+        let(:maximum_number) { 0 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:invalid)
+        end
+      end
+
+      context "when the maximum projects number is more than the minimum" do
+        let(:maximum_number) { 4 }
+
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the maximum projects number is less than the minimum" do
+        let(:maximum_number) { 2 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "with threshold percent enabled" do
+      let(:percent_enabled) { true }
+
+      context "when the threshold percent number is valid" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the threshold percent is NOT valid" do
+        let(:percent) { -1 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component, current_user)
+          end.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "with more than one voting rule enabled" do
+      let(:percent_enabled) { true }
+      let(:minimum_enabled) { true }
+      let(:projects_enabled) { true }
+
+      it "does NOT update the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component, current_user)
+        end.to broadcast(:invalid)
+      end
+    end
+
+    describe "with no voting rule enabled" do
+      let(:percent_enabled) { false }
+      let(:minimum_enabled) { false }
+      let(:projects_enabled) { false }
+
+      it "does NOT update the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component, current_user)
+        end.to broadcast(:invalid)
+      end
+    end
+  end
+
+  describe "on edit", type: :system do
+    let(:edit_component_path) do
+      Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_path(component.id)
+    end
+
+    before do
+      switch_to_host(organization.host)
+      login_as current_user, scope: :user
+    end
+
+    describe "Budget component settings" do
+      before do
+        visit edit_component_path
+      end
+
+      context "when default sort order is selected" do
+        it "shows the default sort order select" do
+          expect(page).to have_content("Default projects sorting")
+          expect(page).to have_css("select#component_settings_default_sort_order")
+          expect(page).to have_select("component_settings_default_sort_order", selected: "Default")
+        end
+
+        it "can change the default sort order" do
+          expect(page).not_to have_select("select#component_settings_default_sort_order", selected: "Random")
+          select "Random", from: "component_settings_default_sort_order"
+          click_button "Update"
+          expect(page).to have_content("The component was updated successfully")
+        end
+
+        it "does not show a sort that doesn't exist" do
+          expect(page).not_to have_select("select#component_settings_default_sort_order", selected: "Nonexistent")
+        end
+      end
+
+      context "when minimum projects rule is checked" do
+        before do
+          check "Enable rule: Minimum number of projects to be voted on"
+        end
+
+        it "is shown the number input" do
+          expect(page).to have_content("Minimum number of projects to vote")
+          expect(page).to have_css("input#component_settings_vote_minimum_budget_projects_number")
+        end
+
+        it "is hidden the percent input" do
+          expect(page).to have_no_content("Vote threshold percent")
+          expect(page).to have_no_css("input#component_settings_vote_threshold_percent")
+        end
+
+        it "is hidden the project rule inputs" do
+          expect(page).to have_no_content("Minimum amount of projects to be selected")
+          expect(page).to have_no_content("Maximum amount of projects to be selected")
+          expect(page).to have_no_css("input#component_settings_vote_selected_projects_minimum")
+          expect(page).to have_no_css("input#component_settings_vote_selected_projects_maximum")
+        end
+      end
+
+      context "when projects rule is checked" do
+        before do
+          check "Enable rule: Minimum and maximum number of projects to be voted on"
+        end
+
+        it "is shown the number input" do
+          expect(page).to have_content("Minimum amount of projects to be selected")
+          expect(page).to have_content("Maximum amount of projects to be selected")
+          expect(page).to have_css("input#component_settings_vote_selected_projects_minimum")
+          expect(page).to have_css("input#component_settings_vote_selected_projects_maximum")
+        end
+
+        it "is hidden the percent input" do
+          expect(page).to have_no_content("Vote threshold percent")
+          expect(page).to have_no_css("input#component_settings_vote_threshold_percent")
+        end
+
+        it "is hidden the number input" do
+          expect(page).to have_no_content("Minimum number of projects to vote")
+          expect(page).to have_no_css("input#component_settings_vote_minimum_budget_projects_number")
+        end
+      end
+
+      context "when threshold percent rule is checked" do
+        before do
+          check "Enable rule: Minimum budget percentage"
+        end
+
+        it "is shown the percent input" do
+          expect(page).to have_content("Vote threshold percent")
+          expect(page).to have_css("input#component_settings_vote_threshold_percent")
+        end
+
+        it "is hidden the number input" do
+          expect(page).to have_no_content("Minimum number of projects to vote")
+          expect(page).to have_no_css("input#component_settings_vote_minimum_budget_projects_number")
+        end
+
+        it "is hidden the project rule inputs" do
+          expect(page).to have_no_content("Minimum amount of projects to be selected")
+          expect(page).to have_no_content("Maximum amount of projects to be selected")
+          expect(page).to have_no_css("input#component_settings_vote_selected_projects_minimum")
+          expect(page).to have_no_css("input#component_settings_vote_selected_projects_maximum")
+        end
+      end
+    end
+  end
+
+  describe "component projects exporter" do
+    subject do
+      component
+        .manifest
+        .export_manifests
+        .find { |manifest| manifest.name == :projects }
+        .collection
+        .call(component, user)
+    end
+
+    let(:component) { create(:budgets_component) }
+    let(:component2) { create(:budgets_component) }
+    let(:budget) { create(:budget, component: component) }
+    let(:budget2) { create(:budget, component: component2) }
+    let(:budget3) { create(:budget, component: component2) }
+    let!(:components_projects) { create_list(:project, 2, budget: budget) }
+    let!(:another_component_projects) { create_list(:project, 3, budget: budget2) }
+    let!(:another_component_projects2) { create_list(:project, 4, budget: budget3) }
+    let(:organization) { component.participatory_space.organization }
+
+    context "when the user is an admin" do
+      let!(:user) { create :user, admin: true, organization: organization }
+
+      it "exports all budgets from the component" do
+        expect(subject.count).to eq(2)
+        expect(subject).to match_array(components_projects)
+      end
+    end
+  end
+
+  describe "budget projects exporter" do
+    subject do
+      component
+        .manifest
+        .export_manifests
+        .find { |manifest| manifest.name == :projects }
+        .collection
+        .call(component, user, budget1.id)
+    end
+
+    let(:component) { create(:budgets_component) }
+    let(:budget1) { create(:budget, component: component) }
+    let(:budget2) { create(:budget, component: component) }
+    let!(:budget1_projects) { create_list(:project, 3, budget: budget1) }
+    let!(:budget2_projects) { create_list(:project, 2, budget: budget2) }
+    let(:organization) { component.participatory_space.organization }
+
+    context "when the user is an admin" do
+      let!(:user) { create :user, admin: true, organization: organization }
+
+      it "exports projects of individual budget" do
+        expect(subject.count).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/system/sorting_projects_spec.rb
+++ b/spec/system/sorting_projects_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Sorting projects", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "budgets" }
+
+  let(:organization) { create :organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
+  let(:project) { projects.first }
+
+  let!(:component) do
+    create(:budgets_component,
+           :with_vote_threshold_percent,
+           manifest: manifest,
+           participatory_space: participatory_process)
+  end
+
+  let(:budget) { create :budget, component: component }
+  let!(:project1) { create(:project, budget: budget, budget_amount: 25_000_000) }
+  let!(:project2) { create(:project, budget: budget, budget_amount: 50_000_000) }
+
+  before do
+    login_as user, scope: :user
+    visit_budget
+  end
+
+  shared_examples "ordering projects by selected option" do |selected_option|
+    before do
+      visit_budget
+      within ".order-by" do
+        expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random order")
+        page.find("a", text: "Random order").click
+        click_link(selected_option)
+      end
+    end
+
+    it "lists the projects ordered by selected option" do
+      # expect(page).to have_selector("#projects li.is-dropdown-submenu-parent a", text: selected_option)
+      within "#projects li.is-dropdown-submenu-parent a" do
+        expect(page).to have_no_content("Random order", wait: 20)
+        expect(page).to have_content(selected_option)
+      end
+
+      expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(first_project.title))
+      expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(last_project.title))
+    end
+  end
+
+  context "when ordering alphabetically" do
+    let!(:project1) { create(:project, budget: budget, title: { "en" => "A project", "es" => "A proyecto" }) }
+    let!(:project2) { create(:project, budget: budget, title: { "en" => "B project", "es" => "B proyecto" }) }
+
+    it_behaves_like "ordering projects by selected option", "Alphabetical order (A-Z)" do
+      let(:first_project) { project1 }
+      let(:last_project) { project2 }
+    end
+  end
+
+  context "when ordering alphabetically in french" do
+    let!(:project1) { create(:project, budget: budget, title: { "en" => "A project", "fr" => "C Projet" }) }
+    let!(:project2) { create(:project, budget: budget, title: { "en" => "B project", "fr" => "B Projet" }) }
+    let!(:project3) { create(:project, budget: budget, title: { "en" => "C project", "fr" => "A Projet" }) }
+
+    before do
+      within_language_menu do
+        click_link "Français"
+      end
+
+      visit_budget
+      within ".order-by" do
+        expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Ordre aléatoire")
+        page.find("a", text: "Ordre aléatoire").click
+        click_link("Alphabétique (A-Z)")
+      end
+    end
+
+    it "lists the projects ordered by selected option" do
+      within "#projects li.is-dropdown-submenu-parent a" do
+        expect(page).to have_no_content("Ordre aléatoire", wait: 20)
+        expect(page).to have_content("Alphabétique (A-Z)")
+      end
+
+      I18n.with_locale(:fr) do
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(project3.title))
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:nth-child(2)", text: translated(project2.title))
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(project1.title))
+      end
+    end
+  end
+
+  context "when ordering by highest cost" do
+    it_behaves_like "ordering projects by selected option", "Highest cost" do
+      let(:first_project) { project2 }
+      let(:last_project) { project1 }
+    end
+  end
+
+  context "when ordering by lowest cost" do
+    it_behaves_like "ordering projects by selected option", "Lowest cost" do
+      let(:first_project) { project1 }
+      let(:last_project) { project2 }
+    end
+  end
+
+  describe "when the voting is finished" do
+    let!(:component) do
+      create(
+        :budgets_component,
+        :with_voting_finished,
+        manifest: manifest,
+        participatory_space: participatory_process
+      )
+    end
+    let!(:project1) { create(:project, :selected, budget: budget, budget_amount: 25_000_000) }
+    let!(:project2) { create(:project, :selected, budget: budget, budget_amount: 77_000_000) }
+
+    context "when ordering by most votes" do
+      before do
+        order = build :order, budget: budget
+        create :line_item, order: order, project: project2
+        order = Decidim::Budgets::Order.last
+        order.checked_out_at = Time.zone.now
+        order.save
+      end
+
+      it "automatically sorts by votes" do
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(project2.title))
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(project1.title))
+      end
+
+      it "automatically sorts by votes and respect the pagination" do
+        component.update!(settings: { projects_per_page: 1 })
+
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        # project2 on first page
+        expect(page).to have_content(translated(project2.title))
+        expect(page).not_to have_content(translated(project1.title))
+
+        within "#projects .pagination" do
+          expect(page).to have_content("2")
+          page.find("a", text: "2").click
+        end
+
+        # project1 on second page
+        expect(page).not_to have_content(translated(project2.title))
+        expect(page).to have_content(translated(project1.title))
+      end
+    end
+  end
+
+  def visit_budget
+    page.visit Decidim::EngineRouter.main_proxy(component).budget_projects_path(budget)
+  end
+end

--- a/spec/system/sorting_projects_spec.rb
+++ b/spec/system/sorting_projects_spec.rb
@@ -52,7 +52,7 @@ describe "Sorting projects", type: :system do
     let!(:project1) { create(:project, budget: budget, title: { "en" => "A project", "es" => "A proyecto" }) }
     let!(:project2) { create(:project, budget: budget, title: { "en" => "B project", "es" => "B proyecto" }) }
 
-    it_behaves_like "ordering projects by selected option", "Alphabetical order (A-Z)" do
+    it_behaves_like "ordering projects by selected option", "A-Z (Alphabetical)" do
       let(:first_project) { project1 }
       let(:last_project) { project2 }
     end
@@ -72,14 +72,14 @@ describe "Sorting projects", type: :system do
       within ".order-by" do
         expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Ordre aléatoire")
         page.find("a", text: "Ordre aléatoire").click
-        click_link("Alphabétique (A-Z)")
+        click_link("A-Z (Alphabétique)")
       end
     end
 
     it "lists the projects ordered by selected option" do
       within "#projects li.is-dropdown-submenu-parent a" do
         expect(page).to have_no_content("Ordre aléatoire", wait: 20)
-        expect(page).to have_content("Alphabétique (A-Z)")
+        expect(page).to have_content("A-Z (Alphabétique)")
       end
 
       I18n.with_locale(:fr) do


### PR DESCRIPTION
#### :tophat: Description
This adds a new sort for the projects of budgets that is now updatable in the BackOffice and which is the alphabetical one

#### :pushpin: Related Issues
- [Feature - Nouvelle option de tri des projets par ordre alphanumérique](https://opensourcepolitics.odoo.com/web?db=opensourcepolitics&signup_email=guillaume%40opensourcepolitics.eu&token=ixqNZ9S5lGRCj9ADpsQq#id=3625&cids=1&menu_id=325&action=471&model=project.task&view_type=form)


#### Testing  
*Steps to validate your PR:*  

1. Log in as an admin.  
2. Go to the Backoffice.  
3. Navigate to a participatory process.  
4. Open the settings for a budgets component.  
5. Enable the default sort (e.g., alphabetical or another option you want to test).  
6. Access a budget within the updated component.  
7. Check that:  
   - The default sort is applied correctly when you arrive.  
   - The projects are displayed in the correct order.  
8. Change the sort option (if you didn’t use alphabetical initially).  
9. Confirm that the projects update and sort as expected.  



#### Tasks
- [x] Add specs
- [x] Addition of the customization of the default order
- [x] Addition of the alphabetical order
- [x] Add missing locales
- [x] Add note about overrides in OVERLOADS.md
- [x] In case of new dependencies or version bump, update related documentation