### PR TITLE
fix: Fix displaying of medias on a project's page

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,12 +118,12 @@ jobs:
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
       #  name: Upload coverage
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots
           path: ./spec/tmp/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: assets-manifest-${{ matrix.slice }}
@@ -192,12 +192,12 @@ jobs:
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
       #  name: Upload coverage
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots
           path: ./spec/tmp/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: assets-manifest-${{ matrix.slice }}

--- a/app/overrides/decidim/budgets/projects/show/fix_videos_and_images_display.html.erb.deface
+++ b/app/overrides/decidim/budgets/projects/show/fix_videos_and_images_display.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- replace "erb[loud]:contains('decidim_sanitize_editor translated_attribute project.description')" -->
+
+<%= decidim_sanitize_editor_admin translated_attribute project.description %>


### PR DESCRIPTION
#### :tophat: Description
This PR fixes the fact that medias were not displayed when they were on a description of a project on the main page of it (show.html.erb). This was occured by the changing of sanitizing editor allowing only the admin editor to display medias.

We had a deface override to fix it and allow again the display of videos on a project's description

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Odoo Card]()

#### Testing

### **Please make sure to run bundle exec rake deface:precompile before running the app otherwise the fix won't be applied** 

* Log in as admin
* Access Backoffice
* Go to a participatory process on its budgets component
* Access a particular project and edit the description adding a media like an image or a video into it 
* Access front office
* Access the project previously edited
* Make sure the media is displayed correctly

#### Tasks
- [x] Add deface override