### PR TITLE
Fix/export issue for assemblies admin

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,12 +118,12 @@ jobs:
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
       #  name: Upload coverage
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots
           path: ./spec/tmp/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: assets-manifest-${{ matrix.slice }}
@@ -192,12 +192,12 @@ jobs:
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
       #  name: Upload coverage
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots
           path: ./spec/tmp/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: assets-manifest-${{ matrix.slice }}

--- a/app/jobs/decidim/export_job.rb
+++ b/app/jobs/decidim/export_job.rb
@@ -12,7 +12,7 @@ module Decidim
       collection = export_manifest.collection.call(component, user, resource_id)
       serializer = export_manifest.serializer
 
-      export_data = if (serializer == Decidim::Proposals::ProposalSerializer) && (user.admin? || admin_of_process?(user, component))
+      export_data = if (serializer == Decidim::Proposals::ProposalSerializer) && (user.admin? || admin_of_process?(user, component) || admin_of_assembly?(user, component))
                       Decidim::Exporters.find_exporter(format).new(collection, serializer).admin_export
                     else
                       Decidim::Exporters.find_exporter(format).new(collection, serializer).export
@@ -26,6 +26,12 @@ module Decidim
       return unless component.respond_to?(:participatory_space)
 
       Decidim::ParticipatoryProcessUserRole.exists?(decidim_user_id: user.id, decidim_participatory_process_id: component.participatory_space.id, role: "admin")
+    end
+
+    def admin_of_assembly?(user, component)
+      return unless component.respond_to?(:participatory_space)
+
+      Decidim::AssemblyUserRole.exists?(decidim_user_id: user.id, decidim_assembly_id: component.participatory_space.id, role: "admin")
     end
   end
 end

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -11,6 +11,8 @@ module Decidim
       let!(:admin) { create(:user, :admin, organization: organization) }
       let!(:admin_of_the_process) { create(:user, organization: organization) }
       let!(:participatory_process) { create(:participatory_process, organization: organization) }
+      let!(:assembly) { create(:assembly, organization: organization) }
+      let!(:admin_of_the_assembly) { create(:user, organization: organization) }
       let(:proposal) { create(:extended_proposal) }
       let(:collection) { [proposal] } # Use an array with the instance_double
       let(:export_manifest) do
@@ -24,100 +26,157 @@ module Decidim
         )
       end
 
-      before do
-        component.update!(participatory_space: participatory_process)
-        create(:participatory_process_user_role, user: admin_of_the_process, participatory_process: participatory_process, role: "admin")
-
-        allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
-      end
-
-      it "sends an email with the result of the export" do
-        ExportJob.perform_now(user, component, "proposals", "CSV")
-
-        email = last_email
-        expect(email.subject).to include("proposals")
-        attachment = email.attachments.first
-
-        expect(attachment.read.length).to be_positive
-        expect(attachment.mime_type).to eq("application/zip")
-        expect(attachment.filename).to match(/^proposals-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
-      end
-
-      describe "CSV" do
-        it "uses the CSV exporter" do
-          export_data = double
-
-          expect(Decidim::Exporters::CSV)
-            .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
-            .and_return(double(export: export_data))
-
-          expect(ExportMailer)
-            .to(receive(:export).with(user, anything, export_data))
-            .and_return(double(deliver_now: true))
-
-          ExportJob.perform_now(user, component, "proposals", "CSV")
-        end
-      end
-
-      describe "JSON" do
-        it "uses the JSON exporter" do
-          export_data = double
-
-          expect(Decidim::Exporters::JSON)
-            .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
-            .and_return(double(export: export_data))
-
-          expect(ExportMailer)
-            .to(receive(:export).with(user, anything, export_data))
-            .and_return(double(deliver_now: true))
-
-          ExportJob.perform_now(user, component, "proposals", "JSON")
-        end
-      end
-
-      describe "Admin export" do
-        let(:serializer) { Decidim::Proposals::ProposalSerializer }
-
+      describe "export for processes" do
         before do
-          allow(Decidim::Exporters::CSV)
-            .to(receive(:new).with(anything, serializer))
-            .and_return(double(export: "normal export data"))
+          component.update!(participatory_space: participatory_process)
+          create(:participatory_process_user_role, user: admin_of_the_process, participatory_process: participatory_process, role: "admin")
+
+          allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
         end
 
-        it "allows admin to access admin_export" do
-          expect(Decidim::Exporters::CSV)
-            .to(receive(:new).with(anything, serializer))
-            .and_return(double(admin_export: "admin export data"))
-
-          expect(ExportMailer)
-            .to(receive(:export).with(admin, anything, "admin export data"))
-            .and_return(double(deliver_now: true))
-
-          ExportJob.perform_now(admin, component, "proposals", "CSV")
-        end
-
-        it "allows admin of the process to access admin_export" do
-          expect(Decidim::Exporters::CSV)
-            .to(receive(:new).with(anything, serializer))
-            .and_return(double(admin_export: "admin export data"))
-
-          expect(ExportMailer)
-            .to(receive(:export).with(admin_of_the_process, anything, "admin export data"))
-            .and_return(double(deliver_now: true))
-
-          ExportJob.perform_now(admin_of_the_process, component, "proposals", "CSV")
-        end
-
-        it "does not allow normal user to access admin_export" do
-          expect(Decidim::Exporters::CSV)
-            .to(receive(:new).with(anything, serializer))
-            .and_return(double(export: "normal export data"))
-
-          expect(ExportMailer)
-            .to(receive(:export).with(user, anything, "normal export data"))
-            .and_return(double(deliver_now: true))
-
+        it "sends an email with the result of the export" do
           ExportJob.perform_now(user, component, "proposals", "CSV")
+
+          email = last_email
+          expect(email.subject).to include("proposals")
+          attachment = email.attachments.first
+
+          expect(attachment.read.length).to be_positive
+          expect(attachment.mime_type).to eq("application/zip")
+          expect(attachment.filename).to match(/^proposals-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+        end
+
+        describe "CSV" do
+          it "uses the CSV exporter" do
+            export_data = double
+
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
+              .and_return(double(export: export_data))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(user, anything, export_data))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(user, component, "proposals", "CSV")
+          end
+        end
+
+        describe "JSON" do
+          it "uses the JSON exporter" do
+            export_data = double
+
+            expect(Decidim::Exporters::JSON)
+              .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
+              .and_return(double(export: export_data))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(user, anything, export_data))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(user, component, "proposals", "JSON")
+          end
+        end
+
+        describe "Admin export" do
+          let(:serializer) { Decidim::Proposals::ProposalSerializer }
+
+          before do
+            allow(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(export: "normal export data"))
+          end
+
+          it "allows admin to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin, component, "proposals", "CSV")
+          end
+
+          it "allows admin of the process to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin_of_the_process, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin_of_the_process, component, "proposals", "CSV")
+          end
+
+          it "does not allow normal user to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(export: "normal export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(user, anything, "normal export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(user, component, "proposals", "CSV")
+          end
+        end
+      end
+
+      describe "export for assemblies" do
+        before do
+          component.update!(participatory_space: assembly)
+          create(:assembly_user_role, user: admin_of_the_assembly, assembly: assembly, role: "admin")
+
+          allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
+        end
+
+        it "sends an email with the result of the export" do
+          ExportJob.perform_now(user, component, "proposals", "CSV")
+
+          email = last_email
+          expect(email.subject).to include("proposals")
+          attachment = email.attachments.first
+
+          expect(attachment.read.length).to be_positive
+          expect(attachment.mime_type).to eq("application/zip")
+          expect(attachment.filename).to match(/^proposals-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+        end
+
+        describe "admin export" do
+          let(:serializer) { Decidim::Proposals::ProposalSerializer }
+
+          before do
+            allow(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(export: "normal export data"))
+          end
+
+          it "allows admin to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin, component, "proposals", "CSV")
+          end
+
+          it "allows admin of the assembly to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin_of_the_assembly, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin_of_the_assembly, component, "proposals", "CSV")
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: Description
The goal of this PR is to complete this previous PR https://github.com/OpenSourcePolitics/decidim-app/pull/573, to add the possibility for assemblies admin to access admin export with name and email.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/OpenSourcePolitics/decidim-app/pull/573
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/4119)

#### Testing

1. Sign in as an admin
2. Go to an assembly, and go to the proposal component with published proposals
3. Click on the export button
4. See that you can view email and names of the participants
5. Invite yourself as an admin of the assembly (with a different email address)
6. Sign in as the space admin and go to the same proposal component
7. Click on the export button
8. See that you can view email and names of the participants just like the administrator of the platform

#### Tasks
- [X] Add specs

