### PR TITLE
Feat/add notification when pj added in process

### DIFF
--- a/app/forms/decidim/admin/attachment_form.rb
+++ b/app/forms/decidim/admin/attachment_form.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form object used to create attachments in a participatory process.
+    #
+    class AttachmentForm < Form
+      include TranslatableAttributes
+
+      attribute :file
+      translatable_attribute :title, String
+      translatable_attribute :description, String
+      attribute :weight, Integer, default: 0
+      attribute :attachment_collection_id, Integer
+      attribute :link, String
+      attribute :send_notification_to_followers, Boolean, default: false
+
+      mimic :attachment
+
+      validates :file, presence: true, unless: :persisted_or_link?
+      validates :link, url: true
+      validates :file, passthru: { to: Decidim::Attachment }
+      validates :title, :description, translatable_presence: true
+      validates :attachment_collection, presence: true, if: ->(form) { form.attachment_collection_id.present? }
+      validates :attachment_collection_id, inclusion: { in: :attachment_collection_ids }, allow_blank: true
+
+      delegate :attached_to, to: :context, prefix: false
+
+      alias organization current_organization
+
+      def persisted_or_link?
+        persisted? || link.present?
+      end
+
+      def attachment_collections
+        @attachment_collections ||= attached_to.attachment_collections
+      end
+
+      def attachment_collection
+        @attachment_collection ||= attachment_collections.find_by(id: attachment_collection_id)
+      end
+
+      private
+
+      def attachment_collection_ids
+        @attachment_collection_ids ||= attachment_collections.pluck(:id)
+      end
+    end
+  end
+end

--- a/app/views/decidim/admin/attachments/_form.html.erb
+++ b/app/views/decidim/admin/attachments/_form.html.erb
@@ -1,0 +1,47 @@
+<div class="form__wrapper">
+  <div class="card pt-4">
+    <div class="card-section">
+      <div class="row column">
+        <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
+      </div>
+
+      <div class="row column">
+        <%= form.number_field :weight %>
+      </div>
+
+      <div class="row column">
+        <%= form.translated :text_field, :description, aria: { label: :description } %>
+      </div>
+
+      <div class="row column">
+        <%= form.select :attachment_collection_id, @form.attachment_collections.map { |c| [translated_attribute(c.name), c.id] }, include_blank: true %>
+      </div>
+
+      <div class="p-6" data-file-or-link-tabs-controller>
+        <%= cell "decidim/tab_panels", [
+          {
+            enabled: true,
+            id: "file",
+            text: "Upload file",
+            icon: "file-upload-line",
+            method: :cell,
+            selected: form.object.file.present?,
+            args: ["/decidim/attachments_file_tab", form]
+          },
+          {
+            enabled: true,
+            id: "link",
+            text: "Link",
+            icon: "link",
+            method: :cell,
+            selected: form.object.link.present?,
+            args: ["/decidim/attachments_link_tab", form]
+          }
+        ] %>
+      </div>
+      <div class="row column">
+        <%= form.check_box :send_notification_to_followers, label: t(".send_notification_to_followers") %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module DecidimApp
 
     config.after_initialize do
       require "extends/commands/decidim/proposals/publish_proposal_extends"
+      require "extends/commands/decidim/admin/create_attachment_extends"
     end
   end
 end

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -41,9 +41,10 @@ Decidim.configure do |config|
 
   # Whether SSL should be enabled or not.
   # if this var is not defined, it is decided automatically per-rails-environment
-  config.force_ssl = Rails.application.secrets.decidim[:force_ssl].present? unless Rails.application.secrets.decidim[:force_ssl] == "auto"
+  config.force_ssl = Rails.application.secrets.decidim[:force_ssl].present? if Rails.env.production? && !Rails.application.secrets.decidim[:force_ssl] == ("auto")
+
   # or set it up manually and prevent any ENV manipulation:
-  # config.force_ssl = true
+  # config.force_ssl = false
 
   # Enable the service worker. By default is disabled in development and enabled in the rest of environments
   config.service_worker_enabled = Rails.application.secrets.decidim[:service_worker_enabled].present?

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -41,10 +41,9 @@ Decidim.configure do |config|
 
   # Whether SSL should be enabled or not.
   # if this var is not defined, it is decided automatically per-rails-environment
-  config.force_ssl = Rails.application.secrets.decidim[:force_ssl].present? if Rails.env.production? && !Rails.application.secrets.decidim[:force_ssl] == ("auto")
-
+  config.force_ssl = Rails.application.secrets.decidim[:force_ssl].present? unless Rails.application.secrets.decidim[:force_ssl] == "auto"
   # or set it up manually and prevent any ENV manipulation:
-  # config.force_ssl = false
+  # config.force_ssl = true
 
   # Enable the service worker. By default is disabled in development and enabled in the rest of environments
   config.service_worker_enabled = Rails.application.secrets.decidim[:service_worker_enabled].present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   decidim:
     admin:
+      attachments:
+        form:
+          send_notification_to_followers: Send a notification to all the people following the consultation who have agreed to receive email notifications
       models:
         assembly:
           fields:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,10 @@
 fr:
   decidim:
+    admin:
+      attachments:
+        form:
+          send_notification_to_followers: Envoyer une notification à toutes les personnes qui suivent la concertation ayant accepté de recevoir des notifications par mail
+        exports:
     events:
       proposals:
         author_confirmation_proposal_event:

--- a/lib/extends/commands/decidim/admin/create_attachment_extends.rb
+++ b/lib/extends/commands/decidim/admin/create_attachment_extends.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module CreateAttachmentExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def notify_followers
+      return unless @attachment.attached_to.is_a?(Decidim::Followable)
+      return unless form.send_notification_to_followers
+
+      Decidim::EventsManager.publish(
+        event: "decidim.events.attachments.attachment_created",
+        event_class: Decidim::AttachmentCreatedEvent,
+        resource: @attachment,
+        followers: @attachment.attached_to.followers,
+        extra: { force_email: true },
+        force_send: true
+      )
+    end
+  end
+end
+
+Decidim::Admin::CreateAttachment.include(CreateAttachmentExtends)

--- a/spec/commands/decidim/admin/create_attachment_spec.rb
+++ b/spec/commands/decidim/admin/create_attachment_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe CreateAttachment do
+    subject { described_class.call(form, attached_to) }
+    let(:user) { create(:user) }
+    let(:send_notification) { true }
+    let(:form) do
+      instance_double(
+        AttachmentForm,
+        title: {
+          en: "An image",
+          ca: "Una imatge",
+          es: "Una imagen"
+        },
+        description: {
+          en: "A city",
+          ca: "Una ciutat",
+          es: "Una ciudad"
+        },
+        file:,
+        attachment_collection: nil,
+        current_user: user,
+        send_notification_to_followers: send_notification,
+        weight: 0
+      )
+    end
+    let(:file) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")) }
+    let(:attached_to) { create(:participatory_process) }
+
+    describe "when valid" do
+      before do
+        allow(form).to receive(:invalid?).and_return(false)
+      end
+
+      it "broadcasts :ok and creates the component" do
+        expect do
+          subject
+        end.to broadcast(:ok)
+
+        expect(Decidim::Attachment.count).to eq(1)
+      end
+
+      it "notifies the followers" do
+        follower = create(:user, organization: attached_to.organization)
+        create(:follow, followable: attached_to, user: follower)
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.attachments.attachment_created",
+            event_class: Decidim::AttachmentCreatedEvent,
+            resource: kind_of(Decidim::Attachment),
+            followers: [follower],
+            extra: { force_email: true },
+            force_send: true
+          )
+
+        subject
+      end
+
+      context "when send notification option is false" do
+        let(:send_notification) { false }
+
+        it "does not notify the followers" do
+          follower = create(:user, organization: attached_to.organization)
+          create(:follow, followable: attached_to, user: follower)
+
+          expect(Decidim::EventsManager)
+            .not_to receive(:publish)
+
+          subject
+        end
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with(:create, Decidim::Attachment, user)
+          .and_call_original
+
+        expect { subject }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("create")
+        expect(action_log.version).to be_present
+      end
+    end
+
+    describe "when invalid" do
+      before do
+        allow(form).to receive(:invalid?).and_return(true)
+      end
+
+      it "broadcasts invalid" do
+        expect do
+          subject
+        end.to broadcast(:invalid)
+
+        expect(Decidim::Attachment.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR is a backport of https://github.com/OpenSourcePolitics/decidim-app/pull/627/files

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/4125)

#### Testing
1. Log in as admin
2. Follow a process
3. Access Backoffice
4. Go to the process you followed, and go to Attachments
5. Add new attachment
6. Check the notification checkbox
7. Submit form
8. See notification in-app and email 
