### PR TITLE
Feat/add email and name in proposals and survey exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem "faker", "~> 3.2"
 gem "letter_opener_web", "~> 2.0"
 gem "rack-attack", "~> 6.7"
 
+# External Decidim gems
+gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git"
+
 group :development, :test do
   gem "brakeman", "~> 6.1"
   gem "byebug", "~> 11.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git
+  revision: c8037a6f81004dc1616b61ffa2da8277cea8780a
+  specs:
+    decidim-additional_authorization_handler (1.0.0)
+      decidim-core (~> 0.29.0)
+
+GIT
   remote: https://github.com/decidim/decidim.git
   revision: 90dc58727e4b5560bd7a102f42e1b831a5096264
   tag: v0.29.2
@@ -880,6 +887,7 @@ DEPENDENCIES
   byebug (~> 11.0)
   dalli
   decidim!
+  decidim-additional_authorization_handler!
   decidim-dev!
   dotenv-rails (~> 2.7)
   faker (~> 3.2)

--- a/app/jobs/decidim/export_job.rb
+++ b/app/jobs/decidim/export_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ExportJob < ApplicationJob
+    queue_as :exports
+
+    def perform(user, component, name, format, resource_id = nil, filters = nil)
+      export_manifest = component.manifest.export_manifests.find do |manifest|
+        manifest.name == name.to_sym
+      end
+
+      collection = export_manifest.collection.call(component, user, resource_id)
+      collection = collection.ransack(filters).result if collection.respond_to?(:ransack) && filters
+      serializer = export_manifest.serializer
+
+      export_data = if (serializer == Decidim::Proposals::ProposalSerializer) && (user.admin? || admin_of_process?(user, component) || admin_of_assembly?(user, component))
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).admin_export
+                    else
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).export
+                    end
+      ExportMailer.export(user, name, export_data).deliver_now
+    end
+
+    private
+
+    def admin_of_process?(user, component)
+      return false unless component.respond_to?(:participatory_space)
+
+      Decidim::ParticipatoryProcessUserRole.exists?(decidim_user_id: user.id, decidim_participatory_process_id: component.participatory_space.id, role: "admin")
+    end
+
+    def admin_of_assembly?(user, component)
+      return false unless component.respond_to?(:participatory_space)
+
+      Decidim::AssemblyUserRole.exists?(decidim_user_id: user.id, decidim_assembly_id: component.participatory_space.id, role: "admin")
+    end
+  end
+end

--- a/app/jobs/decidim/export_job.rb
+++ b/app/jobs/decidim/export_job.rb
@@ -4,7 +4,7 @@ module Decidim
   class ExportJob < ApplicationJob
     queue_as :exports
 
-    def perform(user, component, name, format, resource_id = nil, filters = nil)
+    def perform(user, component, name, format, resource_id = nil, filters = nil) # rubocop:disable Metrics/ParameterLists
       export_manifest = component.manifest.export_manifests.find do |manifest|
         manifest.name == name.to_sym
       end

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "decidim/exporters/serializer"
+require "decidim/translations_helper"
+require "extends/lib/decidim/forms/user_answers_serializer_extend"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,7 @@ en:
           email_outro: You received this notification because you are the author of the proposal. You can unfollow it by visiting the proposal page (" %{resource_title} ") and clicking on " Unfollow ".
           email_subject: Your proposal has been published!
           notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is now live.
+    forms:
+      user_answers_serializer:
+        email: Email
+        name: Name

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -7,6 +7,10 @@ fr:
           email_outro: Vous recevez cette notification car vous êtes l’auteur de la proposition. Vous pouvez vous désabonner en visitant la page de la proposition (« %{resource_title} ») et en cliquant sur « Ne plus suivre ».
           email_subject: Votre proposition a été publiée !
           notification_title: Votre proposition <a href="%{resource_path}">%{resource_title}</a> est maintenant en ligne.
+    forms:
+      user_answers_serializer:
+        email: Email
+        name: Nom
   time:
     buttons:
       select: Sélectionner

--- a/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
+++ b/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module UserAnswersSerializerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def hash_for(answer)
+      {
+        answer_translated_attribute_name(:id) => answer&.session_token,
+        answer_translated_attribute_name(:created_at) => answer&.created_at&.to_fs(:db),
+        answer_translated_attribute_name(:ip_hash) => answer&.ip_hash,
+        answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer&.decidim_user_id.present? ? "registered" : "unregistered")
+      }.merge(user_data(answer))
+    end
+
+    def user_data(answer)
+      {
+        answer_translated_attribute_name(:email) => answer&.user&.email.presence || "",
+        answer_translated_attribute_name(:name) => answer&.user&.name || ""
+      }
+    end
+
+    def answer_translated_attribute_name(attribute)
+      I18n.t(attribute.to_sym, scope: "decidim.forms.user_answers_serializer", default: attribute.to_s)
+    end
+  end
+end
+
+Decidim::Forms::UserAnswersSerializer.class_eval do
+  include(UserAnswersSerializerExtends)
+end

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -14,9 +14,9 @@ module Decidim
       let(:collection) { [proposal] } # Use an array with the instance_double
       let(:export_manifest) do
         instance_double(
-          # rubocop:disable RSpec/VerifiedDoubleReference
+          # rubocop:disable RSpec/StringAsInstanceDoubleConstant
           "Decidim::ComponentExportManifest",
-          # rubocop:enable RSpec/VerifiedDoubleReference
+          # rubocop:enable RSpec/StringAsInstanceDoubleConstant
           name: :proposals,
           collection: ->(_component, _user, _resource_id) { collection },
           serializer: Decidim::Proposals::ProposalSerializer

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ExportJob do
+      let!(:component) { create(:component, manifest_name: "dummy") }
+      let(:organization) { component.organization }
+      let!(:user) { create(:user, organization:) }
+      let!(:admin) { create(:user, :admin, organization:) }
+      let(:serializer) { Decidim::Proposals::ProposalSerializer }
+      let(:proposal) { create(:proposal) }
+      let(:collection) { [proposal] } # Use an array with the instance_double
+      let(:export_manifest) do
+        instance_double(
+          # rubocop:disable RSpec/VerifiedDoubleReference
+          "Decidim::ComponentExportManifest",
+          # rubocop:enable RSpec/VerifiedDoubleReference
+          name: :proposals,
+          collection: ->(_component, _user, _resource_id) { collection },
+          serializer: Decidim::Proposals::ProposalSerializer
+        )
+      end
+
+      it "sends an email with the result of the export" do
+        ExportJob.perform_now(user, component, "dummies", "CSV")
+
+        email = last_email
+        expect(email.subject).to include("dummies")
+        attachment = email.attachments.first
+
+        expect(attachment.read.length).to be_positive
+        expect(attachment.mime_type).to eq("application/zip")
+        expect(attachment.filename).to match(/^dummies-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+      end
+
+      describe "CSV" do
+        it "uses the CSV exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, Decidim::Dev::DummySerializer))
+            .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, export_data))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "dummies", "CSV")
+        end
+      end
+
+      describe "JSON" do
+        it "uses the JSON exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::JSON)
+            .to(receive(:new).with(anything, Decidim::Dev::DummySerializer))
+            .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, export_data))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "dummies", "JSON")
+        end
+      end
+
+      describe "Admin export for processes" do
+        let!(:admin_of_the_process) { create(:user, organization:) }
+        let!(:participatory_process) { create(:participatory_process, organization:) }
+
+        before do
+          component.update!(participatory_space: participatory_process)
+          create(:participatory_process_user_role, user: admin_of_the_process, participatory_process:, role: "admin")
+
+          allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
+        end
+
+        it "allows admin to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(admin_export: "admin export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(admin, anything, "admin export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(admin, component, "proposals", "CSV")
+        end
+
+        it "allows admin of the process to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(admin_export: "admin export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(admin_of_the_process, anything, "admin export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(admin_of_the_process, component, "proposals", "CSV")
+        end
+
+        it "does not allow normal user to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(export: "normal export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, "normal export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "proposals", "CSV")
+        end
+      end
+
+      describe "export for assemblies" do
+        let!(:assembly) { create(:assembly, organization:) }
+        let!(:admin_of_the_assembly) { create(:user, organization:) }
+
+        before do
+          component.update!(participatory_space: assembly)
+          create(:assembly_user_role, user: admin_of_the_assembly, assembly:, role: "admin")
+
+          allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
+        end
+
+        it "sends an email with the result of the export" do
+          ExportJob.perform_now(user, component, "proposals", "CSV")
+
+          email = last_email
+          expect(email.subject).to include("proposals")
+          attachment = email.attachments.first
+
+          expect(attachment.read.length).to be_positive
+          expect(attachment.mime_type).to eq("application/zip")
+          expect(attachment.filename).to match(/^proposals-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+        end
+
+        describe "admin export for assemblies" do
+          before do
+            allow(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(export: "normal export data"))
+          end
+
+          it "allows admin to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin, component, "proposals", "CSV")
+          end
+
+          it "allows admin of the assembly to access admin_export" do
+            expect(Decidim::Exporters::CSV)
+              .to(receive(:new).with(anything, serializer))
+              .and_return(double(admin_export: "admin export data"))
+
+            expect(ExportMailer)
+              .to(receive(:export).with(admin_of_the_assembly, anything, "admin export data"))
+              .and_return(double(deliver_now: true))
+
+            ExportJob.perform_now(admin_of_the_assembly, component, "proposals", "CSV")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Forms
+    describe UserAnswersSerializer do
+      subject do
+        described_class.new(questionnaire.answers)
+      end
+
+      let!(:questionable) { create(:dummy_resource) }
+      let!(:questionnaire) { create(:questionnaire, questionnaire_for: questionable) }
+      let!(:user) { create(:user, organization: questionable.organization) }
+      let!(:questions) { create_list(:questionnaire_question, 3, questionnaire:) }
+      let!(:answers) do
+        questions.map do |question|
+          create(:answer, questionnaire:, question:, user:)
+        end
+      end
+
+      let!(:multichoice_question) { create(:questionnaire_question, questionnaire:, question_type: "multiple_option") }
+      let!(:multichoice_answer_options) { create_list(:answer_option, 2, question: multichoice_question) }
+      let!(:multichoice_answer) do
+        create(:answer, questionnaire:, question: multichoice_question, user:, body: nil)
+      end
+      let!(:multichoice_answer_choices) do
+        multichoice_answer_options.map do |answer_option|
+          create(:answer_choice, answer: multichoice_answer, answer_option:, body: answer_option.body[I18n.locale.to_s])
+        end
+      end
+
+      let!(:singlechoice_question) { create(:questionnaire_question, questionnaire:, question_type: "single_option") }
+      let!(:singlechoice_answer_options) { create_list(:answer_option, 2, question: singlechoice_question) }
+      let!(:singlechoice_answer) do
+        create(:answer, questionnaire:, question: singlechoice_question, user:, body: nil)
+      end
+      let!(:singlechoice_answer_choice) do
+        answer_option = singlechoice_answer_options.first
+        create(:answer_choice, answer: singlechoice_answer, answer_option:, body: answer_option.body[I18n.locale.to_s], custom_body: "Free text")
+      end
+
+      let!(:matrixmultiple_question) { create(:questionnaire_question, questionnaire:, question_type: "matrix_multiple") }
+      let!(:matrixmultiple_answer_options) { create_list(:answer_option, 3, question: matrixmultiple_question) }
+      let!(:matrixmultiple_rows) { create_list(:question_matrix_row, 3, question: matrixmultiple_question) }
+      let!(:matrixmultiple_answer) do
+        create(:answer, questionnaire:, question: matrixmultiple_question, user:, body: nil)
+      end
+      let!(:matrixmultiple_answer_choices) do
+        matrixmultiple_rows.map do |row|
+          [
+            create(:answer_choice, answer: matrixmultiple_answer, answer_option: matrixmultiple_answer_options.first, matrix_row: row, body: matrixmultiple_answer_options.first.body[I18n.locale.to_s]),
+            create(:answer_choice, answer: matrixmultiple_answer, answer_option: matrixmultiple_answer_options.last, matrix_row: row, body: matrixmultiple_answer_options.last.body[I18n.locale.to_s])
+          ]
+        end.flatten
+      end
+
+      let!(:files_question) { create(:questionnaire_question, questionnaire:, question_type: "files") }
+      let!(:files_answer) do
+        create(:answer, :with_attachments, questionnaire:, question: files_question, user:, body: nil)
+      end
+
+      before do
+        questions.each_with_index do |question, idx|
+          question.update!(position: idx)
+        end
+      end
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "includes the answer for each question" do
+          questions.each_with_index do |question, idx|
+            expect(serialized).to include(
+              "#{question.position + 1}. #{translated(question.body, locale: I18n.locale)}" => answers[idx].body
+            )
+          end
+
+          serialized_matrix_answer = matrixmultiple_rows.to_h do |row|
+            key = translated(row.body, locale: I18n.locale)
+            choices = matrixmultiple_answer_options.map do |option|
+              matrixmultiple_answer_choices.find { |choice| choice.matrix_row == row && choice.answer_option == option }
+            end
+
+            [key, choices.map { |choice| choice&.body }]
+          end
+
+          serialized_files_blobs = files_answer.attachments.map(&:file).map(&:blob)
+
+          expect(serialized).to include(
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
+          )
+
+          expect(serialized).to include(
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["#{translated(singlechoice_answer_choice.body)} (Free text)"]
+          )
+
+          expect(serialized).to include(
+            "#{matrixmultiple_question.position + 1}. #{translated(matrixmultiple_question.body, locale: I18n.locale)}" => serialized_matrix_answer
+          )
+
+          expect(serialized["#{files_question.position + 1}. #{translated(files_question.body, locale: I18n.locale)}"]).to include_blob_urls(
+            *serialized_files_blobs
+          )
+        end
+
+        context "and includes the attributes" do
+          let(:an_answer) { answers.first }
+
+          it "the id of the answer" do
+            key = I18n.t(:id, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq an_answer.session_token
+          end
+
+          it "the creation of the answer" do
+            key = I18n.t(:created_at, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq an_answer.created_at.to_fs(:db)
+          end
+
+          it "the IP hash of the user" do
+            key = I18n.t(:ip_hash, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq an_answer.ip_hash
+          end
+
+          it "the user status" do
+            key = I18n.t(:user_status, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq "Registered"
+          end
+
+          it "includes email" do
+            key = I18n.t(:email, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq user.email
+          end
+
+          it "includes name" do
+            key = I18n.t(:name, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq user.name
+          end
+
+          context "when user is not registered" do
+            before do
+              questionnaire.answers.first.update!(decidim_user_id: nil)
+            end
+
+            it "the user status is unregistered" do
+              key = I18n.t(:user_status, scope: "decidim.forms.user_answers_serializer")
+              expect(serialized[key]).to eq "Unregistered"
+            end
+
+            it "does not include email" do
+              key = I18n.t(:email, scope: "decidim.forms.user_answers_serializer")
+              expect(serialized[key]).to eq ""
+            end
+
+            it "does not include name" do
+              key = I18n.t(:name, scope: "decidim.forms.user_answers_serializer")
+              expect(serialized[key]).to eq ""
+            end
+          end
+        end
+
+        context "when conditional question is not answered by user" do
+          let!(:conditional_question) { create(:questionnaire_question, :conditioned, questionnaire:, position: 4) }
+
+          it "includes conditional question as empty" do
+            expect(serialized).to include("5. #{translated(conditional_question.body, locale: I18n.locale)}" => "")
+          end
+        end
+
+        context "when the questionnaire body is very long" do
+          let!(:questionnaire) { create(:questionnaire, questionnaire_for: questionable, description: questionnaire_description) }
+          let(:questionnaire_description) do
+            Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+              Decidim::Faker::Localized.localized { "a" * 1_000_000 }
+            end
+          end
+          let!(:users) { create_list(:user, 100, organization: questionable.organization) }
+
+          before do
+            users.each do |user|
+              questions.each do |question|
+                create(:answer, questionnaire:, question:, user:)
+              end
+            end
+          end
+
+          it "does not load the questionnaire description to memory every time when iterating an answer" do
+            # NOTE:
+            # For this test it is important to fetch the single user "answer
+            # sets" to an array and store them there because this is the same
+            # way the answers are loaded e.g. in the survey component export
+            # functionality. The export had previously a memory leak because the
+            # questionnaire is fetched individually for each "answer set" and if
+            # it has a very long description, it caused the description to be
+            # stored multiple times within the array (for each "answer set"
+            # separately) causing a out of memory errors when there is a large
+            # amount of answers.
+            all_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire)
+
+            initial_memory = memory_usage
+            all_answers.each do |answer_set|
+              described_class.new(answer_set).serialize
+            end
+            expect(memory_usage - initial_memory).to be < 10_000
+          end
+
+          def memory_usage
+            `ps -o rss #{Process.pid}`.lines.last.to_i
+          end
+        end
+      end
+
+      describe "questions_hash" do
+        it "generates a hash of questions ordered by position" do
+          questions.shuffle!
+          expect(subject.instance_eval { questions_hash }.keys.map { |key| key[0].to_i }.uniq).to eq(questions.sort_by(&:position).map { |question| question.position + 1 })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR adds module decidim-additional_authorization_handler in gemfile, and backports several PRs:
- 1 => https://github.com/OpenSourcePolitics/decidim-app/pull/510/files, without the lock of wicked_pdf_version
- 2 => https://github.com/OpenSourcePolitics/decidim-app/pull/573/files, without the extends of proposal_serializer which is present in module added
- 3 => https://github.com/OpenSourcePolitics/decidim-tou/pull/231/files

The global aim is to allow admins (global admin and admins of process or assembly) to export proposals with the added columns nickname email and phone_number.

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/4127)

#### Testing
1. Sign in as an admin
2. Go to PP, and go to a proposal component with published proposals
3. Click on the export button
4. See that you can view email and names of the participants
5. Invite yourself as an admin of the PP (with a different email address)
6. Sign in as the space admin and go to the same proposal component
7. Click on the export button
8. See that you can view email and names of the participants just like the administrator of the platform
9. Do the steps 5 to 8 but with an assembly.
