### PR TITLE
feat: add module 2FA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "activejob-uniqueness", require: "active_job/uniqueness/sidekiq_patch"
 gem "activerecord-session_store"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", "~> 1.4"
+gem "concurrent-ruby", "1.3.4"
 gem "deepl-rb", require: "deepl"
 gem "deface"
 gem "dotenv-rails", "~> 2.7"
@@ -66,7 +67,6 @@ gem "puma", ">= 5.5.1"
 gem "rack-attack", "~> 6.6"
 gem "sys-filesystem"
 gem "wicked_pdf", "2.6.3"
-gem "concurrent-ruby", "1.3.4"
 
 group :development do
   gem "listen", "~> 3.1"

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "decidim-templates", "~> #{DECIDIM_VERSION}.0"
 gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp"
 
 # External Decidim gems
+gem "decidim-admin_multi_factor", git: "https://github.com/OpenSourcePolitics/decidim-module-admin_multi_factor.git", branch: "fix/decidim_version_and_missing_helper"
 gem "decidim-anonymous_proposals", DECIDIM_ANONYMOUS_PROPOSALS_VERSION
 gem "decidim-budget_category_voting", git: "https://github.com/alecslupu-pfa/decidim-budget_category_voting.git", branch: DECIDIM_BRANCH
 gem "decidim-cache_cleaner"
@@ -65,6 +66,7 @@ gem "puma", ">= 5.5.1"
 gem "rack-attack", "~> 6.6"
 gem "sys-filesystem"
 gem "wicked_pdf", "2.6.3"
+gem "concurrent-ruby", "1.3.4"
 
 group :development do
   gem "listen", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-admin_multi_factor.git
+  revision: 8fd7a2736962259cb1bcad1fc1dfbd973bcb9055
+  branch: fix/decidim_version_and_missing_helper
+  specs:
+    decidim-admin_multi_factor (0.27.4)
+      countries (~> 5.1, >= 5.1.2)
+      decidim-core (= 0.27.4)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-anonymous_proposals
   revision: ea7c828c82fabb1c35e161095082f15ba63b6eaf
   branch: feat/disable_override_from_index_proposals
@@ -365,7 +374,7 @@ GEM
     coffee-script-source (1.12.2)
     colorize (0.8.1)
     commonmarker (0.23.10)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     countries (5.7.2)
       unaccent (~> 0.3)
@@ -1178,8 +1187,10 @@ DEPENDENCIES
   brakeman (~> 5.1)
   byebug (~> 11.0)
   climate_control (~> 1.2)
+  concurrent-ruby (= 1.3.4)
   dalli
   decidim (~> 0.27.0)
+  decidim-admin_multi_factor!
   decidim-anonymous_proposals!
   decidim-budget_category_voting!
   decidim-budgets_booth!
@@ -1238,4 +1249,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.22
+   2.5.10

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -170,5 +170,5 @@ ignore_unused:
   - decidim.system.titles.info.*
   - decidim.budgets.projects.orders.*
   - decidim.components.budgets.settings.*
-
+  - decidim.admin_multi_factor.verification_code_mailer.verification_code.*
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,16 @@
 ---
 de:
   decidim:
+    admin_multi_factor:
+      verification_code_mailer:
+        verification_code:
+          title: Ihre Zwei-Faktor-Authentifizierung
+          subtitle_html: Um die Authentifizierung abzuschließen, kopieren Sie den unten stehenden 4-stelligen Code, kehren Sie zur Verifizierungsseite von %{organization} zurück und fügen Sie ihn dort ein!
+          copy: 'Kopieren Sie diesen Code:'
+          expires_in: Es läuft in %{time} ab.
+          ignore_html: |-
+            Falls Sie diese Nachricht nicht angefordert haben, ignorieren Sie bitte diese E-Mail.<br />
+            Ihr Konto wird erst aktiviert, wenn es vollständig bestätigt wurde.
     notifications_digest_mailer:
       subject: Dies ist E-Mail-Zusammenfassung
     participatory_processes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,14 @@ en:
           success: Scope updated successfully
       titles:
         scopes: Scopes
+    admin_multi_factor:
+      verification_code_mailer:
+        verification_code:
+          copy: 'Copy this code:'
+          expires_in: It will expire in %{time}.
+          ignore_html: If you didn't request this communication, please ignore this email.<br/>Your account won't be active until your account is fully confirmed.
+          subtitle_html: To finalize the authentication you just need to copy the 4 digit code below, go back to the %{organization} verification page and paste it!
+          title: Your 2Factor Authentication
     amendments:
       emendation:
         announcement:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -62,6 +62,14 @@ fr:
           success: Secteur mis à jour avec succès.
       titles:
         scopes: Secteurs
+    admin_multi_factor:
+      verification_code_mailer:
+        verification_code:
+          copy: 'Copiez ce code :'
+          expires_in: Il va expirer dans %{time}.
+          ignore_html: Si vous n'avez pas demandé à recevoir cette communication, veuillez ignorer cet email.<br />Votre compte ne sera pas actif tant que votre compte n'est pas confirmé.
+          subtitle_html: Pour finaliser l'authentification, il vous suffit de copier le code à 4 chiffres ci-dessous, retournez à la page de vérification %{organization} et collez-le.
+          title: Votre authentification à deux facteurs
     amendments:
       emendation:
         announcement:

--- a/db/migrate/20250220125330_create_decidim_admin_multi_factor_settings.rb
+++ b/db/migrate/20250220125330_create_decidim_admin_multi_factor_settings.rb
@@ -1,0 +1,17 @@
+# This migration comes from decidim_admin_multi_factor (originally 20241126021907)
+
+# frozen_string_literal: true
+
+class CreateDecidimAdminMultiFactorSettings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :decidim_admin_multi_factor_settings do |t|
+      t.boolean :enable_multifactor, default: false
+      t.boolean :email, default: false
+      t.boolean :sms, default: false
+      t.boolean :webauthn, default: false
+      t.references :decidim_organization, foreign_key: true, index: { name: :index_decidim_admin_multi_factor_settings_on_organization_id }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_18_114335) do
+ActiveRecord::Schema.define(version: 2025_02_20_125330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -117,6 +117,17 @@ ActiveRecord::Schema.define(version: 2024_11_18_114335) do
     t.index ["resource_type", "resource_id"], name: "index_action_logs_on_resource_type_and_id"
     t.index ["version_id"], name: "index_decidim_action_logs_on_version_id"
     t.index ["visibility"], name: "index_decidim_action_logs_on_visibility"
+  end
+
+  create_table "decidim_admin_multi_factor_settings", force: :cascade do |t|
+    t.boolean "enable_multifactor", default: false
+    t.boolean "email", default: false
+    t.boolean "sms", default: false
+    t.boolean "webauthn", default: false
+    t.bigint "decidim_organization_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["decidim_organization_id"], name: "index_decidim_admin_multi_factor_settings_on_organization_id"
   end
 
   create_table "decidim_amendments", force: :cascade do |t|
@@ -2157,6 +2168,7 @@ ActiveRecord::Schema.define(version: 2024_11_18_114335) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "decidim_admin_multi_factor_settings", "decidim_organizations"
   add_foreign_key "decidim_area_types", "decidim_organizations"
   add_foreign_key "decidim_areas", "decidim_area_types", column: "area_type_id"
   add_foreign_key "decidim_areas", "decidim_organizations"

--- a/spec/services/deepl_translator_spec.rb
+++ b/spec/services/deepl_translator_spec.rb
@@ -15,11 +15,11 @@ describe DeeplTranslator do
   before do
     stub_request(:get, "https://translator.example.org/v2/languages").with(
       headers: {
-        'Accept'=>'*/*',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization'=>'DeepL-Auth-Key dummy_key',
-        'Content-Type'=>'application/json',
-        'User-Agent'=>'deepl-ruby/3.0.2 (darwin23) ruby/3.0.6'
+        "Accept" => "*/*",
+        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        "Authorization" => "DeepL-Auth-Key dummy_key",
+        "Content-Type" => "application/json",
+        "User-Agent" => "deepl-ruby/3.0.2 (darwin23) ruby/3.0.6"
       }
     ).to_return(status: 200, body: JSON.dump([
                                                {
@@ -184,7 +184,7 @@ describe DeeplTranslator do
       headers: {
         "Accept" => "*/*",
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        'Authorization'=>'DeepL-Auth-Key dummy_key',
+        "Authorization" => "DeepL-Auth-Key dummy_key",
         "Content-Type" => "application/json",
         "User-Agent" => "deepl-ruby/3.0.2 (darwin23) ruby/3.0.6"
       }

--- a/spec/services/deepl_translator_spec.rb
+++ b/spec/services/deepl_translator_spec.rb
@@ -186,7 +186,7 @@ describe DeeplTranslator do
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
         "Authorization" => "DeepL-Auth-Key dummy_key",
         "Content-Type" => "application/json",
-        "User-Agent" => "deepl-ruby/3.0.2 (darwin23) ruby/3.0.6"
+        "User-Agent" => "deepl-ruby/3.0.2 (linux) ruby/3.0.6"
       }
     ).to_return(status: 200, body: JSON.dump({
                                                translations: [

--- a/spec/services/deepl_translator_spec.rb
+++ b/spec/services/deepl_translator_spec.rb
@@ -19,7 +19,7 @@ describe DeeplTranslator do
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
         "Authorization" => "DeepL-Auth-Key dummy_key",
         "Content-Type" => "application/json",
-        "User-Agent" => "deepl-ruby/3.0.2 (darwin23) ruby/3.0.6"
+        "User-Agent" => "deepl-ruby/3.0.2 (linux) ruby/3.0.6"
       }
     ).to_return(status: 200, body: JSON.dump([
                                                {

--- a/spec/services/deepl_translator_spec.rb
+++ b/spec/services/deepl_translator_spec.rb
@@ -15,9 +15,11 @@ describe DeeplTranslator do
   before do
     stub_request(:get, "https://translator.example.org/v2/languages").with(
       headers: {
-        "Accept" => "*/*",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "User-Agent" => "Ruby"
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'DeepL-Auth-Key dummy_key',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'deepl-ruby/3.0.2 (darwin23) ruby/3.0.6'
       }
     ).to_return(status: 200, body: JSON.dump([
                                                {
@@ -178,12 +180,13 @@ describe DeeplTranslator do
                                              ]), headers: {})
 
     stub_request(:post, "https://translator.example.org/v2/translate").with(
-      body: { "source_lang" => "en", "target_lang" => "es", "text" => "This is a comment" },
+      body: { "text" => ["This is a comment"], "source_lang" => "en", "target_lang" => "es" },
       headers: {
         "Accept" => "*/*",
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "Content-Type" => "application/x-www-form-urlencoded",
-        "User-Agent" => "Ruby"
+        'Authorization'=>'DeepL-Auth-Key dummy_key',
+        "Content-Type" => "application/json",
+        "User-Agent" => "deepl-ruby/3.0.2 (darwin23) ruby/3.0.6"
       }
     ).to_return(status: 200, body: JSON.dump({
                                                translations: [

--- a/spec/services/deepl_translator_spec.rb
+++ b/spec/services/deepl_translator_spec.rb
@@ -18,8 +18,7 @@ describe DeeplTranslator do
         "Accept" => "*/*",
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
         "Authorization" => "DeepL-Auth-Key dummy_key",
-        "Content-Type" => "application/json",
-        "User-Agent" => "deepl-ruby/3.0.2 (linux) ruby/3.0.6"
+        "User-Agent" => "Ruby"
       }
     ).to_return(status: 200, body: JSON.dump([
                                                {
@@ -180,13 +179,13 @@ describe DeeplTranslator do
                                              ]), headers: {})
 
     stub_request(:post, "https://translator.example.org/v2/translate").with(
-      body: { "text" => ["This is a comment"], "source_lang" => "en", "target_lang" => "es" },
+      body: { "source_lang" => "en", "target_lang" => "es", "text" => "This is a comment" },
       headers: {
         "Accept" => "*/*",
         "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
         "Authorization" => "DeepL-Auth-Key dummy_key",
-        "Content-Type" => "application/json",
-        "User-Agent" => "deepl-ruby/3.0.2 (linux) ruby/3.0.6"
+        "Content-Type" => "application/x-www-form-urlencoded",
+        "User-Agent" => "Ruby"
       }
     ).to_return(status: 200, body: JSON.dump({
                                                translations: [

--- a/spec/system/admin_double_authentication_spec.rb
+++ b/spec/system/admin_double_authentication_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin double authentication", type: :system do
+  include Decidim::SanitizeHelper
+
+  let(:organization) { create :organization, default_locale: :en, available_locales: [:en, :es, :ca, :fr] }
+  let(:admin) { create :user, :admin, :confirmed, organization: organization }
+  let!(:setting) { Decidim::AdminMultiFactor::Setting.create!(enable_multifactor: true, email: true, sms: true, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  describe "Access back office" do
+    before do
+      login_as admin, scope: :user
+      allow_any_instance_of(Decidim::AdminMultiFactor::BaseVerification).to receive(:generate_code).and_return("1234")
+    end
+
+    it "can access back office with email" do
+      visit decidim.root_path
+      click_link admin.name.to_s
+      li = page.all("ul.is-dropdown-submenu li")
+      li[4].click
+      expect(page).to have_content("Elevate access rights")
+      links = page.all("a.button.button--social")
+      links[0].click # first link is Email
+      expect(page).to have_content("Please enter the code:")
+      fill_in "digit1", with: 1
+      fill_in "digit2", with: 2
+      fill_in "digit3", with: 3
+      fill_in "digit4", with: 4
+      click_link_or_button "Submit"
+      expect(page).to have_content("Welcome to the Admin Panel.")
+    end
+
+    it "can access back office with sms" do
+      visit decidim.root_path
+      click_link admin.name.to_s
+      li = page.all("ul.is-dropdown-submenu li")
+      li[4].click
+      expect(page).to have_content("Elevate access rights")
+      links = page.all("a.button.button--social")
+      links[1].click # second link is Sms
+      fill_in "sms_code[phone_number]", with: "0612345678"
+      click_link_or_button "Submit"
+      expect(page).to have_content("Please enter the code:")
+      fill_in "digit1", with: 1
+      fill_in "digit2", with: 2
+      fill_in "digit3", with: 3
+      fill_in "digit4", with: 4
+      click_link_or_button "Submit"
+      expect(page).to have_content("Welcome to the Admin Panel.")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to add decidim-admin_multi_factor to the decidim-app.

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/3936)

#### Testing
Log in as admin and access back office
In the settings, go to Multifactors settings, check the 3 checkboxes and update (see screenshot)
Log out
Log in again and try to access admin dashboard from the menu
Choose email and go to letter_opener to get the verification code
See that you get access to BO
Log out
Log in again and try to access admin dashboard from the menu
Choose sms and search in your logs for "verification code is", and type the code
See that you get access to BO


### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
<img width="1016" alt="Capture d’écran 2025-02-20 à 12 19 32" src="https://github.com/user-attachments/assets/8750373f-59f2-4856-ba21-d62fdb78cbd7" />

### Tasks
[X] add specs for admin double authentication