### PR TITLE
fix: add check for parent_assembly in view

### DIFF
--- a/app/views/layouts/decidim/admin/assemblies.html.erb
+++ b/app/views/layouts/decidim/admin/assemblies.html.erb
@@ -1,0 +1,18 @@
+<% content_for :breadcrumb_context_menu do %>
+  <div class="process-title-content-breadcrumb-container-right">
+    <% if allowed_to? :create, :assembly, assembly: (parent_assembly if defined?(parent_assembly) && parent_assembly.present?)  %>
+      <% link = defined?(parent_assembly) ? new_assembly_path(parent_id: parent_assembly&.id) : new_assembly_path %>
+      <%= link_to link, class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link" do %>
+        <%= icon "add-line", class: "w-4 h-4" %>
+        <span>
+          <%= t("actions.new_assembly", scope: "decidim.admin") %>
+        </span>
+      <% end %>
+    <% end %>
+    <%= render partial: "layouts/decidim/admin/manage_assemblies" %>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to fix a bug that occurs on [decidim-0.29.osp.dev](http://decidim-0.29.osp.dev/), but not in local env or docker. When trying to edit a "Hero image and CTA" block in assembly landing page, the error to fix is :  
```
ActionView::Template::Error (undefined local variable or method `parent_assembly' for #<ActionView::Base:0x000000095185c0>):
1: <% content_for :breadcrumb_context_menu do %>
2:   <div class="process-title-content-breadcrumb-container-right">
3:     <% if allowed_to? :create, :assembly, assembly: parent_assembly %>
4:       <% link = defined?(parent_assembly) ? new_assembly_path(parent_id: parent_assembly&.id) : new_assembly_path %>
5:       <%= link_to link, class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link" do %>
6:         <%= icon "add-line", class: "w-4 h-4" %>
decidim (af8d33194b3b) decidim-assemblies/app/views/layouts/decidim/admin/assemblies.html.erb:3
```

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/3929)

#### Testing
- Go to the BO
- Go to an assembly and than to Landing page
- Click on edit button for the Hero image and CTA, and see that you can access the page without error.
- You can also check that you can add an image


### :camera: Screenshots
<img width="928" alt="Capture d’écran 2025-03-05 à 09 34 42" src="https://github.com/user-attachments/assets/c03cead7-3550-4181-83ab-bbad34e42d1b" />

