### PR TITLE
fix: Drag & Drop Missing in Questionnaires 0.29

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,7 @@
 # Set the service urls to be saved for 10 weeks
 # Default: "1" week
 # DECIDIM_SERVICE_URLS_EXPIRES_IN=10
+
+# Deactivate DEFACE when views are already precompiled
+# More information: https://github.com/spree/deface#production--precompiling
+DEFACE_ENABLED=false

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ public/sw.js*
 tailwind.config.js
 yarn-error.log
 minio_data
+
+# Ignore the files and folders generated through Deface
+app/compiled_views/

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "puma", ">= 6.3.1"
 
 gem "aws-sdk-s3", require: false
 gem "dalli"
+gem "deface"
 gem "dotenv-rails", "~> 2.7"
 gem "faker", "~> 3.2"
 gem "letter_opener_web", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,12 @@ GEM
     declarative-builder (0.2.0)
       trailblazer-option (~> 0.1.0)
     declarative-option (0.1.0)
+    deface (1.9.0)
+      actionview (>= 5.2)
+      nokogiri (>= 1.6)
+      polyglot
+      railties (>= 5.2)
+      rainbow (>= 2.1.0)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -607,6 +613,7 @@ GEM
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
+    polyglot (0.3.5)
     premailer (1.27.0)
       addressable
       css_parser (>= 1.19.0)
@@ -889,6 +896,7 @@ DEPENDENCIES
   decidim!
   decidim-additional_authorization_handler!
   decidim-dev!
+  deface
   dotenv-rails (~> 2.7)
   faker (~> 3.2)
   flamegraph

--- a/app/overrides/decidim/forms/admin/questionnaires/_question/add_drag_and_drop_class.html.erb.deface
+++ b/app/overrides/decidim/forms/admin/questionnaires/_question/add_drag_and_drop_class.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- surround "div.card-divider" -->
+<div class="question-divider">
+  <%= render_original %>
+</div>

--- a/app/overrides/decidim/forms/admin/questionnaires/_separator/add_drag_and_drop_class.html.erb.deface
+++ b/app/overrides/decidim/forms/admin/questionnaires/_separator/add_drag_and_drop_class.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- surround "div.card-divider" -->
+<div class="question-divider">
+  <%= render_original %>
+</div>

--- a/app/overrides/decidim/forms/admin/questionnaires/_title_and_description/add_drag_and_drop_class.html.erb.deface
+++ b/app/overrides/decidim/forms/admin/questionnaires/_title_and_description/add_drag_and_drop_class.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- surround "div.card-divider" -->
+<div class="question-divider">
+  <%= render_original %>
+</div>


### PR DESCRIPTION
#### :tophat: Description
Addition of Deface and override files to add the missing class managing the Drag & Drop System removed from 0.28 to 0.29

#### :pushpin: Related Issues
*Link your PR to an issue*

- [BUG 0.29 - Drag and drop non fonctionnel sur les Enquêtes](https://opensourcepolitics.odoo.com/odoo/all-tasks/4277)

#### Testing

##### Please make sure to run `bundle exec rake deface:precompile` before starting your app to make sure changes are compiled properly

Example:
* Log in as admin
* Access Backoffice
* Go to a participatory process
* Navigate through a survey component or create a new one
* Create some questions (don't forget to name them to see properly the order)
* Create some separators and some titles/descriptions
* Shuffle them using the drag & drop
* Test that the buttons are still working

#### Tasks
- [x] Add deface
- [x] Override three files related to the questionnaires to add the missing class to it

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
