### PR TITLE
fix: Change default content_blocks from assemblies and pp's and manag…

### DIFF
--- a/app/services/decidim/content_blocks_creator.rb
+++ b/app/services/decidim/content_blocks_creator.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Service to generate content blocks on spaces o resources which have content
+  # blocks registered for them on their engines.
+  #
+  # This class is initialized passing an space which can be an organization, a
+  # participatory space with content blocks like processes or assemblies or a
+  # participatory process group.
+  class ContentBlocksCreator
+    attr_reader :space, :scope_name, :scoped_resource_id, :is_organization, :organization, :default_content_blocks, :component_content_blocks
+
+    def initialize(space)
+      @space = space
+      @is_organization = space.is_a? Decidim::Organization
+      @organization = is_organization ? space : space.organization
+      @scoped_resource_id = is_organization ? nil : space.id
+      manifest = manifest_for(space)
+      @scope_name = is_organization ? :homepage : manifest.content_blocks_scope_name
+      raise ArgumentError, "[ERROR] The #{manifest.name} spaces do not define a content blocks scope" if scope_name.blank?
+
+      @default_content_blocks = Decidim.content_blocks.for(scope_name).select(&:default)
+      @component_content_blocks = Decidim.content_blocks.for(scope_name).select(&:component_manifest_name)
+    end
+
+    # Creates all content blocks registered as default for the space or
+    # resource unless one created with the same manifest already exists in
+    # the same space.
+    def create_default!
+      default_content_blocks.each_with_index do |manifest, index|
+        next if Decidim::ContentBlock.exists?(decidim_organization_id: organization.id, scope_name:, manifest_name: manifest.name, scoped_resource_id:)
+
+        order, inactive_parts = determine_order_and_inactive_parts(space)
+
+        weight = calculate_weight(manifest.name, order, inactive_parts, index)
+        published_at = inactive_parts.include?(manifest.name) ? nil : Time.current
+
+        Decidim::ContentBlock.create(
+          decidim_organization_id: organization.id,
+          weight:,
+          scope_name:,
+          scoped_resource_id:,
+          manifest_name: manifest.name,
+          published_at:
+        )
+      end
+    end
+
+    # This method only works in participatory spaces. For all the components
+    # published in the space creates an associated content block if registered
+    # for the sope and component and is not created configured for the
+    # component or globally to cover all components of the same type.
+    def create_components_blocks!
+      return unless space.is_a? Decidim::Participable
+
+      space.components.published.each_with_index do |component, index|
+        block_manifest = component_content_blocks.find { |manifest| manifest.component_manifest_name == component.manifest_name }
+
+        next unless block_manifest
+
+        content_blocks = Decidim::ContentBlock.where(decidim_organization_id: organization.id, scope_name:, manifest_name: block_manifest.name, scoped_resource_id:)
+
+        # Ignore creation if there is already a content block for the same
+        # component or a general content block for all the components of the
+        # same type in the space
+        next if content_blocks.any? do |block|
+          component_id = block.settings.component_id
+          component_id.blank? || component_id.to_i == component.id
+        end
+
+        weight = ((index + 1) * 10) + 1000
+
+        Decidim::ContentBlock.create(
+          decidim_organization_id: organization.id,
+          weight:,
+          scope_name:,
+          scoped_resource_id:,
+          manifest_name: block_manifest.name,
+          settings: { component_id: component.id.to_s },
+          published_at: Time.current
+        )
+      end
+    end
+
+    private
+
+    def manifest_for(resource)
+      return resource.manifest if resource.is_a? Decidim::Participable
+
+      resource.resource_manifest if resource.is_a? Decidim::Resourceable
+    end
+
+    def determine_order_and_inactive_parts(space)
+      case space
+      when Decidim::ParticipatoryProcess, Decidim::Assembly
+        [
+          [:hero, :extra_data, :announcement, :main_data, :metadata, :related_documents,
+           :highlighted_meetings, :highlighted_posts, :highlighted_proposals,
+           :highlighted_results, :related_processes, :related_assemblies],
+          [:html, :last_activity, :stats, :metrics, :related_images]
+        ]
+      when Decidim::ParticipatoryProcessGroup
+        [
+          [:hero, :title, :participatory_processes, :highlighted_meetings, :highlighted_proposals, :highlighted_results],
+          # rubocop:disable Naming/VariableNumber
+          [:html_1, :stats, :extra_data]
+          # rubocop:enable Naming/VariableNumber
+        ]
+      else
+        [[], []]
+      end
+    end
+
+    def calculate_weight(manifest_name, order, inactive_parts, index)
+      if inactive_parts.include?(manifest_name)
+        (inactive_parts.index(manifest_name) + 1) * 10
+      elsif order.include?(manifest_name)
+        (order.index(manifest_name) + 1) * 10
+      else
+        (index + 1) * 10
+      end
+    end
+  end
+end

--- a/config/initializers/assemblies_registry_manager_override.rb
+++ b/config/initializers/assemblies_registry_manager_override.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    module ContentBlocks
+      class RegistryManager
+        def self.register!
+          Decidim.content_blocks.register(:homepage, :highlighted_assemblies) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/highlighted_assemblies"
+            content_block.public_name_key = "decidim.assemblies.content_blocks.highlighted_assemblies.name"
+            content_block.settings_form_cell = "decidim/assemblies/content_blocks/highlighted_assemblies_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :html) do |content_block|
+            content_block.cell = "decidim/content_blocks/html"
+            content_block.public_name_key = "decidim.content_blocks.html.name"
+            content_block.settings_form_cell = "decidim/content_blocks/html_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :html_content, type: :text, translated: true
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :hero) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_hero"
+            content_block.settings_form_cell = "decidim/content_blocks/participatory_space_hero_settings_form"
+            content_block.public_name_key = "decidim.content_blocks.hero.name"
+
+            content_block.images = [
+              {
+                name: :background_image,
+                uploader: "Decidim::BackgroundImageUploader"
+              }
+            ]
+
+            content_block.settings do |settings|
+              settings.attribute :button_text, type: :text, translated: true
+              settings.attribute :button_url, type: :text, translated: true
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :announcement) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_announcement"
+            content_block.public_name_key = "decidim.content_blocks.announcement.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :main_data) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/main_data"
+            content_block.public_name_key = "decidim.content_blocks.main_data.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :extra_data) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/extra_data"
+            content_block.public_name_key = "decidim.assemblies.content_blocks.extra_data.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :metadata) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/metadata"
+            content_block.public_name_key = "decidim.content_blocks.metadata.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :dates_metadata) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/dates_metadata"
+            content_block.public_name_key = "decidim.assemblies.content_blocks.dates_metadata.name"
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :social_networks_metadata) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_social_networks"
+            content_block.public_name_key = "decidim.content_blocks.social_networks_metadata.name"
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :last_activity) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_last_activity"
+            content_block.public_name_key = "decidim.content_blocks.last_activity.name"
+            content_block.settings_form_cell = "decidim/content_blocks/last_activity_settings_form"
+            content_block.settings do |settings|
+              settings.attribute :max_last_activity_users, type: :integer, default: Decidim.default_max_last_activity_users
+            end
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :stats) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/stats"
+            content_block.public_name_key = "decidim.content_blocks.participatory_space_stats.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :related_assemblies) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/children_assemblies"
+            content_block.settings_form_cell = "decidim/assemblies/content_blocks/highlighted_assemblies_settings_form"
+            content_block.public_name_key = "decidim.assemblies.content_blocks.related_assemblies.name"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :related_documents) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_documents"
+            content_block.public_name_key = "decidim.application.documents.related_documents"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:assembly_homepage, :related_images) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_images"
+            content_block.public_name_key = "decidim.application.photos.related_photos"
+            content_block.default!
+          end
+
+          register_highlighted_meetings
+          register_highlighted_posts
+          register_highlighted_proposals
+          register_highlighted_results
+          register_related_processes
+        end
+
+        def self.register_highlighted_meetings
+          return unless Decidim.module_installed?(:meetings)
+
+          Decidim.content_blocks.register(:assembly_homepage, :highlighted_meetings) do |content_block|
+            content_block.cell = "decidim/meetings/content_blocks/highlighted_meetings"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.meetings.content_blocks.upcoming_meetings.name"
+            content_block.component_manifest_name = "meetings"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_posts
+          return unless Decidim.module_installed?(:blogs)
+
+          Decidim.content_blocks.register(:assembly_homepage, :highlighted_posts) do |content_block|
+            content_block.cell = "decidim/blogs/content_blocks/highlighted_posts"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.blogs.content_blocks.highlighted_posts.name"
+            content_block.component_manifest_name = "blogs"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_proposals
+          return unless Decidim.module_installed?(:proposals)
+
+          Decidim.content_blocks.register(:assembly_homepage, :highlighted_proposals) do |content_block|
+            content_block.cell = "decidim/proposals/content_blocks/highlighted_proposals"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.proposals.content_blocks.highlighted_proposals.name"
+            content_block.component_manifest_name = "proposals"
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "recent", choices: %w(random recent)
+              settings.attribute :component_id, type: :select, default: nil
+            end
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_results
+          return unless Decidim.module_installed?(:accountability)
+
+          Decidim.content_blocks.register(:assembly_homepage, :highlighted_results) do |content_block|
+            content_block.cell = "decidim/accountability/content_blocks/highlighted_results"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.accountability.content_blocks.highlighted_results.results"
+            content_block.component_manifest_name = "accountability"
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
+              settings.attribute :component_id, type: :select, default: nil
+            end
+            content_block.default!
+          end
+        end
+
+        def self.register_related_processes
+          return unless Decidim.module_installed?(:participatory_processes)
+
+          Decidim.content_blocks.register(:assembly_homepage, :related_processes) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/related_processes"
+            content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/highlighted_processes_settings_form"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.related_processes.name"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+            content_block.default!
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/participatory_processes_registry_manager_override.rb
+++ b/config/initializers/participatory_processes_registry_manager_override.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module ContentBlocks
+      class RegistryManager
+        def self.register!
+          Decidim.content_blocks.register(:homepage, :highlighted_processes) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/highlighted_processes"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.highlighted_processes.name"
+            content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/highlighted_processes_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :title) do |content_block|
+            content_block.cell = "decidim/participatory_process_groups/content_blocks/main_data"
+            content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.main_data.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :extra_data) do |content_block|
+            content_block.cell = "decidim/participatory_process_groups/content_blocks/extra_data"
+            content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.extra_data.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :hero) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_hero"
+            content_block.settings_form_cell = "decidim/content_blocks/participatory_space_hero_settings_form"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.hero.name"
+
+            content_block.images = [
+              {
+                name: :background_image,
+                uploader: "Decidim::BackgroundImageUploader"
+              }
+            ]
+
+            content_block.settings do |settings|
+              settings.attribute :button_text, type: :text, translated: true
+              settings.attribute :button_url, type: :text, translated: true
+            end
+
+            content_block.default!
+          end
+
+          (1..3).each do |index|
+            Decidim.content_blocks.register(:participatory_process_group_homepage, :"html_#{index}") do |content_block|
+              content_block.cell = "decidim/content_blocks/html"
+              content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.html_#{index}.name"
+              content_block.settings_form_cell = "decidim/content_blocks/html_settings_form"
+
+              content_block.settings do |settings|
+                settings.attribute :html_content, type: :text, translated: true
+              end
+
+              content_block.default! if index == 1
+            end
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :html) do |content_block|
+            content_block.cell = "decidim/content_blocks/html"
+            content_block.public_name_key = "decidim.content_blocks.html.name"
+            content_block.settings_form_cell = "decidim/content_blocks/html_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :html_content, type: :text, translated: true
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :hero) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_hero"
+            content_block.settings_form_cell = "decidim/content_blocks/participatory_space_hero_settings_form"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.hero.name"
+
+            content_block.images = [
+              {
+                name: :background_image,
+                uploader: "Decidim::BackgroundImageUploader"
+              }
+            ]
+
+            content_block.settings do |settings|
+              settings.attribute :button_text, type: :text, translated: true
+              settings.attribute :button_url, type: :text, translated: true
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :announcement) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_announcement"
+            content_block.public_name_key = "decidim.content_blocks.announcement.name"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :main_data) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/main_data"
+            content_block.public_name_key = "decidim.content_blocks.main_data.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :extra_data) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/extra_data"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.extra_data.name"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :metadata) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/metadata"
+            content_block.public_name_key = "decidim.content_blocks.metadata.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :last_activity) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_last_activity"
+            content_block.public_name_key = "decidim.content_blocks.last_activity.name"
+            content_block.settings_form_cell = "decidim/content_blocks/last_activity_settings_form"
+            content_block.settings do |settings|
+              settings.attribute :max_last_activity_users, type: :integer, default: Decidim.default_max_last_activity_users
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :stats) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/stats"
+            content_block.public_name_key = "decidim.content_blocks.participatory_space_stats.name"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :metrics) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/metrics"
+            content_block.public_name_key = "decidim.content_blocks.participatory_space_metrics.name"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :related_processes) do |content_block|
+            content_block.cell = "decidim/participatory_processes/content_blocks/related_processes"
+            content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/highlighted_processes_settings_form"
+            content_block.public_name_key = "decidim.participatory_processes.content_blocks.related_processes.name"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :related_documents) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_documents"
+            content_block.public_name_key = "decidim.application.documents.related_documents"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :related_images) do |content_block|
+            content_block.cell = "decidim/content_blocks/participatory_space_images"
+            content_block.public_name_key = "decidim.application.photos.related_photos"
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :stats) do |content_block|
+            content_block.cell = "decidim/participatory_process_groups/content_blocks/statistics"
+            content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.stats.name"
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :participatory_processes) do |content_block|
+            content_block.cell = "decidim/participatory_process_groups/content_blocks/related_processes"
+            content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/processes_settings_form"
+            content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.participatory_processes.name"
+
+            content_block.settings do |settings|
+              settings.attribute :default_filter, type: :enum, default: "all", choices: %w(active all)
+            end
+
+            content_block.default!
+          end
+
+          register_highlighted_meetings
+          register_highlighted_posts
+          register_highlighted_proposals
+          register_highlighted_results
+          register_related_assemblies
+        end
+
+        def self.register_highlighted_meetings
+          return unless Decidim.module_installed?(:meetings)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_meetings) do |content_block|
+            content_block.cell = "decidim/meetings/content_blocks/highlighted_meetings"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.meetings.content_blocks.upcoming_meetings.name"
+            content_block.component_manifest_name = "meetings"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :highlighted_meetings) do |content_block|
+            content_block.cell = "decidim/meetings/content_blocks/highlighted_meetings"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_settings_form"
+            content_block.public_name_key = "decidim.meetings.content_blocks.upcoming_meetings.name"
+            content_block.component_manifest_name = "meetings"
+            content_block.default!
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
+              settings.attribute :show_space, type: :boolean, default: true
+            end
+
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_posts
+          return unless Decidim.module_installed?(:blogs)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_posts) do |content_block|
+            content_block.cell = "decidim/blogs/content_blocks/highlighted_posts"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.blogs.content_blocks.highlighted_posts.name"
+            content_block.component_manifest_name = "blogs"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_proposals
+          return unless Decidim.module_installed?(:proposals)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_proposals) do |content_block|
+            content_block.cell = "decidim/proposals/content_blocks/highlighted_proposals"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.proposals.content_blocks.highlighted_proposals.name"
+            content_block.component_manifest_name = "proposals"
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "recent", choices: %w(random recent)
+              settings.attribute :component_id, type: :select, default: nil
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :highlighted_proposals) do |content_block|
+            content_block.cell = "decidim/proposals/content_blocks/highlighted_proposals"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_settings_form"
+            content_block.public_name_key = "decidim.proposals.content_blocks.highlighted_proposals.name"
+            content_block.component_manifest_name = "proposals"
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
+              settings.attribute :show_space, type: :boolean, default: true
+            end
+
+            content_block.default!
+          end
+        end
+
+        def self.register_highlighted_results
+          return unless Decidim.module_installed?(:accountability)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_results) do |content_block|
+            content_block.cell = "decidim/accountability/content_blocks/highlighted_results"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.accountability.content_blocks.highlighted_results.results"
+            content_block.component_manifest_name = "accountability"
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
+              settings.attribute :component_id, type: :select, default: nil
+            end
+
+            content_block.default!
+          end
+
+          Decidim.content_blocks.register(:participatory_process_group_homepage, :highlighted_results) do |content_block|
+            content_block.cell = "decidim/accountability/content_blocks/highlighted_results"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_settings_form"
+            content_block.public_name_key = "decidim.accountability.content_blocks.highlighted_results.results"
+            content_block.component_manifest_name = "accountability"
+            content_block.default!
+
+            content_block.settings do |settings|
+              settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
+              settings.attribute :show_space, type: :boolean, default: true
+            end
+
+            content_block.default!
+          end
+        end
+
+        def self.register_related_assemblies
+          return unless Decidim.module_installed?(:assemblies)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :related_assemblies) do |content_block|
+            content_block.cell = "decidim/assemblies/content_blocks/related_assemblies"
+            content_block.settings_form_cell = "decidim/assemblies/content_blocks/highlighted_assemblies_settings_form"
+            content_block.public_name_key = "decidim.assemblies.content_blocks.related_assemblies.name"
+
+            content_block.settings do |settings|
+              settings.attribute :max_results, type: :integer, default: 6
+            end
+
+            content_block.default!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR aims to change the way content_blocks are generated for PP's, PP's groups and Assemblies to match what was done on 0.27 + it manages automatically the order to match what was also done previously.

It also changes the default sort for the "Participatory processes" content_block on PP's groups to "all" instead of "actives"

#### :pushpin: Related Issues
- [Feature 0.29 - Blocs de contenus actifs par défaut](https://opensourcepolitics.odoo.com/odoo/all-tasks/4287)

#### Testing
Example:
* Log in as admin
* Access Backoffice
* Create a PP, a PP group and an Assembly
* Check each landing page
* Make sure screenshots on the card matches the landing page that was generated through your components

#### Tasks
- [x] Override Content Blocks Creator Service (maybe we should try to create an extend but I didn't manage to)
- [x] Override Assembly registery manager onto an initializer
- [x] Override PP's and PP's groups registery manager onto an initializer
