### PR TITLE
Fix/copy blocks when duplicating assemblies or pp

### DIFF
--- a/app/views/decidim/assemblies/admin/assembly_copies/_form.html.erb
+++ b/app/views/decidim/assemblies/admin/assembly_copies/_form.html.erb
@@ -1,0 +1,33 @@
+<%= append_javascript_pack_tag "decidim_assemblies_admin" %>
+<div class="form__wrapper">
+  <div class="card pt-4" id="assemblies">
+    <div class="card-section">
+      <div class="row column">
+        <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
+      </div>
+      <div class="row column slug">
+        <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
+      </div>
+      <div class="card">
+        <div class="card-divider">
+          <legend><%= t("assembly_copies.new.select", scope: "decidim.admin") %></legend>
+        </div>
+        <div class="card-section">
+          <div class="row">
+            <div class="columns">
+              <%= form.check_box :copy_categories %>
+            </div>
+
+            <div class="columns">
+              <%= form.check_box :copy_components %>
+            </div>
+
+            <div class="columns">
+              <%= form.check_box :copy_landing_page_blocks %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
+++ b/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
@@ -1,0 +1,38 @@
+<div class="form__wrapper">
+  <div class="card pt-4" id="processes">
+    <div class="card-section">
+      <div class="row column">
+        <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
+      </div>
+      <div class="row column">
+        <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:processes, form.object.slug)) %>
+      </div>
+      <div class="row column">
+        <div class="card">
+          <div class="card-divider">
+            <legend><%= t("participatory_process_copies.new.select", scope: "decidim.admin") %></legend>
+          </div>
+          <div class="card-section">
+            <div class="row">
+              <div class="columns">
+                <%= form.check_box :copy_steps %>
+              </div>
+
+              <div class="columns">
+                <%= form.check_box :copy_categories %>
+              </div>
+
+              <div class="columns">
+                <%= form.check_box :copy_components %>
+              </div>
+
+              <div class="columns">
+                <%= form.check_box :copy_landing_page_blocks %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ module DecidimApp
     config.after_initialize do
       require "extends/commands/decidim/proposals/publish_proposal_extends"
       require "extends/commands/decidim/admin/create_attachment_extends"
+      require "extends/commands/decidim/assemblies/admin/copy_assembly_extends"
+      require "extends/forms/decidim/assemblies/admin/assembly_copy_form_extends"
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,10 +12,14 @@ module DecidimApp
     config.load_defaults 7.0
 
     config.after_initialize do
+      # commands
       require "extends/commands/decidim/proposals/publish_proposal_extends"
       require "extends/commands/decidim/admin/create_attachment_extends"
       require "extends/commands/decidim/assemblies/admin/copy_assembly_extends"
+      require "extends/commands/decidim/participatory_processes/admin/copy_participatory_process_extends"
+      # forms
       require "extends/forms/decidim/assemblies/admin/assembly_copy_form_extends"
+      require "extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends"
     end
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -82,7 +82,12 @@ translation:
 
 # Do not consider these keys missing:
 ignore_missing:
-
+  - decidim.admin.assembly_copies.new.select
+  - decidim.assemblies.admin.assembly_copies.new.select
+  - decidim.assemblies.admin.assembly_copies.form.slug_help_html
+  - decidim.admin.participatory_process_copies.new.select
+  - decidim.participatory_processes.admin.participatory_process_copies.new.select
+  - decidim.participatory_processes.admin.participatory_process_copies.form.slug_help_html
 
 # Consider these keys used:
 ignore_unused:
@@ -94,3 +99,5 @@ ignore_unused:
   - decidim.initiatives.admin.initiatives_types.*
   - time.buttons.*
   - decidim.admin.models.assembly.fields.promoted.*
+  - activemodel.attributes.assembly.copy_landing_page_blocks
+  - activemodel.attributes.participatory_process.copy_landing_page_blocks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,11 @@
 ---
 en:
+  activemodel:
+    attributes:
+      assembly:
+        copy_landing_page_blocks: Copy landing page blocks
+      participatory_process:
+        copy_landing_page_blocks: Copy landing page blocks
   decidim:
     admin:
       attachments:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,11 @@
 ---
 fr:
+  activemodel:
+    attributes:
+      assembly:
+        copy_landing_page_blocks: Copier les blocs de la page d'accueil
+      participatory_process:
+        copy_landing_page_blocks: Copier les blocs de la page d'accueil
   decidim:
     admin:
       attachments:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema[7.0].define(version: 2025_03_03_145039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -412,14 +411,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_03_145039) do
     t.bigint "decidim_budgets_budget_id"
     t.index ["decidim_budgets_budget_id"], name: "index_decidim_budgets_orders_on_decidim_budgets_budget_id"
     t.index ["decidim_user_id"], name: "index_decidim_budgets_orders_on_decidim_user_id"
-  end
-
-  create_table "decidim_budgets_paper_ballot_results", force: :cascade do |t|
-    t.integer "votes", null: false
-    t.bigint "decidim_project_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["decidim_project_id"], name: "index_decidim_paper_ballot_on_project"
   end
 
   create_table "decidim_budgets_projects", id: :serial, force: :cascade do |t|

--- a/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
+++ b/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
@@ -21,24 +21,23 @@ module CopyAssemblyExtends
       broadcast(:ok, @copied_assembly)
     end
 
-
     private
 
     def copy_landing_page_blocks
       blocks = Decidim::ContentBlock.where(scoped_resource_id: @assembly.id, scope_name: "assembly_homepage", organization: @assembly.organization)
-      if blocks.present?
-        blocks.each do |block|
-          new_block = Decidim::ContentBlock.create!(
-            organization: @copied_assembly.organization,
-            scope_name: "assembly_homepage",
-            scoped_resource_id: @copied_assembly.id,
-            manifest_name: block.manifest_name,
-            settings: block.settings,
-            weight: block.weight,
-            published_at: block.published_at.present? ? @copied_assembly.created_at : nil, # determine if block is active/inactive
-            )
-          copy_block_attachments(block, new_block) if block.attachments.present?
-        end
+      return if blocks.blank?
+
+      blocks.each do |block|
+        new_block = Decidim::ContentBlock.create!(
+          organization: @copied_assembly.organization,
+          scope_name: "assembly_homepage",
+          scoped_resource_id: @copied_assembly.id,
+          manifest_name: block.manifest_name,
+          settings: block.settings,
+          weight: block.weight,
+          published_at: block.published_at.present? ? @copied_assembly.created_at : nil # determine if block is active/inactive
+        )
+        copy_block_attachments(block, new_block) if block.attachments.present?
       end
     end
 

--- a/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
+++ b/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module CopyAssemblyExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def call
+      return broadcast(:invalid) if form.invalid?
+
+      Decidim.traceability.perform_action!("duplicate", @assembly, @user) do
+        Decidim::Assembly.transaction do
+          copy_assembly
+          copy_assembly_attachments
+          copy_assembly_categories if @form.copy_categories?
+          copy_assembly_components if @form.copy_components?
+          copy_landing_page_blocks if @form.copy_landing_page_blocks?
+        end
+      end
+
+      broadcast(:ok, @copied_assembly)
+    end
+
+
+    private
+
+    def copy_landing_page_blocks
+      blocks = Decidim::ContentBlock.where(scoped_resource_id: @assembly.id, scope_name: "assembly_homepage", organization: @assembly.organization)
+      if blocks.present?
+        blocks.each do |block|
+          new_block = Decidim::ContentBlock.create!(
+            organization: @copied_assembly.organization,
+            scope_name: "assembly_homepage",
+            scoped_resource_id: @copied_assembly.id,
+            manifest_name: block.manifest_name,
+            settings: block.settings,
+            weight: block.weight,
+            published_at: block.published_at.present? ? @copied_assembly.created_at : nil, # determine if block is active/inactive
+            )
+          copy_block_attachments(block, new_block) if block.attachments.present?
+        end
+      end
+    end
+
+    def copy_block_attachments(block, new_block)
+      block.attachments.map(&:name).each do |name|
+        original_image = block.images_container.send(name).blob.download
+        new_block.images_container.send("#{name}=", ActiveStorage::Blob.create_and_upload!(
+                                                      io: StringIO.new(original_image),
+                                                      filename: "image.png",
+                                                      content_type: block.images_container.background_image.blob.content_type
+                                                    ))
+        new_block.save!
+      end
+    end
+  end
+end
+
+Decidim::Assemblies::Admin::CopyAssembly.include(CopyAssemblyExtends)

--- a/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
+++ b/lib/extends/commands/decidim/assemblies/admin/copy_assembly_extends.rb
@@ -43,9 +43,11 @@ module CopyAssemblyExtends
 
     def copy_block_attachments(block, new_block)
       block.attachments.map(&:name).each do |name|
-        original_image = block.images_container.send(name).blob.download
+        original_image = block.images_container.send(name).blob
+        next if original_image.blank?
+
         new_block.images_container.send("#{name}=", ActiveStorage::Blob.create_and_upload!(
-                                                      io: StringIO.new(original_image),
+                                                      io: StringIO.new(original_image.download),
                                                       filename: "image.png",
                                                       content_type: block.images_container.background_image.blob.content_type
                                                     ))

--- a/lib/extends/commands/decidim/participatory_processes/admin/copy_participatory_process_extends.rb
+++ b/lib/extends/commands/decidim/participatory_processes/admin/copy_participatory_process_extends.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module CopyParticipatoryProcessExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def call
+      return broadcast(:invalid) if form.invalid?
+
+      Decidim.traceability.perform_action!("duplicate", @participatory_process, current_user) do
+        Decidim::ParticipatoryProcess.transaction do
+          copy_participatory_process
+          copy_participatory_process_attachments
+          copy_participatory_process_steps if @form.copy_steps?
+          copy_participatory_process_categories if @form.copy_categories?
+          copy_participatory_process_components if @form.copy_components?
+          copy_landing_page_blocks if @form.copy_landing_page_blocks?
+        end
+      end
+
+      broadcast(:ok, @copied_process)
+    end
+
+    private
+
+    def copy_landing_page_blocks
+      blocks = Decidim::ContentBlock.where(scoped_resource_id: @participatory_process.id, scope_name: "participatory_process_homepage",
+                                           organization: @participatory_process.organization)
+      return if blocks.blank?
+
+      blocks.each do |block|
+        new_block = Decidim::ContentBlock.create!(
+          organization: @copied_process.organization,
+          scope_name: "participatory_process_homepage",
+          scoped_resource_id: @copied_process.id,
+          manifest_name: block.manifest_name,
+          settings: block.settings,
+          weight: block.weight,
+          published_at: block.published_at.present? ? @copied_process.created_at : nil # determine if block is active/inactive
+        )
+        copy_block_attachments(block, new_block) if block.attachments.present?
+      end
+    end
+
+    def copy_block_attachments(block, new_block)
+      block.attachments.map(&:name).each do |name|
+        original_image = block.images_container.send(name).blob
+        next if original_image.blank?
+
+        new_block.images_container.send("#{name}=", ActiveStorage::Blob.create_and_upload!(
+                                                      io: StringIO.new(original_image.download),
+                                                      filename: "image.png",
+                                                      content_type: block.images_container.background_image.blob.content_type
+                                                    ))
+        new_block.save!
+      end
+    end
+  end
+end
+
+Decidim::ParticipatoryProcesses::Admin::CopyParticipatoryProcess.include(CopyParticipatoryProcessExtends)

--- a/lib/extends/forms/decidim/assemblies/admin/assembly_copy_form_extends.rb
+++ b/lib/extends/forms/decidim/assemblies/admin/assembly_copy_form_extends.rb
@@ -6,9 +6,7 @@ module AssemblyCopyFormExtends
   extend ActiveSupport::Concern
 
   included do
-
     attribute :copy_landing_page_blocks, Decidim::AttributeObject::TypeMap::Boolean
-
   end
 end
 

--- a/lib/extends/forms/decidim/assemblies/admin/assembly_copy_form_extends.rb
+++ b/lib/extends/forms/decidim/assemblies/admin/assembly_copy_form_extends.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module AssemblyCopyFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+
+    attribute :copy_landing_page_blocks, Decidim::AttributeObject::TypeMap::Boolean
+
+  end
+end
+
+Decidim::Assemblies::Admin::AssemblyCopyForm.include(AssemblyCopyFormExtends)

--- a/lib/extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends.rb
+++ b/lib/extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ParticipatoryProcessCopyFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :copy_landing_page_blocks, Decidim::AttributeObject::TypeMap::Boolean
+  end
+end
+
+Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessCopyForm.include(ParticipatoryProcessCopyFormExtends)

--- a/spec/commands/copy_assembly_spec.rb
+++ b/spec/commands/copy_assembly_spec.rb
@@ -21,7 +21,7 @@ module Decidim::Assemblies
         slug: "copied-slug",
         copy_categories?: copy_categories,
         copy_components?: copy_components,
-        copy_landing_page_blocks?: copy_landing_page_blocks,
+        copy_landing_page_blocks?: copy_landing_page_blocks
       )
     end
     let!(:category) do
@@ -75,8 +75,8 @@ module Decidim::Assemblies
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-                .with("duplicate", Decidim::Assembly, user)
-                .and_call_original
+          .with("duplicate", Decidim::Assembly, user)
+          .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last
@@ -112,7 +112,7 @@ module Decidim::Assemblies
         expect { subject.call }.to change(Decidim::Component, :count).by(1)
 
         last_assembly = Decidim::Assembly.last
-        last_component = Decidim::Component.all.reorder(:id).last
+        last_component = Decidim::Component.reorder(:id).last
 
         expect(last_component.participatory_space).to eq(last_assembly)
         expect(last_component.name).to eq(component.name)

--- a/spec/commands/copy_assembly_spec.rb
+++ b/spec/commands/copy_assembly_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Assemblies
+  describe Admin::CopyAssembly do
+    subject { described_class.new(form, assembly, user) }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, organization:) }
+    let(:scope) { create(:scope, organization:) }
+    let(:errors) { double.as_null_object }
+    let!(:assembly) { create(:assembly) }
+    let!(:content_block) { create(:content_block, manifest_name: :hero, organization: assembly.organization, scope_name: :assembly_homepage, scoped_resource_id: assembly.id) }
+    let!(:component) { create(:component, manifest_name: :dummy, participatory_space: assembly) }
+    let(:form) do
+      instance_double(
+        Admin::AssemblyCopyForm,
+        invalid?: invalid,
+        title: { en: "title" },
+        slug: "copied-slug",
+        copy_categories?: copy_categories,
+        copy_components?: copy_components,
+        copy_landing_page_blocks?: copy_landing_page_blocks,
+      )
+    end
+    let!(:category) do
+      create(
+        :category,
+        participatory_space: assembly
+      )
+    end
+
+    let(:invalid) { false }
+    let(:copy_categories) { false }
+    let(:copy_components) { false }
+    let(:copy_landing_page_blocks) { false }
+
+    context "when the form is not valid" do
+      let(:invalid) { true }
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      it "duplicates an assembly" do
+        expect { subject.call }.to change(Decidim::Assembly, :count).by(1)
+
+        old_assembly = Decidim::Assembly.first
+        new_assembly = Decidim::Assembly.last
+
+        expect(new_assembly.slug).to eq("copied-slug")
+        expect(new_assembly.title["en"]).to eq("title")
+        expect(new_assembly).not_to be_published
+        expect(new_assembly.organization).to eq(old_assembly.organization)
+        expect(new_assembly.subtitle).to eq(old_assembly.subtitle)
+        expect(new_assembly.description).to eq(old_assembly.description)
+        expect(new_assembly.short_description).to eq(old_assembly.short_description)
+        expect(new_assembly.promoted).to eq(old_assembly.promoted)
+        expect(new_assembly.scope).to eq(old_assembly.scope)
+        expect(new_assembly.developer_group).to eq(old_assembly.developer_group)
+        expect(new_assembly.local_area).to eq(old_assembly.local_area)
+        expect(new_assembly.target).to eq(old_assembly.target)
+        expect(new_assembly.participatory_scope).to eq(old_assembly.participatory_scope)
+        expect(new_assembly.meta_scope).to eq(old_assembly.meta_scope)
+        expect(new_assembly.announcement).to eq(old_assembly.announcement)
+      end
+
+      it "broadcasts ok" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+                .with("duplicate", Decidim::Assembly, user)
+                .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("duplicate")
+        expect(action_log.version).to be_present
+      end
+    end
+
+    context "when copy_categories exists" do
+      let(:copy_categories) { true }
+
+      it "duplicates an assembly and the categories" do
+        expect { subject.call }.to change(Decidim::Category, :count).by(1)
+        expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 2
+
+        old_assembly_category = Decidim::Category.unscoped.first
+        new_assembly_category = Decidim::Category.unscoped.last
+
+        expect(new_assembly_category.name).to eq(old_assembly_category.name)
+        expect(new_assembly_category.description).to eq(old_assembly_category.description)
+        expect(new_assembly_category.parent).to eq(old_assembly_category.parent)
+      end
+    end
+
+    context "when copy_components exists" do
+      let(:copy_components) { true }
+
+      it "duplicates an assembly and the components" do
+        dummy_hook = proc {}
+        component.manifest.on :copy, &dummy_hook
+        expect(dummy_hook).to receive(:call).with({ new_component: an_instance_of(Decidim::Component), old_component: component })
+
+        expect { subject.call }.to change(Decidim::Component, :count).by(1)
+
+        last_assembly = Decidim::Assembly.last
+        last_component = Decidim::Component.all.reorder(:id).last
+
+        expect(last_component.participatory_space).to eq(last_assembly)
+        expect(last_component.name).to eq(component.name)
+        expect(last_component.settings.attributes.except("dummy_global_translatable_text")).to eq(component.settings.attributes.except("dummy_global_translatable_text"))
+        expect(last_component.settings.attributes["dummy_global_translatable_text"]).to include(component.settings.attributes["dummy_global_translatable_text"])
+        expect(last_component.step_settings.keys).to eq(component.step_settings.keys)
+        expect(last_component.step_settings.values).to eq(component.step_settings.values)
+      end
+    end
+
+    context "when copy_landing_page_blocks exists" do
+      let(:copy_landing_page_blocks) { true }
+      let(:original_image) do
+        Rack::Test::UploadedFile.new(
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+          "image/jpeg"
+        )
+      end
+
+      before do
+        content_block.images_container.background_image.purge
+        content_block.images_container.background_image = original_image
+        content_block.save
+        content_block.reload
+      end
+
+      it "duplicates an assembly and the content_block with its attachments" do
+        expect { subject.call }.to change(Decidim::ContentBlock, :count).by(1)
+
+        old_block = Decidim::ContentBlock.unscoped.first
+        new_block = Decidim::ContentBlock.unscoped.last
+        last_assembly = Decidim::Assembly.last
+
+        expect(new_block.scope_name).to eq(old_block.scope_name)
+        expect(new_block.manifest_name).to eq(old_block.manifest_name)
+        # published_at is set in content_block factory
+        expect(new_block.published_at).not_to be_nil
+        expect(new_block.scoped_resource_id).to eq(last_assembly.id)
+        expect(new_block.attachments.length).to eq(1)
+        expect(new_block.attachments.first.name).to eq("background_image")
+        expect(new_block.images_container.attached_uploader(:background_image).url).not_to be_nil
+      end
+    end
+
+    context "when copying a child assembly" do
+      context "when the form is not valid" do
+        let(:invalid) { true }
+
+        it "broadcasts invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
+
+      context "when everything is ok" do
+        let!(:assembly_parent) { create(:assembly, organization:) }
+        let!(:assembly) { create(:assembly, parent: assembly_parent, organization:) }
+
+        it "duplicates an assembly" do
+          expect { subject.call }.to change(Decidim::Assembly, :count).by(1)
+
+          old_assembly = Decidim::Assembly.find_by(id: assembly.id)
+          new_assembly = Decidim::Assembly.last
+
+          expect(new_assembly.slug).to eq("copied-slug")
+          expect(new_assembly.title["en"]).to eq("title")
+          expect(new_assembly).not_to be_published
+          expect(new_assembly.organization).to eq(old_assembly.organization)
+          expect(new_assembly.subtitle).to eq(old_assembly.subtitle)
+          expect(new_assembly.description).to eq(old_assembly.description)
+          expect(new_assembly.short_description).to eq(old_assembly.short_description)
+          expect(new_assembly.promoted).to eq(old_assembly.promoted)
+          expect(new_assembly.scope).to eq(old_assembly.scope)
+          expect(new_assembly.parent).to eq(old_assembly.parent)
+          expect(new_assembly.developer_group).to eq(old_assembly.developer_group)
+          expect(new_assembly.local_area).to eq(old_assembly.local_area)
+          expect(new_assembly.target).to eq(old_assembly.target)
+          expect(new_assembly.participatory_scope).to eq(old_assembly.participatory_scope)
+          expect(new_assembly.meta_scope).to eq(old_assembly.meta_scope)
+        end
+
+        it "broadcasts ok" do
+          expect { subject.call }.to broadcast(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/copy_participatory_process_spec.rb
+++ b/spec/commands/copy_participatory_process_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe Admin::CopyParticipatoryProcess do
+    subject { described_class.new(form, participatory_process) }
+
+    let(:organization) { create(:organization) }
+    let(:current_user) { create(:user, organization:) }
+    let(:participatory_process_group) { create(:participatory_process_group, organization:) }
+    let(:scope) { create(:scope, organization:) }
+    let(:errors) { double.as_null_object }
+    let!(:participatory_process) { create(:participatory_process, :with_steps) }
+    let!(:content_block) { create(:content_block, manifest_name: :hero, organization: participatory_process.organization, scope_name: :participatory_process_homepage, scoped_resource_id: participatory_process.id) }
+    let!(:component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
+    let(:form) do
+      instance_double(
+        Admin::ParticipatoryProcessCopyForm,
+        invalid?: invalid,
+        title: { en: "title" },
+        slug: "copied-slug",
+        copy_steps?: copy_steps,
+        copy_categories?: copy_categories,
+        copy_components?: copy_components,
+        copy_landing_page_blocks?: copy_landing_page_blocks,
+        current_user:
+      )
+    end
+    let!(:category) do
+      create(
+        :category,
+        participatory_space: participatory_process
+      )
+    end
+
+    let(:invalid) { false }
+    let(:copy_steps) { false }
+    let(:copy_categories) { false }
+    let(:copy_components) { false }
+    let(:copy_landing_page_blocks) { false }
+
+    context "when the form is not valid" do
+      let(:invalid) { true }
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      it "duplicates a participatory process" do
+        expect { subject.call }.to change(Decidim::ParticipatoryProcess, :count).by(1)
+
+        old_participatory_process = Decidim::ParticipatoryProcess.first
+        new_participatory_process = Decidim::ParticipatoryProcess.last
+
+        expect(new_participatory_process.slug).to eq("copied-slug")
+        expect(new_participatory_process.title["en"]).to eq("title")
+        expect(new_participatory_process).not_to be_published
+        expect(new_participatory_process.organization).to eq(old_participatory_process.organization)
+        expect(new_participatory_process.subtitle).to eq(old_participatory_process.subtitle)
+        expect(new_participatory_process.description).to eq(old_participatory_process.description)
+        expect(new_participatory_process.short_description).to eq(old_participatory_process.short_description)
+        expect(new_participatory_process.promoted).to eq(old_participatory_process.promoted)
+        expect(new_participatory_process.scope).to eq(old_participatory_process.scope)
+        expect(new_participatory_process.developer_group).to eq(old_participatory_process.developer_group)
+        expect(new_participatory_process.local_area).to eq(old_participatory_process.local_area)
+        expect(new_participatory_process.target).to eq(old_participatory_process.target)
+        expect(new_participatory_process.participatory_scope).to eq(old_participatory_process.participatory_scope)
+        expect(new_participatory_process.meta_scope).to eq(old_participatory_process.meta_scope)
+        expect(new_participatory_process.end_date).to eq(old_participatory_process.end_date)
+        expect(new_participatory_process.participatory_process_group).to eq(old_participatory_process.participatory_process_group)
+        expect(new_participatory_process.private_space).to eq(old_participatory_process.private_space)
+      end
+
+      it "broadcasts ok" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with("duplicate", Decidim::ParticipatoryProcess, current_user)
+          .and_call_original
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("duplicate")
+        expect(action_log.version).to be_present
+      end
+    end
+
+    context "when copy_steps exists" do
+      let(:copy_steps) { true }
+
+      it "duplicates a participatory process and the steps" do
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessStep, :count).by(1)
+        expect(Decidim::ParticipatoryProcessStep.distinct.pluck(:decidim_participatory_process_id).count).to eq 2
+
+        old_participatory_process_step = Decidim::ParticipatoryProcessStep.first
+        new_participatory_process_step = Decidim::ParticipatoryProcessStep.last
+
+        expect(new_participatory_process_step.title).to eq(old_participatory_process_step.title)
+        expect(new_participatory_process_step.description).to eq(old_participatory_process_step.description)
+        expect(new_participatory_process_step.end_date).to eq(old_participatory_process_step.end_date)
+        expect(new_participatory_process_step.start_date).to eq(old_participatory_process_step.start_date)
+      end
+    end
+
+    context "when copy_categories exists" do
+      let(:copy_categories) { true }
+
+      it "duplicates a participatory process and the categories" do
+        expect { subject.call }.to change(Decidim::Category, :count).by(1)
+        expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 2
+
+        old_participatory_process_category = Decidim::Category.unscoped.first
+        new_participatory_process_category = Decidim::Category.unscoped.last
+
+        expect(new_participatory_process_category.name).to eq(old_participatory_process_category.name)
+        expect(new_participatory_process_category.description).to eq(old_participatory_process_category.description)
+        expect(new_participatory_process_category.participatory_space).not_to eq(participatory_process)
+      end
+
+      context "with subcategories" do
+        let!(:subcategory) { create(:category, parent: category, participatory_space: participatory_process) }
+
+        it "duplicates the parent and its children" do
+          expect { subject.call }.to change(Decidim::Category, :count).by(2)
+          new_participatory_process = Decidim::ParticipatoryProcess.last
+
+          expect(participatory_process.categories.count).to eq(2)
+          expect(new_participatory_process.categories.count).to eq(2)
+        end
+      end
+    end
+
+    context "when copy_components exists" do
+      let(:copy_components) { true }
+
+      it "duplicates a participatory process and the components" do
+        dummy_hook = proc {}
+        component.manifest.on :copy, &dummy_hook
+        expect(dummy_hook).to receive(:call).with({ new_component: an_instance_of(Decidim::Component), old_component: component })
+
+        expect { subject.call }.to change(Decidim::Component, :count).by(1)
+
+        last_participatory_process = Decidim::ParticipatoryProcess.last
+        last_component = Decidim::Component.reorder(:id).last
+
+        expect(last_component.participatory_space).to eq(last_participatory_process)
+        expect(last_component.name).to eq(component.name)
+        expect(last_component.settings.attributes.except("dummy_global_translatable_text")).to eq(component.settings.attributes.except("dummy_global_translatable_text"))
+        expect(last_component.settings.attributes["dummy_global_translatable_text"]).to include(component.settings.attributes["dummy_global_translatable_text"])
+        expect(last_component.step_settings.keys).not_to eq(component.step_settings.keys)
+        expect(last_component.step_settings.values).not_to eq(component.step_settings.values)
+      end
+    end
+
+    context "when copy_landing_page_blocks exists" do
+      let(:copy_landing_page_blocks) { true }
+      let(:original_image) do
+        Rack::Test::UploadedFile.new(
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+          "image/jpeg"
+        )
+      end
+
+      before do
+        content_block.images_container.background_image.purge
+        content_block.images_container.background_image = original_image
+        content_block.save
+        content_block.reload
+      end
+
+      it "duplicates a participatory_process and the content_block with its attachments" do
+        expect { subject.call }.to change(Decidim::ContentBlock, :count).by(1)
+
+        old_block = Decidim::ContentBlock.unscoped.first
+        new_block = Decidim::ContentBlock.unscoped.last
+        last_process = Decidim::ParticipatoryProcess.last
+
+        expect(new_block.scope_name).to eq(old_block.scope_name)
+        expect(new_block.manifest_name).to eq(old_block.manifest_name)
+        # published_at is set in content_block factory
+        expect(new_block.published_at).not_to be_nil
+        expect(new_block.scoped_resource_id).to eq(last_process.id)
+        expect(new_block.attachments.length).to eq(1)
+        expect(new_block.attachments.first.name).to eq("background_image")
+        expect(new_block.images_container.attached_uploader(:background_image).url).not_to be_nil
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,15 +1328,15 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
-"@esbuild/darwin-arm64@0.19.12":
+"@esbuild/darwin-x64@0.19.12":
   version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz"
-  integrity sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz"
+  integrity sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==
 
-"@esbuild/darwin-arm64@0.21.5":
+"@esbuild/darwin-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.1"
@@ -1668,10 +1668,10 @@
   resolved "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.1.2.tgz"
   integrity sha512-5DobW1CHgnBROOEpFlEXytED5OosEWESFvg/VYmH0143oXcijYTprRYJTs+55HzGM4IqxiLFSuqEzu9mPNwVsA==
 
-"@parcel/watcher-darwin-arm64@2.5.0":
+"@parcel/watcher-darwin-x64@2.5.0":
   version "2.5.0"
-  resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz"
-  integrity sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==
+  resolved "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz"
+  integrity sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.0"
@@ -8211,10 +8211,10 @@ safe-regex-test@^1.0.3:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-embedded-darwin-arm64@1.81.0:
+sass-embedded-darwin-x64@1.81.0:
   version "1.81.0"
-  resolved "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.81.0.tgz"
-  integrity sha512-gLKbsfII9Ppua76N41ODFnKGutla9qv0OGAas8gxe0jYBeAQFi/1iKQYdNtQtKi4mA9n5TQTqz+HHCKszZCoyA==
+  resolved "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.81.0.tgz"
+  integrity sha512-7uMOlT9hD2KUJCbTN2XcfghDxt/rc50ujjfSjSHjX1SYj7mGplkINUXvVbbvvaV2wt6t9vkGkCo5qNbeBhfwBg==
 
 sass-embedded@^1.63.6, sass-embedded@^1.79.3:
   version "1.81.0"


### PR DESCRIPTION
#### :tophat: Description
When an admin duplicates an assembly or a participatory_process, this PR allows to also duplicate blocks in landing page.

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/action-465/144/tasks/4280)

#### Testing
1. As an admin, go in the BO to the assemblies index
2. Find an assembly that has blocks in its landing page, with a background-image in the "Hero image and CTA" (add them if you don't find such an assembly)
3. On the assemblies index page, click on the duplicate button for the assembly you found (cf screenshot)
4. In the form, check the checkbox "copy landing page blocks"
5. See that a new assembly is created, that it has duplicated the blocks from the parent assembly in landing page, and that the "Hero image and CTA" block contains the image.
6. Reproduce steps 1 to 6 for a participatory_process

#### Tasks
- [X] Add specs

#### Screenshots
<img width="1358" alt="Capture d’écran 2025-03-10 à 11 34 31" src="https://github.com/user-attachments/assets/a8f40f6e-edc8-4d8f-b7e3-23233cf9e409" />
