### PR TITLE
Bump/decidim module homepage interactive map

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git
-  revision: 1ff222533cb3e7c30c8112a56c09c217c0530dbc
+  revision: 15e409e3b521b443f5824ed213ac3bdf9de62794
   branch: release/0.27-stable
   specs:
     decidim-homepage_interactive_map (2.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git
-  revision: 15e409e3b521b443f5824ed213ac3bdf9de62794
+  revision: 1ff222533cb3e7c30c8112a56c09c217c0530dbc
   branch: release/0.27-stable
   specs:
     decidim-homepage_interactive_map (2.0.1)


### PR DESCRIPTION
#### :tophat: Description
This PR bumps the decidim-module-homepage_interactive_map to the latest commit of its release/0.27-stable branch, to replace HERE with Openstreetmap in tile layer.

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/4291)
