### PR TITLE
fix(rake): Repair Proposals and Comments i18n data (#695)

### DIFF
--- a/lib/tasks/repair_data.rake
+++ b/lib/tasks/repair_data.rake
@@ -70,5 +70,56 @@ namespace :decidim do
         end
       end
     end
+
+    desc "Correct locales depth for proposals"
+    task proposals_locales: :environment do
+      total = Decidim::Proposals::Proposal.count
+      Rails.logger.warn("(decidim:repair:proposals_locales) > Checking locales for #{total} proposals...")
+      updated = 0
+      Decidim::Proposals::Proposal.find_each do |proposal|
+        title = proposal.title
+        body = proposal.body
+        new_title = {}
+        new_body = {}
+
+        Decidim.available_locales.map(&:to_s).each do |locale|
+          new_title[locale] = title[locale] if title[locale].present? && title[locale].is_a?(String)
+          new_title[locale] = title[locale].values.first if title[locale].present? && title[locale].is_a?(Hash)
+          new_body[locale] = body[locale] if body[locale].present? && body[locale].is_a?(String)
+          new_body[locale] = body[locale].values.first if body[locale].present? && body[locale].is_a?(Hash)
+        end
+
+        proposal.title = new_title if new_title.present?
+        proposal.body = new_body if new_body.present?
+        if proposal.changed?
+          updated += 1
+          proposal.save(validate: false)
+        end
+      end
+      Rails.logger.warn("(decidim:repair:proposals_locales) > Updated #{updated} proposals")
+    end
+
+    desc "Correct locales depth for comments"
+    task comments_locales: :environment do
+      total = Decidim::Comments::Comment.count
+      Rails.logger.warn("(decidim:repair:comments_locales) > Checking locales for #{total} comments...")
+      updated = 0
+      Decidim::Comments::Comment.find_each do |comment|
+        body = comment.body
+        new_body = {}
+
+        Decidim.available_locales.map(&:to_s).each do |locale|
+          new_body[locale] = body[locale] if body[locale].present? && body[locale].is_a?(String)
+          new_body[locale] = body[locale].values.first if body[locale].present? && body[locale].is_a?(Hash)
+        end
+
+        comment.body = new_body if new_body.present?
+        if comment.changed?
+          updated += 1
+          comment.save(validate: false)
+        end
+      end
+      Rails.logger.warn("(decidim:repair:comments_locales) > Updated #{updated} comments")
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Proposals and comments returns Internal Server Error in production after migrating to Decidim-app

[Proposal data move migration](https://github.com/decidim/decidim/blob/83be368eb17d4a1b77512dbb59ed2bff04e40246/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb#L45) has been run twice
And so [Comment data move migration](https://github.com/decidim/decidim/blob/a04d63a325ed94c49c8a20e4912ce4a9200f243b/decidim-comments/db/migrate/20200706123136_make_comments_handle_i18n.rb#L17) 

Stacktrace : 
```
ActionView::Template::Error (undefined method `to_str' for {"nl"=>"------"}:Hash
```



#### Note for deployment

Command to run
```
bundle exec rake decidim:repair:proposals_locales
bundle exec rake decidim:repair:comments_locales
bundle exec rake decidim:locales:rebuild_search
```