### PR TITLE
Fix date format in datepicker when creating a process 

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,8 @@
 ---
 fr:
+  date:
+    formats:
+      order: d-m-y
   decidim:
     admin:
       attachments:


### PR DESCRIPTION
#### :tophat: Description
When creating a process, the date format is incorrect for non-English languages as Castillan and French. The expected format should be day/month/year (DD/MM/YYYY), but in some cases, the date appears incorrectly as MM/DD/YYYY.

#### :pushpin: Related Issues
Issue*
- [Wrong date format in non-English languages when creating a process](https://github.com/decidim/decidim/issues/14312)

When creating a process, the date format is incorrect for non-English languages as Castillan and French. The expected format should be day/month/year (DD/MM/YYYY), but in some cases, the date appears incorrectly as MM/DD/YYYY.

To Reproduce
Change the language to French, or Castillan
Go to Admin > Processes > Create new process.
Look at the date field format, and fill it.
💥 The date appears incorrectly (MM/DD/YYYY instead of DD/MM/YYYY).

### :camera: Screenshots
<img width="1198" alt="Capture d’écran 2025-03-17 à 15 53 48" src="https://github.com/user-attachments/assets/43a30063-2292-4692-a318-875280aa018f" />

