### PR TITLE
fix: remove host from variant_url in mailer_logo partial

### DIFF
--- a/app/views/layouts/decidim/_mailer_logo.html.erb
+++ b/app/views/layouts/decidim/_mailer_logo.html.erb
@@ -1,0 +1,20 @@
+<% if organization %>
+  <% if defined?(custom_url_for_mail_root) && custom_url_for_mail_root.present? %>
+    <% url = custom_url_for_mail_root %>
+  <% else %>
+    <% url = decidim.root_url(host: organization.host) %>
+  <% end %>
+  <%= link_to url do %>
+    <% if organization.logo.attached? %>
+      <%= image_tag(
+            organization.attached_uploader(:logo).variant_url(:medium),
+            style: "max-height: 50px",
+            alt: organization_name(organization)
+          ) %>
+    <% else %>
+      <span><%= organization_name(organization) %></span>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= Decidim.application_name %>
+<% end %>


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to fix the error ActionView::Template::Error:unexpected value at params[:host]
that occured in sidekiq when trying to sign up or to reset a password (cf screenshot one). 
The error was linked to the line `organization.attached_uploader(:logo).variant_url(:medium, host: organization.host)` in mailer_logo partial, and has been fix by removing the host.

#### :pushpin: Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/4340)

#### Testing
You need to be in Docker to test this PR 

1. As an admin, go to the settings in the BO
2. Go to Appearance page and add a logo image
3. Log out
4. In a new tab, connect to https://localhost:3000/sidekiq
5. In the app, go to log in, and then to Forgot your password?
6. Fill your email and click on "send me reset password instructions"
7. Go to sidekiq tab, and see that everything is ok (nothing in Attempts)
8. Go to Docker desktop, to the sidekiq container logs and check that you have the email in the logs (cf screenshot 2), and that the MailDeliveryJob has performed well (cf screenshot 3)
9. in the app, create a new account, and check again steps 7 to 9. 

### :camera: Screenshots
ONE =>
<img width="1231" alt="Capture d’écran 2025-03-18 à 09 50 59" src="https://github.com/user-attachments/assets/ac5a3dca-b879-4d3c-9d74-46800f6f045d" />

TWO => 
<img width="1109" alt="two" src="https://github.com/user-attachments/assets/84565b09-f9c2-48a5-b29f-f9d46e1443fb" />

THREE => 
<img width="1006" alt="three" src="https://github.com/user-attachments/assets/4fb452ef-5703-4364-b03d-63a812d55df1" />


