### PR TITLE
fix alignment text document to review

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -28,3 +28,6 @@ a[title="Find out more about cookies"]{
   text-decoration: underline;
 }
 
+.docs__container button {
+  text-align: left;
+}


### PR DESCRIPTION
#### :tophat: Description
There was an alignement problem in the 'document to review' on the process show page
![image (1)](https://github.com/user-attachments/assets/6a506d3d-7e65-4680-ac9c-092d06d92889)


#### :pushpin: Related 
- [Notion Odoo](https://opensourcepolitics.odoo.com/odoo/all-tasks/4298)

#### Testing

1. As an admin, go to a participatory process where you can add an attachment ( Processes> Process> Attachments > Folders)
3. Create a folder with a long name, and associate it with a file.
4. Go to the frontend, and verify that the folder name is now properly left-aligned in the document list.

<img width="878" alt="Capture d’écran 2025-03-21 à 11 01 13" src="https://github.com/user-attachments/assets/96be4ed9-592c-49df-a2e8-17035062547e" />


### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
