### PR TITLE
Feat: modify coauthor in proposals file import

### DIFF
--- a/app/views/decidim/proposals/admin/imports/_proposals_fields.html.erb
+++ b/app/views/decidim/proposals/admin/imports/_proposals_fields.html.erb
@@ -1,0 +1,11 @@
+<% if current_organization.user_groups_enabled? && form.object.user_groups.any? %>
+  <div>
+    <%#= form.select(
+          :user_group_id,
+          form.object.user_groups.map { |g| [g.name, g.id] },
+          selected: form.object.user_group_id.presence,
+          include_blank: current_user.name,
+          label: true
+        ) %>
+  </div>
+<% end %>

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -3,3 +3,4 @@
 require "decidim/exporters/serializer"
 require "decidim/translations_helper"
 require "extends/lib/decidim/forms/user_answers_serializer_extend"
+require "extends/lib/decidim/proposals/import/proposal_creator_extends"

--- a/lib/extends/lib/decidim/proposals/import/proposal_creator_extends.rb
+++ b/lib/extends/lib/decidim/proposals/import/proposal_creator_extends.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ProposalCreatorExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def produce
+      resource.add_coauthor(context[:current_organization])
+      resource
+    end
+
+    def finish!
+      Decidim.traceability.perform_action!(:create, self.class.resource_klass, context[:current_user], visibility: "admin-only") do
+        resource.save!
+        resource
+      end
+      publish(resource)
+    end
+
+    private
+
+    def publish(proposal)
+      Decidim::EventsManager.publish(
+        event: "decidim.events.proposals.proposal_published",
+        event_class: Decidim::Proposals::PublishProposalEvent,
+        resource: proposal,
+        followers: proposal.participatory_space.followers,
+        extra: {
+          participatory_space: true
+        }
+      )
+    end
+  end
+end
+
+Decidim::Proposals::Import::ProposalCreator.class_eval do
+  include(ProposalCreatorExtends)
+end

--- a/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::Import::ProposalCreator do
+  subject { described_class.new(data, context) }
+
+  let!(:moment) { Time.current }
+  let(:data) do
+    {
+      :id => 1337,
+      "id" => "101",
+      :category => category,
+      :scope => scope,
+      :"title/en" => Faker::Lorem.sentence,
+      :"body/en" => Faker::Lorem.paragraph(sentence_count: 3),
+      :address => "#{Faker::Address.street_name}, #{Faker::Address.city}",
+      :latitude => Faker::Address.latitude,
+      :longitude => Faker::Address.longitude,
+      :component => component,
+      :published_at => moment
+    }
+  end
+  let(:organization) { create(:organization, available_locales: [:en]) }
+  let(:user) { create(:user, organization:) }
+  let(:context) do
+    {
+      current_organization: organization,
+      current_user: user,
+      current_component: component,
+      current_participatory_space: participatory_process
+    }
+  end
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:component) { create(:proposal_component, participatory_space: participatory_process) }
+  let(:scope) { create(:scope, organization:) }
+  let(:category) { create(:category, participatory_space: participatory_process) }
+
+  it "removes the IDs from the hash" do
+    expect(subject.instance_variable_get(:@data)).not_to have_key(:id)
+    expect(subject.instance_variable_get(:@data)).not_to have_key("id")
+  end
+
+  describe "#resource_klass" do
+    it "returns the correct class" do
+      expect(described_class.resource_klass).to be(Decidim::Proposals::Proposal)
+    end
+  end
+
+  describe "#resource_attributes" do
+    it "returns the attributes hash" do
+      expect(subject.resource_attributes).to eq(
+        "title/en": data[:"title/en"],
+        "body/en": data[:"body/en"],
+        category: data[:category],
+        scope: data[:scope],
+        address: data[:address],
+        latitude: data[:latitude],
+        longitude: data[:longitude],
+        component: data[:component],
+        published_at: data[:published_at]
+      )
+    end
+  end
+
+  describe "#produce" do
+    it "makes a new proposal" do
+      record = subject.produce
+
+      expect(record).to be_a(Decidim::Proposals::Proposal)
+      expect(record.category).to eq(category)
+      expect(record.scope).to eq(scope)
+      expect(record.title["en"]).to eq(data[:"title/en"])
+      expect(record.body["en"]).to eq(data[:"body/en"])
+      expect(record.address).to eq(data[:address])
+      expect(record.latitude).to eq(data[:latitude])
+      expect(record.longitude).to eq(data[:longitude])
+      expect(record.published_at).to be >= (moment)
+    end
+  end
+
+  describe "#finish!" do
+    it "saves the proposal" do
+      record = subject.produce
+      subject.finish!
+      expect(record.new_record?).to be(false)
+      expect(record.authors.first).to eq(organization)
+    end
+
+    it "creates admin log" do
+      record = subject.produce
+      expect { subject.finish! }.to change(Decidim::ActionLog, :count).by(1)
+      expect(Decidim::ActionLog.last.user).to eq(user)
+      expect(Decidim::ActionLog.last.resource).to eq(record)
+      expect(Decidim::ActionLog.last.visibility).to eq("admin-only")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to set the co-author of the proposals imported by file to the Organization, so that the author appears as "Official proposal".

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=103716385&issue=OpenSourcePolitics%7Cdecidim-app%7C713?


#### Testing

1. As an admin, export proposals as a CSV or XLS file
2. Import proposals from the file in a new proposal components
3. See that in FO the author of the imported proposals is "Official proposal"


#### Tasks
- [X ] Add specs

