### PR TITLE
fix: add new csp to allow openstreetmap images

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,7 +5,7 @@
 
 content_security_policies = {
   "default-src" => %w(decidim.storage.opensourcepolitics.eu templates.opensourcepolitics.net),
-  "img-src" => %w(decidim.storage.opensourcepolitics.eu),
+  "img-src" => %w(decidim.storage.opensourcepolitics.eu https://*.tile.openstreetmap.org),
   "media-src" => %w(decidim.storage.opensourcepolitics.eu www.youtube.com),
   "script-src" => %w(decidim.storage.opensourcepolitics.eu templates.opensourcepolitics.net tarteaucitron.io unpkg.com),
   "style-src" => %w(decidim.storage.opensourcepolitics.eu templates.opensourcepolitics.net),


### PR DESCRIPTION
#### :tophat: Description
This PR adds a new CSP to allow openstreetmap images.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=104646731&issue=OpenSourcePolitics%7Cdecidim-app%7C718

