### PR TITLE
Fix(system): remove Secret key length validation on organization form

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module DecidimApp
       require "extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends"
       require "extends/forms/decidim/proposals/proposal_form_extends"
       require "extends/forms/decidim/comments/comment_form_extends"
+      require "extends/forms/decidim/system/base_organization_form_extends"
       # controllers
       require "extends/controllers/decidim/admin/scopes_controller_extends"
       require "extends/controllers/decidim/scopes_controller_extends"

--- a/lib/extends/forms/decidim/system/base_organization_form_extends.rb
+++ b/lib/extends/forms/decidim/system/base_organization_form_extends.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module BaseOrganizationFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+    # TODO : Remove this when we have a procedure to update the secret_key_base
+    def validate_secret_key_base_for_encryption
+      true
+    end
+  end
+end
+
+Decidim::System::BaseOrganizationForm.include(BaseOrganizationFormExtends)


### PR DESCRIPTION
Remove the length validation (128 characters) added on the organization form in `/system` backend. 

If the `SECRET_KEY_BASE` is shorter than 128 characters, the organization form (create / edit) doesn't validate with the error message : 
```
EN : You need to define the SECRET_KEY_BASE environment variable to be able to save this field
FR : Vous devez définir la variable d'environnement SECRET_KEY_BASE pour pouvoir enregistrer ce champ
``` 

While we create a rake tasks to update short `SECRET_KEY_BASE` we need to temporary remove this validation to be able to update existing platform.