### PR TITLE
fix: Fix maps display on 0.29

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,3 +5,19 @@
 # Deactivate DEFACE when views are already precompiled
 # More information: https://github.com/spree/deface#production--precompiling
 DEFACE_ENABLED=false
+
+# Map provider and API key (used for map rendering)
+MAPS_PROVIDER=here                    # Main maps provider (e.g., 'osm', 'here')
+MAPS_API_KEY=                         # API key for the selected maps provider (if needed)
+
+# Static map configuration (for rendering fixed images)
+MAPS_STATIC_URL="https://image.maps.ls.hereapi.com/mia/1.6/mapview"  # Static map image service URL
+
+# Dynamic (interactive) map configuration
+MAPS_DYNAMIC_PROVIDER=osm            # Provider for dynamic/interactive maps (here it is OpenStreetMap)
+MAPS_DYNAMIC_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png  # Tile URL for the provider you are using (here it is OpenStreetMap)
+MAPS_ATTRIBUTION='<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap</a> contributors'  # Legal attribution for map tiles
+
+# Geocoder configuration (for converting addresses to coordinates)
+GEOCODER_TIMEOUT=5                   # Timeout for geocoding requests (in seconds)
+GEOCODER_UNITS=km                    # Units for geocoder results (e.g., km or mi)

--- a/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -1,0 +1,57 @@
+<% new_proposal ||= false %>
+<%= form.text_field :title, class: "js-hashtags", value: form_presenter.title %>
+
+<%= text_editor_for_proposal_body(form) %>
+
+<% if !new_proposal && @form.component_automatic_hashtags.any? %>
+  <%= field_set_tag form.label(:automatic_hashtags, nil, for: nil) do %>
+    <% @form.component_automatic_hashtags.each do |hashtag| %>
+      <%= form.check_box "", checked: true, disabled: true, label: "##{hashtag}", label_options: { class: "form__wrapper-checkbox-label" } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if !new_proposal && @form.component_suggested_hashtags.any? %>
+  <%= field_set_tag form.label(:suggested_hashtags, nil, for: nil) do %>
+    <%= form.collection_check_boxes :suggested_hashtags, @form.component_suggested_hashtags.map { |hashtag| [hashtag.downcase, "##{hashtag}"] }, :first, :last, { legend_title: "hey ho" } do |option|
+      option.label(class: "form__wrapper-checkbox-label") { option.check_box(checked: @form.suggested_hashtag_checked?(option.value)) + option.text }
+    end %>
+  <% end %>
+<% end %>
+
+<% if @form.geocoding_enabled? %>
+  <div id="address_input">
+    <div class="address-fill">
+      <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address"), data: { screen_reader_announcement: t("decidim.proposals.proposals.edit_form_fields.marker_added") } %>
+    </div>
+    <div id="address_map" class="proposal__container">
+      <p class="help-text">
+        <%= t("instructions", scope: "decidim.proposals.proposals.dynamic_map_instructions") %> <%= t("description", scope: "decidim.proposals.proposals.dynamic_map_instructions") %>
+      </p>
+      <%= dynamic_map_for proposal_preview_data_for_map(@form.to_h) %>
+    </div>
+  </div>
+<% end %>
+
+<% if @form.categories&.any? %>
+  <%= form.categories_select :category_id, @form.categories, include_blank: t("decidim.proposals.proposals.edit.select_a_category") %>
+<% end %>
+
+<% if current_component.has_subscopes? %>
+  <%= scopes_select_field form, :scope_id, root: current_component.scope %>
+<% end %>
+
+<% if component_settings.attachments_allowed? && (new_proposal || @proposal) %>
+  <%= form.attachment :documents,
+                      multiple: true,
+                      label: t("decidim.proposals.proposals.edit.add_documents"),
+                      button_label: t("decidim.proposals.proposals.edit.add_documents"),
+                      button_edit_label: t("decidim.proposals.proposals.edit.edit_documents"),
+                      button_class: "button button__lg button__transparent-secondary w-full",
+                      help_i18n_scope: "decidim.forms.file_help.file",
+                      help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit") %>
+<% end %>
+
+<% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+  <%= user_group_select_field form, :user_group_id %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module DecidimApp
 
     config.after_initialize do
       # commands
+      require "extends/commands/decidim/proposals/create_proposal_extends"
       require "extends/commands/decidim/proposals/publish_proposal_extends"
       require "extends/commands/decidim/admin/create_attachment_extends"
       require "extends/commands/decidim/assemblies/admin/copy_assembly_extends"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -110,3 +110,4 @@ ignore_unused:
   - decidim.components.proposals.settings.global.require_scope
   - decidim.admin.scopes.update.error
   - decidim.admin.scopes.update.success
+  - date.formats.order

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -143,15 +143,13 @@ Decidim.configure do |config|
       geocoding: {
         provider: Rails.application.secrets.maps[:geocoding_provider]&.to_sym || Rails.application.secrets.maps[:provider]&.to_sym || :here,
         api_key: Rails.application.secrets.maps[:geocoding_api_key] || Rails.application.secrets.maps[:api_key] || ""
-      }
-    }
+      },
 
-    if Rails.application.secrets.maps[:static_url].present?
-      config.maps[:static] = {
-        provider: Rails.application.secrets.maps[:static_provider]&.to_sym || Rails.application.secrets.maps[:provider]&.to_sym || :here,
+      static: {
+        provider: Rails.application.secrets.maps[:static_provider]&.to_sym || :here,
         url: Rails.application.secrets.maps[:static_url] || "https://image.maps.ls.hereapi.com/mia/1.6/mapview"
       }
-    end
+    }
 
     if Rails.application.secrets.maps[:extra_vars].present?
       vars = URI.decode_www_form(Rails.application.secrets.maps[:extra_vars])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
         copy_landing_page_blocks: Copy landing page blocks
       participatory_process:
         copy_landing_page_blocks: Copy landing page blocks
+  date:
+    formats:
+      order: "%Y-%m-%d"
   decidim:
     admin:
       actions:
@@ -14,6 +17,7 @@ en:
         confirm_destroy: Confirm destroy
         destroy: Destroy
         edit: Edit
+        new_assembly: New assembly
       attachments:
         form:
           send_notification_to_followers: Send a notification to all the people following the consultation who have agreed to receive email notifications
@@ -27,11 +31,15 @@ en:
             scope_type: Scope type
       scopes:
         no_scopes: No scopes at this level.
+        titles:
+          scopes: Scopes
         update:
           error: There was a problem updating this scope.
           success: Scope updated successfully
-        titles:
-          scopes: Scopes    
+    comments:
+      comments:
+        create:
+          error: There was a problem creating the comment.
     components:
       proposals:
         settings:
@@ -63,6 +71,39 @@ en:
             success: The initiative type has been successfully removed.
           edit:
             update: Update
+      create_initiative:
+        fill_data:
+          back: Back
+          continue: Continue
+          fill_data_help: "<ul> <li>Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative?</li> </ul>"
+          more_information: "(More information)"
+          select_area: Select an area
+          select_scope: Select a scope
+        select_initiative_type:
+          new: Create a new initiative
+      form:
+        add_documents: Add documents
+        add_image: Add image
+        attachment_legend: "(Optional) Add an attachment"
+        edit_documents: Edit documents
+        edit_image: Edit image
+        image_legend: "(Optional) Add an image"
+    proposals:
+      proposals:
+        dynamic_map_instructions:
+          description: The coordinates will be updated when clicking on 'preview' button. However, the address does not change.
+          instructions: You can move the point on the map.
+        edit:
+          add_documents: Add documents
+          attachment_legend: "(Optional) Add an attachment"
+          edit_documents: Edit documents
+          select_a_category: Please select a category
+        edit_form_fields:
+          marker_added: Marker added to the map.
+        placeholder:
+          address: 37 Homewood Drive Brownsburg, IN 46112
+    scopes:
+      global: Global scope
   time:
     buttons:
       select: Select

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -17,6 +17,7 @@ fr:
         confirm_destroy: Confirmer la suppression
         destroy: Supprimer
         edit: Modifier
+        new_assembly: Nouvelle assemblée
       attachments:
         form:
           send_notification_to_followers: Envoyer une notification à toutes les personnes qui suivent la concertation ayant accepté de recevoir des notifications par mail
@@ -30,17 +31,21 @@ fr:
             scope_type: Type de secteur
       scopes:
         no_scopes: Aucun secteur à ce niveau.
+        titles:
+          scopes: Secteurs
         update:
           error: Il y a eu une erreur lors de la mise à jour du secteur.
           success: Secteur mis à jour avec succès.
-        titles:
-          scopes: Secteurs    
+    comments:
+      comments:
+        create:
+          error: Une erreur s'est produite lors de la création du commentaire.
     components:
       proposals:
         settings:
           global:
             require_category: La catégorie est obligatoire
-            require_scope: Le secteur est obligatoire    
+            require_scope: Le secteur est obligatoire
     events:
       proposals:
         author_confirmation_proposal_event:
@@ -66,6 +71,39 @@ fr:
             success: Le type de pétition a été supprimé avec succès.
           edit:
             update: Mettre à jour
+      create_initiative:
+        fill_data:
+          back: Retour
+          continue: Continuer
+          fill_data_help: "<ul> <li>Vérifier le contenu de votre pétition : le titre est-il facile à comprendre ? L'objectif de votre pétition est-il clair ?</li> <li>Vous devez choisir le type de signature : en présentiel, en ligne ou une combinaison des deux</li> <li>Quelle est le secteur géographique de l'initiative ?</li> </ul>"
+          more_information: "(Plus d'informations)"
+          select_area: Sélectionnez une zone
+          select_scope: Sélectionnez une portée
+        select_initiative_type:
+          new: Créer une nouvelle pétition
+      form:
+        add_documents: Ajouter des documents
+        add_image: Ajouter une image
+        attachment_legend: "(Facultatif) Ajouter une pièce jointe"
+        edit_documents: Modifier les documents
+        edit_image: Modifier l'Image
+        image_legend: "(Facultatif) Ajouter une image"
+    proposals:
+      proposals:
+        dynamic_map_instructions:
+          description: Les coordonnées seront mises à jour en cliquant sur le bouton 'Aperçu'. Cependant, l'adresse ne change pas.
+          instructions: Vous pouvez déplacer le point sur la carte.
+        edit:
+          add_documents: Ajouter des documents
+          attachment_legend: "(Facultatif) Ajouter une pièce jointe"
+          edit_documents: Modifier les documents
+          select_a_category: Veuillez sélectionner une catégorie
+        edit_form_fields:
+          marker_added: Marqueur ajouté à la carte.
+        placeholder:
+          address: 60 Boulevard Victor Hugo Saint-Jean-de-Luz, BP 64500
+    scopes:
+      global: Portée générale
   time:
     buttons:
       select: Sélectionner

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -137,15 +137,21 @@ default: &default
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   maps:
-    dynamic_provider: <%= Decidim::Env.new("MAPS_DYNAMIC_PROVIDER", ENV["MAPS_PROVIDER"]).to_s %>
-    static_provider: <%= Decidim::Env.new("MAPS_STATIC_PROVIDER", ENV["MAPS_PROVIDER"]).to_s  %>
+    provider: <%= Decidim::Env.new("MAPS_PROVIDER", "here") %>
+    api_key: <%= ENV["MAPS_API_KEY"] %>
+    dynamic_provider: <%= Decidim::Env.new("MAPS_DYNAMIC_PROVIDER", ENV["MAPS_PROVIDER"]) %>
+    static_provider: <%=  Decidim::Env.new("MAPS_STATIC_PROVIDER", ENV["MAPS_PROVIDER"]) %>
     static_api_key: <%= Decidim::Env.new("MAPS_STATIC_API_KEY", ENV["MAPS_API_KEY"]).to_s %>
     dynamic_api_key: <%= Decidim::Env.new("MAPS_DYNAMIC_API_KEY", ENV["MAPS_API_KEY"]).to_s %>
     dynamic_url: <%= ENV["MAPS_DYNAMIC_URL"] %>
     static_url: <%= ENV["MAPS_STATIC_URL"] %>
     attribution: <%= ENV["MAPS_ATTRIBUTION"].to_json %>
     extra_vars: <%= ENV["MAPS_EXTRA_VARS"].to_json %>
+    geocoding_provider: <%= Decidim::Env.new("MAPS_GEOCODING_PROVIDER", ENV["MAPS_PROVIDER"]) %>
+    geocoding_api_key: <%= Decidim::Env.new("MAPS_GEOCODING_API_KEY", ENV["MAPS_API_KEY"]) %>
     geocoding_host: <%= ENV["MAPS_GEOCODING_HOST"] %>
+    geocoder_timeout: <%= Decidim::Env.new("GEOCODER_TIMEOUT", 5) %>
+    geocoder_units: <%= Decidim::Env.new("GEOCODER_UNITS", "km") %>
   etherpad:
     server: <%= ENV["ETHERPAD_SERVER"] %>
     api_key: <%= ENV["ETHERPAD_API_KEY"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
   app:
     image: decidim-app:3.0.0
     command: [ "bundle", "exec", "rails", "server", "-b", "ssl://0.0.0.0:3000?key=/opt/decidim/tls-certificate/key.pem&cert=/opt/decidim/tls-certificate/cert.pem" ]
+    env_file:
+      - .env
     environment:
       - DATABASE_HOST=database
       - DATABASE_USERNAME=postgres

--- a/lib/extends/commands/decidim/proposals/create_proposal_extends.rb
+++ b/lib/extends/commands/decidim/proposals/create_proposal_extends.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module CreateProposalExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def create_proposal
+      PaperTrail.request(enabled: false) do
+        @proposal = Decidim.traceability.perform_action!(
+          :create,
+          Decidim::Proposals::Proposal,
+          @current_user,
+          visibility: "public-only"
+        ) do
+          proposal = Decidim::Proposals::Proposal.new(
+            title: {
+              I18n.locale => title_with_hashtags
+            },
+            body: {
+              I18n.locale => body_with_hashtags
+            },
+            component: form.component
+          )
+
+          proposal.category = form.category if form.category_id.present?
+          proposal.scope = form.scope if form.scope_id.present?
+          proposal.documents = form.documents if form.documents.present?
+          proposal.address = form.address if form.address.present?
+          proposal.latitude = form.latitude if form.latitude.present?
+          proposal.longitude = form.longitude if form.longitude.present?
+          proposal.add_coauthor(@current_user, user_group:)
+          proposal.save!
+          @attached_to = proposal
+          proposal
+        end
+      end
+    end
+  end
+end
+
+Decidim::Proposals::CreateProposal.include(CreateProposalExtends)

--- a/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe CreateProposal do
+      let(:form_klass) { ProposalForm }
+      let(:component) { create(:proposal_component) }
+      let(:organization) { component.organization }
+      let(:user) { create(:user, :admin, :confirmed, organization:) }
+      let(:form) do
+        form_klass.from_params(
+          form_params
+        ).with_context(
+          current_user: user,
+          current_organization: organization,
+          current_participatory_space: component.participatory_space,
+          current_component: component
+        )
+      end
+
+      let(:author) { create(:user, organization:) }
+
+      let(:user_group) do
+        create(:user_group, :verified, organization:, users: [author])
+      end
+
+      describe "call" do
+        let(:form_params) do
+          {
+            title: "A reasonable proposal title",
+            body: "A reasonable proposal body",
+            user_group_id: user_group.try(:id)
+          }
+        end
+
+        let(:command) do
+          described_class.new(form, author)
+        end
+
+        describe "when the form is not valid" do
+          before do
+            allow(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "does not create a proposal" do
+            expect do
+              command.call
+            end.not_to change(Decidim::Proposals::Proposal, :count)
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it_behaves_like "fires an ActiveSupport::Notification event", "decidim.proposals.create_proposal:before"
+          it_behaves_like "fires an ActiveSupport::Notification event", "decidim.proposals.create_proposal:after"
+
+          it "creates a new proposal" do
+            expect do
+              command.call
+            end.to change(Decidim::Proposals::Proposal, :count).by(1)
+          end
+
+          it "sets the body and title as i18n" do
+            command.call
+            proposal = Decidim::Proposals::Proposal.last
+
+            expect(proposal.title).to be_a(Hash)
+            expect(proposal.title[I18n.locale.to_s]).to eq form_params[:title]
+            expect(proposal.body).to be_a(Hash)
+            expect(proposal.body[I18n.locale.to_s]).to eq form_params[:body]
+          end
+
+          it "does not create a searchable resource" do
+            command.call
+
+            expect { command.call }.not_to change(Decidim::SearchableResource, :count)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(
+                :create,
+                Decidim::Proposals::Proposal,
+                author,
+                visibility: "public-only"
+              ).and_call_original
+
+            expect { described_class.call(form, author) }.to change(Decidim::ActionLog, :count).by(1)
+          end
+
+          context "with an author" do
+            let(:user_group) { nil }
+
+            it "sets the author" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+              creator = proposal.creator
+
+              expect(creator.author).to eq(author)
+              expect(creator.user_group).to be_nil
+            end
+
+            it "adds the author as a follower" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+
+              expect(proposal.followers).to include(author)
+            end
+
+            context "with a proposal limit" do
+              let(:component) do
+                create(:proposal_component, settings: { "proposal_limit" => 2 })
+              end
+
+              it "checks the author does not exceed the amount of proposals" do
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:invalid)
+              end
+            end
+          end
+
+          context "with a user group" do
+            it "sets the user group" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+              creator = proposal.creator
+
+              expect(creator.author).to eq(author)
+              expect(creator.user_group).to eq(user_group)
+            end
+
+            context "with a proposal limit" do
+              let(:component) do
+                create(:proposal_component, settings: { "proposal_limit" => 2 })
+              end
+
+              before do
+                create_list(:proposal, 2, component:, users: [author])
+              end
+
+              it "checks the user group does not exceed the amount of proposals independently of the author" do
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:invalid)
+              end
+            end
+          end
+
+          describe "the proposal limit excludes withdrawn proposals" do
+            let(:component) do
+              create(:proposal_component, settings: { "proposal_limit" => 1 })
+            end
+
+            describe "when the author is a user" do
+              let(:user_group) { nil }
+
+              before do
+                create(:proposal, :withdrawn, users: [author], component:)
+              end
+
+              it "checks the user does not exceed the amount of proposals" do
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:invalid)
+
+                user_proposal_count = Decidim::Coauthorship.where(author:, coauthorable_type: "Decidim::Proposals::Proposal").count
+                expect(user_proposal_count).to eq(2)
+              end
+            end
+
+            describe "when the author is a user_group" do
+              before do
+                create(:proposal, :withdrawn, users: [author], user_groups: [user_group], component:)
+              end
+
+              it "checks the user_group does not exceed the amount of proposals" do
+                expect { command.call }.to broadcast(:ok)
+                expect { command.call }.to broadcast(:invalid)
+
+                user_group_proposal_count = Decidim::Coauthorship.where(user_group:, coauthorable_type: "Decidim::Proposals::Proposal").count
+                expect(user_group_proposal_count).to eq(2)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR fixes the display of the map on 0.29 by changing the config to the new version and adapting new env vars

#### Testing

**Please make sure you have a `.env` and you may need to use the docker image updating the docker-compose below [#L90](https://github.com/OpenSourcePolitics/decidim-app/blob/develop/docker-compose.yml#L22) (`command: [ "bundle", "exec", "rails", "server", "-b", "ssl://0.0.0.0:3000?key=/opt/decidim/tls-certificate/key.pem&cert=/opt/decidim/tls-certificate/cert.pem" ]`)**
```
    env_file:
      - .env
```

In your .env file make sure to at the very least put the following var
`MAPS_API_KEY=<your_api_key> `

And if you use docker use the command `make run` it will be easier then follow those steps 

- Let the seeds run to ensure you have some upcoming meetings  
- Go to the homepage and scroll to the **Upcoming Meetings** section  
- Make sure the map is displayed, and if you're lucky, that some points appear on it  
- Click the `See all meetings` button  
- Log in as an admin  
- Select a meeting to edit  
- Try using the geolocator by updating the address  
- Save the meeting and return to the meetings page  
- Make sure the point appeared and was updated correctly on the map  
- If the meeting was upcoming, make sure it also changed on the homepage  

Example:

#### Tasks
- [x] Change config
- [x] Update env vars example
