### PR TITLE
feat: Add nl.yml file and translate e-mails

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,367 @@
+---
+nl:
+  activemodel:
+    attributes:
+      attachment:
+        documents: add a document
+      initiative:
+        offline_votes_for_scope: In-person signatures for %{scope_name}
+      osp_authorization_handler:
+        birthday: Birthday
+        document_number: Unique number
+        postal_code: Postal code
+      participatory_process:
+        private_space: Private space
+      participatory_space_private_user_csv_import:
+        file: importing file
+  decidim:
+    account:
+      omniauth_synced_profile:
+        helper:
+          body_html: |-
+            <p>
+              The following informations are synchronized with an external identity provider:
+            </p>
+            <ul>
+              <li>Name</li>
+              <li>Nickname</li>
+              <li>Email</li>
+            </ul>
+            <p>
+              You can't edit these informations here.
+            </p>
+          title: Profile synchronization
+    admin:
+      actions:
+        add: Add
+        browse: Browse
+        confirm_destroy: Confirm destroy
+        destroy: Destroy
+        edit: Edit
+      attachments:
+        form:
+          send_notification_to_followers: Send a notification to all the people following the consultation who have agreed to receive email notifications
+      exports:
+        export_as: "%{name} as %{export_format}"
+        notice: Your export is currently in progress. You'll receive an email when it's complete.
+      menu:
+        initiatives_settings: Instellingen voor initiatieven
+      models:
+        scope:
+          fields:
+            name: Name
+            scope_type: Scope type
+      participatory_space_private_users:
+        create:
+          error: Error
+          success: Success
+      scopes:
+        no_scopes: No scopes at this level.
+        update:
+          error: There was a problem updating this scope.
+          success: Scope updated successfully
+      titles:
+        scopes: Scopes
+    admin_multi_factor:
+      verification_code_mailer:
+        verification_code:
+          copy: 'Kopieer deze code:'
+          expires_in: Deze vervalt na %{time}.
+          ignore_html: Als je deze code niet zelf aangevraagd hebt, gelieve deze e-mail te negeren.<br/>Je account wordt pas geactiveerd na bevestiging.
+          subtitle_html: Om de authentificatie te finaliseren moet je de 4-cijferige code onderaan invoeren. Ga terug naar de %{organization} verificatiepagina en plak die daar.
+          title: Jouw tweefactorauthentificatie
+    amendments:
+      emendation:
+        announcement:
+          evaluating: |-
+            This amendment for %{amendable_type} %{proposal_link}
+            is in evaluation state.
+    anonymous_user: Anonymous user
+    assemblies:
+      show:
+        active_assembly_participatory_processes: Active participatory processes
+        active_assembly_participatory_processes_mini: Active
+        future_assembly_participatory_processes: Future participatory processes
+        future_assembly_participatory_processes_mini: Future
+        past_assembly_participatory_processes: Past participatory processes
+        past_assembly_participatory_processes_mini: Past
+        private_space: This is a private assembly
+        related_participatory_processes: Related participatory processes
+        social_networks: Social Networks
+        social_networks_title: Visit assembly on
+    authorization_handlers:
+      osp_authorization_handler:
+        explanation: Verify your identity by entering a unique number
+        fields:
+          birthday: Birthday
+          document_number: Unique number
+          postal_code: Postal code
+        name: Identity Verification Form
+      osp_authorization_workflow:
+        name: Authorization procedure
+    budgets:
+      order_reminder:
+        text_message: Your vote is still pending for the participatory budget. Please reconnect to %{organization_host} to confirm it
+      projects:
+        count:
+          projects_count:
+            one: 1 project
+            other: "%{count} projects"
+        orders:
+          alphabetical: A-Z (Alphabetical)
+          highest_cost: Highest cost
+          label: Order projects by
+          lowest_cost: Lowest cost
+          most_voted: Most voted
+          random: Random order
+          selected: Selected
+    comments:
+      comments:
+        create:
+          error: There was a problem creating the comment.
+    components:
+      budgets:
+        settings:
+          global:
+            default_sort_order: Default projects sorting
+            default_sort_order_help: Default means that if the supports are disabled, the projects will be shown sorted by random, and if the supports are enabled, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (Alphabetical)
+              default: Default
+              highest_cost: Highest cost
+              lowest_cost: Lowest cost
+              most_voted: Most supported
+              random: Random
+          step:
+            default_sort_order: Default projects sorting
+            default_sort_order_help: Default means that if the supports are enabled, the projects will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
+            default_sort_order_options:
+              alphabetical: A-Z (Alphabetical)
+              default: Default
+              highest_cost: Highest cost
+              lowest_cost: Lowest cost
+              most_voted: Most supported
+              random: Random
+    devise:
+      sessions:
+        new:
+          sign_in_disabled: Sign in disabled
+    events:
+      budgets:
+        pending_order:
+          email_intro: De stemming bij het budget "%{resource_title}" is nog niet bevestigd in "%{participatory_space_title}".
+          email_outro: Je hebt deze melding ontvangen omdat je deelneemt in "%{participatory_space_title}"
+          email_subject: Jouw stem is nog in behandeling in %{participatory_space_title}
+          notification_title: De stem voor het budget <a href="%{resource_path}">%{resource_title}</a> wacht nog op bevestiging in %{participatory_space_title}
+      initiatives:
+        initiative_answered:
+          email_intro: Het initiatief  "%{resource_title}" is beantwoord.
+          email_outro: Je hebt deze melding ontvangen omdat je het initiatief "%{resource_title}" volgt.
+          email_subject: Initiatief "%{resource_title}" is beantwoord.
+          notification_title: Het initiatief <a href="%{resource_path}">%{resource_title}</a> is beantwoord.
+      proposals:
+        author_confirmation_proposal_event:
+          email_intro: 'Je voorstel " %{resource_title} " werd succesvol ontvangen en is nu zichtbaar. Bedankt om deel te nemen. Je kan het hier bekijken:'
+          email_outro: Je ontving deze melding omdat je de auteur bent van een voorstel. Je kunt dit voorstel ontvolgen door naar de voorstellenpagina te surfen en daar op 'ontvolgen' te klikken.
+          email_subject: Je voorstel is gepubliceerd!
+          notification_title: Je voorstel <a href="%{resource_path}">%{resource_title}</a> is nu zichtbaar.
+      users:
+        user_officialized:
+          email_intro: Deelnemer %{name} (%{nickname}) werd bevestigd.
+          email_outro: Je hebt deze melding ontvangen omdat je een beheerder bent van de organisatie.
+          email_subject: "%{name} werd bevestigd."
+          notification_title: Deelnemer %{name} (%{nickname}) werd bevestigd.
+      verifications:
+        verify_with_managed_user:
+          email_intro: De deelnemer <a href="%{resource_path}">%{resource_title}</a> probeerde zich te verifiëren met de gegevens van de beheerde deelnemer <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          email_outro: Bekijk de <a href="%{conflicts_path}">lijst met verificatieproblemen</a> en contacteer de deelnemer om hun gegevens te verifiëren en het probleem op te lossen.
+          email_subject: Mislukte verificatiepoging van een deelnemer
+          notification_title: De deelnemer <a href="%{resource_path}">%{resource_title}</a> probeerde zich te verifiëren met de gegevens van de beheerde deelnemer <a href="%{managed_user_path}">%{managed_user_name}</a>.
+    forms:
+      user_answers_serializer:
+        email: Email
+        name: Name
+    half_signup:
+      quick_auth:
+        sms_verification:
+          text_message: Hello, %{verification} is the code to authenticate yourself on the platform
+    initiatives:
+      admin:
+        initiatives:
+          edit:
+            success: The initiative has been sent to technical validation
+          form:
+            attachments: Attachments
+            settings: Settings
+            title: General information
+          index:
+            warning: Initiatives are not used for now. When you create an initiative type, it will be displayed in front-office.
+          update:
+            error: An error has occurred
+            success: The initiative has been successfully updated
+      pages:
+        home:
+          highlighted_initiatives:
+            active_initiatives: Active initiatives
+            see_all_initiatives: See all initiatives
+      unavailable_scope: Unavailable scope
+    meetings:
+      application_helper:
+        filter_scope_values:
+          all: All
+      directory:
+        meetings:
+          index:
+            all: All
+      meeting:
+        not_allowed: You are not allowed to view this meeting
+      meetings:
+        create:
+          invalid: There was a problem creating this meeting.
+          success: You have created the meeting successfully.
+        update:
+          invalid: There was a problem updating the meeting.
+          success: You have updated the meeting successfully.
+    omniauth:
+      france_connect:
+        explanation: Explanation
+        external:
+          link: https://franceconnect.gouv.fr/
+          text: What is FranceConnect ?
+        forgot_password:
+          ok_text: Warning, this password is the one of your local account and in no case the one of the account you use through FranceConnect. It will only be used when you log in with your email address rather than via FranceConnect.
+    participatory_processes:
+      show:
+        local_area: Organization area
+    proposals:
+      admin:
+        exports:
+          awesome_private_proposals: Proposals with private fields
+          proposal_comments: Comments
+      collaborative_drafts:
+        new:
+          add_file: Add file
+          edit_file: Edit file
+      proposals:
+        index:
+          collaborative_drafts_list: Collaborative drafts list
+          new_proposal: New proposal
+          view_proposal: View proposal
+      update:
+        error: There was a problem saving the idea.
+        success: Idea successfully updated.
+      update_draft:
+        error: There was a problem saving the idea.
+        success: Idea draft successfully updated.
+    scopes:
+      global: Global
+      picker:
+        cancel: Cancel
+        change: Change
+        choose: Choose
+        currently_selected: Currently selected
+      prompt: Select a scope
+    shared:
+      login_modal:
+        close_modal: Close modal
+        please_sign_in: Please sign in
+        sign_up: Sign up
+    system:
+      dashboard:
+        show:
+          current_organizations: Current organizations
+      organizations:
+        omniauth_settings:
+          cultuur_connect:
+            client_id: Client ID
+            client_secret: Client secret
+            site_url: Site URL
+          france_connect:
+            client_id: Client ID
+            client_secret: Client secret
+            provider: FranceConnect
+            provider_name: FranceConnect
+            scope: scope
+            site_url: Site URL
+          france_connect_profile:
+            button_path: Button path
+            client_id: Client ID
+            client_secret: Client secret
+            provider_name: Provider name
+            site: Site URL
+          france_connect_uid:
+            button_path: Button path
+            client_id: Client ID
+            client_secret: Client secret
+            provider_name: Provider name
+            site: Site URL
+          openid_connect:
+            client_options_identifier: Client ID
+            client_options_redirect_uri: Redirection URL
+            client_options_secret: Client secret
+            discovery: Enable discovery (true or false)
+            issuer: Issuer (Identity Provider)
+            logout_path: Logout path (with starting "/")
+            logout_policy: Logout policy (none|session.destroy)
+            post_logout_redirect_uri: Post logout redirect URI
+            response_type: Response type
+            scope: Scope
+            uid_field: UID field
+          publik:
+            client_id: Client ID
+            client_secret: Client secret
+            site_url: Site URL
+      titles:
+        dashboard:
+          info:
+            db_size: 'Database size: %{db_size}'
+            decidim_version: 'Decidim version: v%{version}'
+            title: General informations
+          title: Dashboard
+    verifications:
+      authorizations:
+        create:
+          error: Error
+          success: Success
+        first_login:
+          actions:
+            osp_authorization_handler: Verify with the identity verification form
+            osp_authorization_workflow: Verify with the identity verification form
+  devise:
+    passwords:
+      new:
+        forgot_your_password: Forgot your password
+        send_me_reset_password_instructions: Send me reset password instructions
+    sessions:
+      new:
+        sign_in: Log in
+    shared:
+      links:
+        forgot_your_password: Forgot your password
+        sign_in_with_france_connect: Sign in with france connect
+  faker:
+    address:
+      country_code:
+        - EN
+        - EN0
+        - EN1
+        - EN2
+        - EN3
+        - EN4
+        - EN5
+        - EN6
+        - EN7
+        - EN8
+        - EN9
+  layouts:
+    decidim:
+      footer:
+        made_with_open_source: Website made by <a target="_blank" href="https://opensourcepolitics.eu/en/">Open Source Politics</a> with the <a target="_blank" href="https://github.com/decidim/decidim">decidim free software</a>.
+  rack_attack:
+    too_many_requests:
+      message: Your connection has been slowed because server received too many requests.
+      time: 'You will be able to navigate on our website in :'
+      time_unit: seconds
+      title: Thank you for your participation on %{organization_name}
+  sms_verification_workflow:
+    message: 'Hello, here is the code to authenticate yourself on the %{platform} platform: %{code}'


### PR DESCRIPTION
#### :tophat: Description
This PR introduces the nl.yml translation file to address missing Dutch translations within the application.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to [#13 - Add nl.yml file on decidim-app for CultuurConnect](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=107028606&issue=OpenSourcePolitics%7Cprivate-tasks%7C13)

#### Testing
**Describe the best way to test or validate your PR:**

1. In `config/initializers/decidim.rb`, update [lines 15 and 16](https://github.com/OpenSourcePolitics/decidim-app/blob/develop/config/initializers/decidim.rb#L15-L16) to the following:

    ```ruby
    config.default_locale = ENV.fetch("DEFAULT_LOCALE", "nl").to_sym
    config.available_locales = ENV.fetch("AVAILABLE_LOCALES", "nl").split(",").map(&:to_sym)
    ```

2. Set up your database seeds.

3. Log in as an admin.

4. Go to your user profile and verify that your notifications digest is set to **daily**.

5. Access the **Backoffice**.

6. Navigate to the **Initiatives** section.

7. Choose a published initiative and follow it from the **front-office**.

8. Return to the **Backoffice** and respond to this initiative.

9. Open [Letter Opener](http://localhost:3000/letter_opener).

10. Confirm that the received email is correctly translated into **Dutch**.

#### Tasks
- [x] Add nl.yml
- [x] Fix some translations
