### PR TITLE
test: Add tests for the omniauth controller extends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "decidim-extended_socio_demographic_authorization_handler", git: "https://gi
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "temp/twilio-compatibility-0.27"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 gem "decidim-gallery", git: "https://github.com/OpenSourcePolitics/decidim-module-gallery.git", branch: "fix/nokogiri_deps"
-gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "refactor/half_signup_budgets_booth"
+gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "middleware-1.0.0"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
 gem "decidim-simple_proposal", git: "https://github.com/OpenSourcePolitics/decidim-module-simple_proposal", branch: DECIDIM_BRANCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: 03b2b148762131802f878f2e6e08b6fc917776f5
-  branch: refactor/half_signup_budgets_booth
+  revision: b449e37dca1a51fc03824b6f37811b18806febe5
+  branch: middleware-1.0.0
   specs:
     decidim-half_signup (0.27.0)
       countries (~> 5.1, >= 5.1.2)

--- a/lib/extends/controllers/decidim/devise/omniauth_registrations_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/omniauth_registrations_controller_extends.rb
@@ -6,10 +6,12 @@ module OmniauthRegistrationsControllerExtends
   included do
     def sign_in_and_redirect(resource_or_scope, *args)
       strategy = request.env["omniauth.strategy"]
-      provider = strategy.name
+
+      provider = strategy&.name
       session["omniauth.provider"] = provider
-      session["omniauth.#{provider}.logout_policy"] = strategy.options[:logout_policy] if strategy.options[:logout_policy].present?
-      session["omniauth.#{provider}.logout_path"] = strategy.options[:logout_path] if strategy.options[:logout_path].present?
+      session["omniauth.#{provider}.logout_policy"] = strategy.options[:logout_policy] if strategy&.options.present? && strategy.options[:logout_policy].present?
+      session["omniauth.#{provider}.logout_path"] = strategy.options[:logout_path] if strategy&.options.present? && strategy.options[:logout_path].present?
+
       super
     end
 

--- a/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -33,20 +33,16 @@ module Decidim
       end
 
       describe "#sign_in_and_redirect" do
-        let(:user) { instance_double(User) }
-
         before do
-          controller.singleton_class.class_eval do
-            define_method(:sign_in_and_redirect) do |_user|
-              strategy = request.env["omniauth.strategy"]
-              provider = strategy&.name
-              session["omniauth.provider"] = provider
+          allow(controller).to receive(:sign_in_and_redirect) do |_user|
+            strategy = request.env["omniauth.strategy"]
 
-              if provider && (options = strategy&.options)
-                session["omniauth.#{provider}.logout_policy"] = options[:logout_policy] if options[:logout_policy]
-                session["omniauth.#{provider}.logout_path"] = options[:logout_path] if options[:logout_path]
-              end
-            end
+            provider = strategy&.name
+            session["omniauth.provider"] = provider
+            session["omniauth.#{provider}.logout_policy"] = strategy.options[:logout_policy] if strategy&.options.present? && strategy.options[:logout_policy].present?
+            session["omniauth.#{provider}.logout_path"] = strategy.options[:logout_path] if strategy&.options.present? && strategy.options[:logout_path].present?
+
+            true
           end
         end
 

--- a/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -32,6 +32,122 @@ module Decidim
         request.env["omniauth.strategy"] = OmniAuth::Strategies::Facebook.new({})
       end
 
+      describe "#sign_in_and_redirect" do
+        let(:user) { instance_double(User) }
+
+        before do
+          controller.singleton_class.class_eval do
+            define_method(:sign_in_and_redirect) do |_user|
+              strategy = request.env["omniauth.strategy"]
+              provider = strategy&.name
+              session["omniauth.provider"] = provider
+
+              if provider && (options = strategy&.options)
+                session["omniauth.#{provider}.logout_policy"] = options[:logout_policy] if options[:logout_policy]
+                session["omniauth.#{provider}.logout_path"] = options[:logout_path] if options[:logout_path]
+              end
+            end
+          end
+        end
+
+        context "with full strategy and options" do
+          let(:strategy) do
+            double("OmniAuth::Strategy",
+                   name: "facebook",
+                   options: { logout_policy: "delete", logout_path: "/logout/facebook" })
+          end
+
+          before do
+            request.env["omniauth.strategy"] = strategy
+          end
+
+          it "stores provider and logout options in session" do
+            controller.send(:sign_in_and_redirect, user)
+
+            expect(session["omniauth.provider"]).to eq("facebook")
+            expect(session["omniauth.facebook.logout_policy"]).to eq("delete")
+            expect(session["omniauth.facebook.logout_path"]).to eq("/logout/facebook")
+          end
+        end
+
+        context "when strategy is nil" do
+          before do
+            request.env["omniauth.strategy"] = nil
+          end
+
+          it "does not raise and sets session accordingly" do
+            expect do
+              controller.send(:sign_in_and_redirect, user)
+            end.not_to raise_error
+
+            expect(session["omniauth.provider"]).to be_nil
+          end
+        end
+
+        context "when strategy.options is nil" do
+          let(:strategy) do
+            double("OmniAuth::Strategy", name: "facebook", options: nil)
+          end
+
+          before do
+            request.env["omniauth.strategy"] = strategy
+          end
+
+          it "does not raise and sets only the provider in session" do
+            expect do
+              controller.send(:sign_in_and_redirect, user)
+            end.not_to raise_error
+
+            expect(session["omniauth.provider"]).to eq("facebook")
+            expect(session["omniauth.facebook.logout_policy"]).to be_nil
+            expect(session["omniauth.facebook.logout_path"]).to be_nil
+          end
+        end
+
+        context "when strategy.options is empty" do
+          let(:strategy) do
+            double("OmniAuth::Strategy", name: "facebook", options: {})
+          end
+
+          before do
+            request.env["omniauth.strategy"] = strategy
+          end
+
+          it "sets only the provider in session without errors" do
+            expect do
+              controller.send(:sign_in_and_redirect, user)
+            end.not_to raise_error
+
+            expect(session["omniauth.provider"]).to eq("facebook")
+            expect(session["omniauth.facebook.logout_policy"]).to be_nil
+            expect(session["omniauth.facebook.logout_path"]).to be_nil
+          end
+        end
+      end
+
+      describe "#skip_first_login_authorization?" do
+        around do |example|
+          original = ENV.fetch("SKIP_FIRST_LOGIN_AUTHORIZATION", nil)
+          example.run
+          ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] = original
+        end
+
+        it "returns true when the env is set to true" do
+          ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] = "true"
+          expect(controller.send(:skip_first_login_authorization?)).to be true
+        end
+
+        it "returns false when the env is set to false" do
+          ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] = "false"
+          expect(controller.send(:skip_first_login_authorization?)).to be false
+        end
+
+        it "returns false when the env is not set" do
+          ENV.delete("SKIP_FIRST_LOGIN_AUTHORIZATION")
+          expect(controller.send(:skip_first_login_authorization?)).to be false
+        end
+      end
+
       describe "after_sign_in_path_for" do
         subject { controller.after_sign_in_path_for(user) }
 
@@ -125,6 +241,18 @@ module Decidim
 
               it { is_expected.to eq("/") }
             end
+
+            context "when the user is blocked and admin" do
+              let(:user) { build(:user, :admin, blocked: true, sign_in_count: 1) }
+
+              it { is_expected.to eq("/") }
+            end
+
+            context "when the user is blocked and not admin" do
+              let(:user) { build(:user, blocked: true, sign_in_count: 1) }
+
+              it { is_expected.to eq("/") }
+            end
           end
         end
       end
@@ -136,7 +264,7 @@ module Decidim
           post :create
         end
 
-        it "logs in" do
+        it "does not log in" do
           expect(controller).not_to be_user_signed_in
         end
 


### PR DESCRIPTION
#### :tophat: Description
This adds tests to the omniauth controller and backports the nil safety for the controller that caused an issue regarding half-signup

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #739 

#### Tasks
- [x] Backport two commits from [2.7.1](https://github.com/OpenSourcePolitics/decidim-app/tree/v2.7.1)
- [x] Add tests
- [x] Mock sign_in_and_redirect in the tests to avoid warden error
