### PR TITLE
fix(search): Prevent crash on search page for comments

### DIFF
--- a/app/cells/decidim/card_metadata/show.erb
+++ b/app/cells/decidim/card_metadata/show.erb
@@ -1,0 +1,24 @@
+<% items.each do |item| %>
+  <%# byebug if item.blank? %>
+
+  <% if item[:hook].present? %>
+    <% hook_output = render_hook(item[:hook]) %>
+    <% next if hook_output.blank? %>
+
+    <%= content_tag :div, data: item[:data_attributes] do %>
+      <%= icon item[:icon] if item[:icon].present? %>
+      <%= hook_output %>
+    <% end %>
+  <% else %>
+    <%= content_tag :div, data: item[:data_attributes] do %>
+      <%= icon item[:icon] if item[:icon].present? %>
+      <% if item[:text].present? %>
+        <%= link_to_if enable_links? && item.has_key?(:url), item[:text], item[:url] %>
+      <% elsif item[:cell].present? && item[:args].is_a?(Enumerable) %>
+        <%= cell(item[:cell], *item[:args]) %>
+      <% elsif item[:cell].present? %>
+        <%= cell(item[:cell], item[:args]) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ module DecidimApp
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       # cells
       require "extends/cells/decidim/system/system_checks_cell_extends"
+      require "extends/cells/decidim/comments/comment_metadata_cell_extends"
     end
   end
 end

--- a/lib/extends/cells/decidim/comments/comment_metadata_cell_extends.rb
+++ b/lib/extends/cells/decidim/comments/comment_metadata_cell_extends.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module CommentMetadataCellExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def items
+      [author_item, commentable_item, comments_count_item].compact
+    end
+  end
+end
+
+Decidim::Comments::CommentMetadataCell.include(CommentMetadataCellExtends)

--- a/spec/cells/decidim/comments/comment_metadata_cell_spec.rb
+++ b/spec/cells/decidim/comments/comment_metadata_cell_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Comments::CommentMetadataCell, type: :cell do
+  controller Decidim::Comments::CommentsController
+  subject { my_cell.call }
+
+  let(:my_cell) { cell("decidim/comments/comment_metadata", comment) }
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:component) { create(:component, participatory_space: participatory_process) }
+  let(:commentable) { create(:dummy_resource, component:) }
+  let(:comment) { create(:comment, commentable:) }
+  let(:created_at) { Time.current }
+
+  describe "#items" do
+    it "returns an array of items" do
+      expect(my_cell.send(:items)).to be_an(Array)
+    end
+
+    it "includes the commentable item" do
+      expect(my_cell.send(:items)).to include(my_cell.send(:commentable_item))
+    end
+
+    it "includes the comments count item" do
+      expect(my_cell.send(:items)).to include(my_cell.send(:comments_count_item))
+    end
+
+    it "has 3 items" do
+      expect(my_cell.send(:items).count).to eq(3)
+    end
+
+    context "when comments_count_item is nil" do
+      before do
+        allow(my_cell).to receive(:comments_count_item).and_return(nil)
+      end
+
+      it "does not include the comments count item" do
+        expect(my_cell.send(:items)).not_to include(my_cell.send(:comments_count_item))
+        expect(my_cell.send(:items).count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/comments/test/factories"
 require "decidim/proposals/test/factories"


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
Fixes a a crash on search page when a Commentable has comment disabled. 

Cf https://github.com/OpenSourcePolitics/decidim-app/issues/738