### PR TITLE
bump: Spam detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
-  revision: 5e4f92f19b903228b8349fb002d735e900d63ed4
+  revision: ef9f735409fe1ccd6d59e8680c58dd21c761e7e8
   tag: 4.1.2
   specs:
     decidim-spam_detection (4.1.2)


### PR DESCRIPTION
#### :tophat: Description

This just bumps the spam detection module to its last commit to fix the issue of usernames when the module is trying to block the user