### PR TITLE
feat(sso): Exclude nickname from tne force profile sync on omniauth connection

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -109,6 +109,9 @@ SMS_GATEWAY_MB_ACCOUNT_ID=
 # Force profile sync on every omniauth connection (default: false)
 # FORCE_PROFILE_SYNC_ON_OMNIAUTH_CONNECTION=false
 
+# Ignore nickname from omniauth providers when creating an account (default: false)
+# OMNIAUTH_IGNORE_NICKNAME=false
+
 # Delay until a user is considered inactive and receive a warning email (in days, default: 365)
 # DECIDIM_CLEANER_INACTIVE_USERS_MAIL=
 

--- a/app/overrides/decidim/account/show/disabled_omniauth_synced_nickname_field.html.erb.deface
+++ b/app/overrides/decidim/account/show/disabled_omniauth_synced_nickname_field.html.erb.deface
@@ -1,2 +1,0 @@
-<!-- replace "erb[loud]:contains('text_field :nickname')" -->
-      <%= f.text_field :nickname, disabled: force_profile_sync_on_omniauth_connection?, autocomplete: "nickname" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,7 @@ module DevelopmentApp
       require "extends/forms/decidim/initiatives/initiative_form_extends"
       require "extends/forms/decidim/initiatives/admin/initiative_form_extends"
       require "extends/forms/decidim/comments/comment_form_extends"
+      require "extends/forms/decidim/omniauth_registration_form_extends"
       # Commands
       require "extends/commands/decidim/initiatives/admin/update_initiative_answer_extends"
       require "extends/commands/decidim/budgets/admin/import_proposals_to_budgets_extends"

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,7 +16,6 @@ def update_user_profile(data)
   user.email = data[:email] if data[:email].present?
   user.skip_reconfirmation! if data[:email].present? && user.email_changed?
   user.name = data[:name] if data[:name].present?
-  user.nickname = data[:nickname] if data[:nickname].present? && data.dig(:raw_data, :info, "nickname") != user.nickname
 
   user.save!(validate: false, touch: false)
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,6 @@ en:
             </p>
             <ul>
               <li>Name</li>
-              <li>Nickname</li>
               <li>Email</li>
             </ul>
             <p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,7 +24,6 @@ fr:
             </p>
             <ul>
               <li>Nom</li>
-              <li>Pseudonyme</li>
               <li>Email</li>
             </ul>
             <p>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -44,6 +44,7 @@ default: &default
       do_not_require_authorization: <%= ENV.fetch("INITIATIVES_DO_NOT_REQUIRE_AUTHORIZATION", "auto").to_s %>
     omniauth:
       force_profile_sync_on_omniauth_connection: <%= ENV.fetch("FORCE_PROFILE_SYNC_ON_OMNIAUTH_CONNECTION", "false") == "true" %>
+      ignore_nickname: <%= ENV.fetch("OMNIAUTH_IGNORE_NICKNAME", "false") == "true" %>
     rack_attack:
       enabled: <%= ENV["ENABLE_RACK_ATTACK"] %>
       fail2ban:

--- a/lib/extends/controllers/decidim/account_controller_extends.rb
+++ b/lib/extends/controllers/decidim/account_controller_extends.rb
@@ -46,7 +46,6 @@ module Decidim
       if force_profile_sync_on_omniauth_connection?
         params[:user][:name] = current_user.name
         params[:user][:email] = current_user.email
-        params[:user][:nickname] = current_user.nickname
       end
       params[:user].to_unsafe_h
     end

--- a/lib/extends/forms/decidim/omniauth_registration_form_extends.rb
+++ b/lib/extends/forms/decidim/omniauth_registration_form_extends.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module OmniauthRegistrationFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def normalized_nickname
+      source = Rails.application.secrets.dig(:decidim, :omniauth, :ignore_nickname) ? name : (nickname || name)
+      Decidim::UserBaseEntity.nicknamize(source, organization: current_organization)
+    end
+  end
+end
+
+Decidim::OmniauthRegistrationForm.include(OmniauthRegistrationFormExtends)


### PR DESCRIPTION
1. Nickname is excluded from the forced profile sync on omniauth connection
2. When env variable `OMNIAUTH_IGNORE_NICKNAME` is set to `true`, the nickname from the Omniauth data is ignored on account creation (decidim will use the name to generate a nickname)