### PR TITLE
Fix/add missing paper ballot translations

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -172,4 +172,8 @@ ignore_unused:
   - decidim.budgets.projects.orders.*
   - decidim.components.budgets.settings.*
   - decidim.admin_multi_factor.verification_code_mailer.verification_code.*
+  - activemodel.attributes.content_block_attachment.background_image
+  - activemodel.attributes.project.document
+  - decidim.budgets.admin.imports.*
+  - decidim.proposals.admin.imports.help.proposals
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
     attributes:
       attachment:
         documents: add a document
+      content_block_attachment:
+        background_image: Background image
       initiative:
         offline_votes_for_scope: In-person signatures for %{scope_name}
       osp_authorization_handler:
@@ -14,6 +16,8 @@ en:
         private_space: Private space
       participatory_space_private_user_csv_import:
         file: importing file
+      project:
+        document: Document
   decidim:
     account:
       omniauth_synced_profile:
@@ -103,6 +107,13 @@ en:
         import: Import proposals to projects
         new: New %{name}
       admin:
+        imports:
+          help:
+            paper_ballot_results: 'The import document should contain the following columns: ''id'' (with the project''s id) and ''paper_ballots_to_import'' (with the number of new votes for the project that should be imported). You can simply reuse an export of all the projects and add a column named ''paper_ballots_to_import''.'
+          label:
+            paper_ballot_results: Import paper ballots
+          title:
+            paper_ballot_results: Import results from paper ballots
         models:
           project:
             name: Project
@@ -247,6 +258,9 @@ en:
         exports:
           awesome_private_proposals: Proposals with private fields
           proposal_comments: Comments
+        imports:
+          help:
+            proposals: 'The file should have the following column names in the case of CSV or Excel files, or the following key names in the case of JSON files: <ul> <li><b>title/fr:</b> Title of the proposal. This will depend on the language configuration of your platform.</li> <li><b>body/fr:</b> Body of the proposal. This will depend on the language configuration of your platform.</li> <li><b>scope/id:</b> ID of the application scope.</li> <li><b>category/id:</b> ID of the category.</li> </ul>'
       collaborative_drafts:
         new:
           add_file: Add file

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,6 +4,8 @@ fr:
     attributes:
       attachment:
         documents: ajouter un document
+      content_block_attachment:
+        background_image: Image de fond
       initiative:
         offline_votes_for_scope: Signatures en personne pour %{scope_name}
       osp_authorization_handler:
@@ -14,6 +16,8 @@ fr:
         private_space: Espace privé
       participatory_space_private_user_csv_import:
         file: importer un fichier d'utilisateurs
+      project:
+        document: Document
   decidim:
     account:
       omniauth_synced_profile:
@@ -105,6 +109,12 @@ fr:
         import: Importer des propositions dans des projets
         new: Nouveau %{name}
       admin:
+        help:
+          paper_ballot_results: 'Le document d''import doit contenir les colonnes suivantes : ''id'' (avec l''identifiant du projet) et ''paper_ballots_to_import'' (avec le nombre de nouveaux votes pour le projet qui doivent être importés). Vous pouvez simplement réutiliser une exportation de tous les projets et ajouter une colonne nommée ''paper_ballots_to_import''.'
+          label:
+            paper_ballot_results: Importer les votes papier
+          title:
+            paper_ballot_results: Importer les résultats du vote papier
         models:
           project:
             name: Projet
@@ -249,6 +259,9 @@ fr:
         exports:
           awesome_private_proposals: Propositions avec champs privés
           proposal_comments: Commentaires
+        imports:
+          help:
+            proposals: 'Le fichier doit avoir les noms de colonnes suivants en cas de fichiers CSV ou Excel ou noms de clés suivants en cas de fichiers JSON : <ul> <li><b>title/fr:</b> Titre de la proposition. Cela dépendra de la configuration de la langue de votre plateforme.</li> <li><b>body/fr:</b> Corps de la proposition. Cela dépendra de la configuration de la langue de votre plateforme.</li> <li><b>scope/id :</b> ID du périmêtre d''application</li> <li><b>category/id :</b> ID de la catégorie</li> </ul>'
       collaborative_drafts:
         new:
           add_file: Ajouter le fichier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -109,8 +109,9 @@ fr:
         import: Importer des propositions dans des projets
         new: Nouveau %{name}
       admin:
-        help:
-          paper_ballot_results: 'Le document d''import doit contenir les colonnes suivantes : ''id'' (avec l''identifiant du projet) et ''paper_ballots_to_import'' (avec le nombre de nouveaux votes pour le projet qui doivent être importés). Vous pouvez simplement réutiliser une exportation de tous les projets et ajouter une colonne nommée ''paper_ballots_to_import''.'
+        imports:
+          help:
+            paper_ballot_results: 'Le document d''import doit contenir les colonnes suivantes : ''id'' (avec l''identifiant du projet) et ''paper_ballots_to_import'' (avec le nombre de nouveaux votes pour le projet qui doivent être importés). Vous pouvez simplement réutiliser une exportation de tous les projets et ajouter une colonne nommée ''paper_ballots_to_import''.'
           label:
             paper_ballot_results: Importer les votes papier
           title:


### PR DESCRIPTION
#### :tophat: Description
This PR adds missing translations for paper ballots module ([bump of https://github.com/OpenSourcePolitics/decidim-cd44/pull/117/files)

#### Related to
Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=110270472&issue=OpenSourcePolitics%7Cdecidim-app%7C761
