### PR TITLE
fix: Change instructions translation to match the behavior

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -163,6 +163,7 @@ ignore_unused:
   - decidim.newsletters.unsubscribe.success
   - decidim.newsletters.unsubscribe.error
   - decidim.newsletters.unsubscribe.token_error
+  - decidim.half_signup.quick_auth.sms.instruction
   - decidim.half_signup.quick_auth.sms_verification.text_message
   - decidim.events.proposals.author_confirmation_proposal_event.email_intro
   - decidim.events.proposals.author_confirmation_proposal_event.email_outro

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,8 @@ en:
         name: Name
     half_signup:
       quick_auth:
+        sms:
+          instruction: After entering your phone number, you will receive a code via SMS. This code will grant you access to the voting booth.
         sms_verification:
           text_message: Hello, %{verification} is the code to authenticate yourself on the platform
     initiatives:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -205,8 +205,7 @@ fr:
     half_signup:
       quick_auth:
         sms:
-          instruction: Après avoir saisi votre numéro de téléphone vous allez recevoir un code par SMS. 
-            Ce code vous donnera accès à la cabine de vote.
+          instruction: Après avoir saisi votre numéro de téléphone vous allez recevoir un code par SMS. Ce code vous donnera accès à la cabine de vote.
         sms_verification:
           text_message: Bonjour, %{verification} est le code pour vous authentifier sur la plateforme
     initiatives:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -204,6 +204,9 @@ fr:
         name: Nom
     half_signup:
       quick_auth:
+        sms:
+          instruction: Après avoir saisi votre numéro de téléphone vous allez recevoir un code par SMS. 
+            Ce code vous donnera accès à la cabine de vote.
         sms_verification:
           text_message: Bonjour, %{verification} est le code pour vous authentifier sur la plateforme
     initiatives:


### PR DESCRIPTION
#### :tophat: Description

Changes the half signup instructions on the sms authentication page from 

Le numéro de téléphone sera votre clé d'accès à la plateforme. À moins que vous n'ajoutiez un mot de passe à votre compte, un SMS sera envoyé à votre numéro de téléphone chaque fois que vous souhaitez vous connecter

to 

Après avoir saisi votre numéro de téléphone vous allez recevoir un code par SMS. 
            Ce code vous donnera accès à la cabine de vote.


#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Change your locale to the french one
* Go to organization settings
* Go to authentication settings
* Enable Half Signup SMS method
* Go to participatory processes
* Select the budgets component of a PP
* Make sure to disable zipcode if it is enabled and to be able to vote in it
* Go to the front office
* Access the budgets component and start a vote
* Make sure the instructions are correct in **french** and that it's the following : 

```
Après avoir saisi votre numéro de téléphone vous allez recevoir un code par SMS. Ce code vous donnera accès à la cabine de vote.
```

- Fixes #775 