### PR TITLE
fix: Add missing "Help" translation to the footer

### DIFF
--- a/app/cells/decidim/footer_topics/show.erb
+++ b/app/cells/decidim/footer_topics/show.erb
@@ -1,0 +1,8 @@
+<nav role="navigation" aria-label="Help">
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.help") %></h2>
+  <ul class="space-y-4 break-inside-avoid">
+    <% topics.each do |topic| %>
+      <%= topic_item(topic, class: "font-semibold underline") %>
+    <% end %>
+  </ul>
+</nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,10 @@ en:
           address: 37 Homewood Drive Brownsburg, IN 46112
     scopes:
       global: Global scope
+  layouts:
+    decidim:
+      footer:
+        help: Help
   time:
     buttons:
       select: Select

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -104,6 +104,10 @@ fr:
           address: 60 Boulevard Victor Hugo Saint-Jean-de-Luz, BP 64500
     scopes:
       global: Portée générale
+  layouts:
+    decidim:
+      footer:
+        help: Aide
   time:
     buttons:
       select: Sélectionner


### PR DESCRIPTION
#### :tophat: Description
On decidim, they added categories to the footer, but the issue is that they created the "Help" cells and they hard-coded the title as "Help" which was not following any translation

#### Testing

* Compile your app on docker (if you already have one you can run `make rebuild`
* Make sure you're on french locale
* Go to the bottom of the page
* Make sure the "Help" has been translated to "Aide"

#### :pushpin: Related Issues
- Fixes #783 

#### Tasks
- [x] Add translations
- [x] Override the cell to fix the hard-coded "Help" to the translation we added before