### PR TITLE
feat: add emitter module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSou
 gem "decidim-decidim_awesome", git: "https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git", branch: "fix/update_packages_dependancies"
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "bump/0.29"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "backport/fix_database_not_available"
+gem "decidim-emitter", git: "https://github.com/OpenSourcePolitics/decidim-module-emitter.git", branch: "bump/0.29"
 
 group :development, :test do
   gem "brakeman", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,15 @@ GIT
       sassc (~> 2.3)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-emitter.git
+  revision: 4ce3f32a268351dcfcb94f8be75926d73f221c86
+  branch: bump/0.29
+  specs:
+    decidim-emitter (1.0.0)
+      decidim-core (~> 0.29.0)
+      decidim-participatory_processes (~> 0.29.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git
   revision: 7428d7f0c797506ad0919e13ed7d8a78e46e448c
   branch: bump/0.29
@@ -975,6 +984,7 @@ DEPENDENCIES
   decidim-conferences!
   decidim-decidim_awesome!
   decidim-dev!
+  decidim-emitter!
   decidim-extra_user_fields!
   decidim-initiatives!
   decidim-templates!


### PR DESCRIPTION
#### :tophat: Description

This PR adds decidim module emitter to the dedicim-app.

#### Related to
Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=111700453&issue=OpenSourcePolitics%7Cdecidim-app%7C788

#### Testing
1. As admin, go to the edit of a process without emitter
2. Add a "Promoter group" in the metadata
3. Add a new emitter and update
4. On the edit page, check that the fields "Emitter logo" and "Emitter now" are correctly filled (cd screenshot)
5. Go to the processes index in the front, and check that the emitter appears in the process 's card, with the promoter group indication.
6. As admin, go to the edit of another process without emitter
7. In the "Select an emitter", select the previous created emitter and update
8. Check that the emitter is well stored on the process, and check in the front that it also appears on the processes index page
9. As an admin, go back to the edit of this last process
10. Add a new emitter and update
11. Check that this new emitter is well stored on the process, and check in the front that it also appears on the processes index page
