### PR TITLE
feat: Add decidim-cleaner module (migration already existing)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -21,3 +21,19 @@ MAPS_ATTRIBUTION='<a href="https://www.openstreetmap.org/copyright" target="_bla
 # Geocoder configuration (for converting addresses to coordinates)
 GEOCODER_TIMEOUT=5                   # Timeout for geocoding requests (in seconds)
 GEOCODER_UNITS=km                    # Units for geocoder results (e.g., km or mi)
+
+# Delay until a user is considered inactive and receive a warning email (in days, default: 365)
+# DECIDIM_CLEANER_INACTIVE_USERS_MAIL=
+
+# Delay until a user is deleted after receiving an email (in days, default: 30)
+# DECIDIM_CLEANER_DELETE_INACTIVE_USERS=
+
+# Delay until an admin log is deleted (in days, default: 365)
+# DECIDIM_CLEANER_DELETE_ADMIN_LOGS=
+
+# Delay until user's versions are deleted after the user deletion (in days, default: 30)
+# DECIDIM_CLEANER_DELETE_DELETED_USERS_DATA=
+
+# Delay until deleted authorization's versions are deleted after the authorization creation (in days, default: 30)
+# DECIDIM_CLEANER_DELETE_DELETED_AUTHORIZATIONS_DATA=
+

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "uri", ">= 1.0.3"
 
 # External Decidim gems
 gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git"
+gem "decidim-cleaner", git: "https://github.com/OpenSourcePolitics/decidim-module-cleaner.git", branch: "bump/0.29"
 gem "decidim-decidim_awesome", git: "https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git", branch: "fix/update_packages_dependancies"
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "bump/0.29"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "backport/fix_database_not_available"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
       decidim-core (~> 0.29.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-cleaner.git
+  revision: 2199b9ad30c2ef596843ec467d3b98bf5b107399
+  branch: bump/0.29
+  specs:
+    decidim-cleaner (5.0.0)
+      decidim-core (~> 0.29.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git
   revision: 5148029a3d2e25873ce86c48448bc862ef283677
   branch: fix/update_packages_dependancies
@@ -972,6 +980,7 @@ DEPENDENCIES
   dalli
   decidim!
   decidim-additional_authorization_handler!
+  decidim-cleaner!
   decidim-conferences!
   decidim-decidim_awesome!
   decidim-dev!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,3 +17,19 @@
   - active_storage_analysis
   - active_storage_purge
   - initiatives
+
+
+:scheduler:
+  :schedule:
+    CleanAdminLogs:
+      cron: "0 9 0 * * *"
+      class: Decidim::Cleaner::CleanAdminLogsJob
+      queue: scheduled
+    CleanInactiveUsers:
+      cron: "0 9 0 * * *"
+      class: Decidim::Cleaner::CleanInactiveUsersJob
+      queue: scheduled
+    CleanDeletedUsersData:
+      cron: "0 9 0 * * *"
+      class: Decidim::Cleaner::CleanDeletedUsersDataJob
+      queue: scheduled

--- a/spec/system/admin_manages_organization_cleaning_spec.rb
+++ b/spec/system/admin_manages_organization_cleaning_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "AdminManagesOrganizationCleaning" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "edit" do
+    it "updates the values from the form" do
+      visit decidim_admin.edit_organization_cleaner_path
+
+      expect(page).to have_content("Enable admin logs deletion")
+      expect(page).to have_content("Delete admin logs after")
+      expect(page).to have_content("Enable inactive users deletion")
+      expect(page).to have_content("Delete inactive users x days after")
+      expect(page).to have_content("Send email to inactive users before deletion")
+
+      find(:css, "input[name='organization[delete_admin_logs]'").set(true)
+      fill_in "Delete admin logs after", with: 365
+      find(:css, "input[name='organization[delete_inactive_users]'").set(true)
+      fill_in "Delete inactive users x days after", with: 30
+      fill_in "Send email to inactive users before deletion", with: 365
+
+      click_link_or_button "Update"
+      expect(page).to have_content("updated successfully")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description

Addition of the decidim cleaner module to the decidim-app for the 0.29 app

#### :pushpin: Related Issues
- #787

#### Testing

# LOCAL APP VERSION (WITHOUT DOCKER)

### Setup

* Log in as admin
* Access Backoffice
* Go to organization settings
* Access the "Data Cleaner"
* Enable both of the tests and put "1" or "2" whatever we'll actually test for a longer duration than that.

### Technical Part

- Go to your IDE (RubyMine would be the best one)
- Click on the DB Interface
- Click on the "+"
- Select Data Source PostgreSQL
- When the page opens access Schemas
- Click All databases and all schemas and validate
- Click OK and Select on your interface the thing you just created (must be a name like postgres@localhost)
- Search for osp_app
- Click on "public"
- Click on "tables"
- Search for "decidim_users" and double click on it
- Target a user (preferably the user with the id "2" which may correspond to "user@example.org"

### Test the deletion of a user

- Log in on the instance as user@example.org
- Go back to the DB and check if the columns `current_sign_in_at` and `last_signin_at` were updated
- If they were, please update it and go back 2 years earlier.
- Now run the command `bundle exec rake decidim_cleaner:clean_inactive_users`
- Check that for the same user the column `warning_date` has been updated
- If it was, please update it and go back 1 year earlier.
- Rerun the command `bundle exec rake decidim_cleaner:clean_inactive_users`
- Make sure the column `deleted_at` has been updated and that the reason has been greatly fulfilled in the column next to it `delete_reason`

If everything worked correctly that means that the decidim_cleaner is working pretty well.

------------------------

# DOCKER VERSION

### Setup

* Log in as admin
* Access Backoffice
* Go to organization settings
* Access the "Data Cleaner"
* Enable both of the tests and put "1" or "2" whatever we'll actually test for a longer duration than that.

### Technical part

- Open a terminal
- Connect to the PostgreSQL container with the command:
  `docker exec -it decidim-app-database-1 psql -U postgres`
  (Check your instance's database name if this doesn't work)
- Once connected to psql, execute the following commands:
  \c osp_app
  (If this doesn't work please run `\l` to list all existing databases)
  `SELECT email FROM public.decidim_users WHERE id = 2;`
- Make sure that he exists and it should be `user@example.org`

### Test the deletion of a user

- Log in to the instance as user@example.org
- Go back to the terminal and check if the columns `current_sign_in_at` and `last_sign_in_at` were updated for the user with ID "2":
  `SELECT current_sign_in_at, last_sign_in_at FROM public.decidim_users WHERE id = 2;`
- If they were updated, update them to go back 2 years earlier:
  `UPDATE public.decidim_users SET current_sign_in_at = current_sign_in_at - INTERVAL '2 years', last_sign_in_at = last_sign_in_at - INTERVAL '2 years' WHERE id = 2;`

------------

## TERMINAL VERSION

- On another terminal run the command to clean inactive users: (TERMINAL 2)
 `docker exec -it decidim-app-app-1 bundle exec rake decidim_cleaner:clean_inactive_users`
  (Check your instance's app name if this doesn't work)

- Check that the `warning_date` column has been updated for the same user: (TERMINAL 1)
  `SELECT warning_date FROM public.decidim_users WHERE id = 2;`

- If it was updated, update it to go back 1 year earlier: (TERMINAL 1)
  `UPDATE public.decidim_users SET warning_date = warning_date - INTERVAL '1 year' WHERE id =  2;`

- Rerun the command to clean inactive users: (TERMINAL 2)
  `docker exec -it decidim-app-app-1 bundle exec rake decidim_cleaner:clean_inactive_users`

- Make sure the `deleted_at` column has been updated and that the reason has been fulfilled in the `delete_reason` column: (TERMINAL 1)
 `SELECT deleted_at, delete_reason FROM public.decidim_users WHERE id = 2;`

-----------

## SIDEKIQ VERSION

- Connect to https://localhost:3000/sidekiq
- Go to the Recurring jobs
- Add `CleanInactiveUsers` to the queue

- Check that the `warning_date` column has been updated for the same user:
  `SELECT warning_date FROM public.decidim_users WHERE id = 2;`

- If it was updated, update it to go back 1 year earlier:
  `UPDATE public.decidim_users SET warning_date = warning_date - INTERVAL '1 year' WHERE id = 2;`

- Return to Recurring jobs
- Add `CleanInactiveUsers` to the queue
- Make sure the `deleted_at` column has been updated and that the reason has been fulfilled in the `delete_reason` column:
 `SELECT deleted_at, delete_reason FROM public.decidim_users WHERE id = 2;`

#### Tasks
- [x] Add the module cleaner to the decidim-app
- [x] Update the .env-example with the new env variables
- [x] Update the sidekiq queues to add new ones
- [x] Add a system test related to the back-office enabling of the cleaner
