### PR TITLE
Feat:  add multiple answer survey module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "uri", ">= 1.0.3"
 gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git"
 gem "decidim-decidim_awesome", git: "https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git", branch: "fix/update_packages_dependancies"
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "bump/0.29"
+gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers.git", branch: "bump/0.29"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "backport/fix_database_not_available"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,17 @@ GIT
       deface (~> 1.5)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers.git
+  revision: 971ad38a2955b5f495b7f2ed719589cd329cf269
+  branch: bump/0.29
+  specs:
+    decidim-survey_multiple_answers (0.29.2)
+      decidim-admin (>= 0.26.0, < 0.30.0)
+      decidim-core (>= 0.26.0, < 0.30.0)
+      decidim-forms (>= 0.26.0, < 0.30.0)
+      decidim-surveys (>= 0.26.0, < 0.30.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git
   revision: f3b55cae4e22713d7c842f0de4c421e9765ad7b0
   branch: backport/fix_database_not_available
@@ -977,6 +988,7 @@ DEPENDENCIES
   decidim-dev!
   decidim-extra_user_fields!
   decidim-initiatives!
+  decidim-survey_multiple_answers!
   decidim-templates!
   decidim-term_customizer!
   deface


### PR DESCRIPTION
#### :tophat: Description
This PR adds the decidim-module-survey_multiple_answers

📌 Related Issues
Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=111700754&issue=OpenSourcePolitics%7Cdecidim-app%7C789

Testing

1. As an admin, go to a pp, to the survey's component configuration and check the checkbox to allow multiple answers Ensure that the survey is published
2. As a logged in user, when multiple answers are enabled, go to the survey and answer multiple times
3. Do the same as a not logged in user