### PR TITLE
fix: migration to ensure decidim_proposals_proposal_state_id is nullable

### DIFF
--- a/db/migrate/20250522141917_update_nullable_on_decidim_proposals_proposal_state_id.rb
+++ b/db/migrate/20250522141917_update_nullable_on_decidim_proposals_proposal_state_id.rb
@@ -1,0 +1,5 @@
+class UpdateNullableOnDecidimProposalsProposalStateId < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :decidim_proposals_proposals, :decidim_proposals_proposal_state_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_03_145039) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_22_141917) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"


### PR DESCRIPTION
#### :tophat: Description
This PR adds a migration file to ensure that decidim_proposals_proposal_state_id in decidim_proposals_proposals table is nullable

#### Testing
As a user, go to a process where you can create proposal
Ensure you can create and publish the proposal without error type `PG::NotNullViolation: ERROR:  null value in column "decidim_proposals_proposal_state_id" of relation "decidim_proposals_proposals" violates not-null constraint`