### PR TITLE
feat: Add omniauth_publik to 0.29

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "nokogiri", ">= 1.18.4"
 gem "rack", "~> 2.2.14"
 gem "uri", ">= 1.0.3"
 
+# omniauth
+gem "omniauth-publik", git: "https://github.com/OpenSourcePolitics/omniauth-publik.git", branch: "feat/update_to_0.29"
+
 # External Decidim gems
 gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git"
 gem "decidim-decidim_awesome", git: "https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git", branch: "fix/update_packages_dependancies"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,15 @@ GIT
       decidim-core (~> 0.29.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/omniauth-publik.git
+  revision: 3bec74589e5a1c97a1529edfc20bfb61666021a8
+  branch: feat/update_to_0.29
+  specs:
+    omniauth-publik (0.1.1)
+      omniauth (~> 2.1)
+      omniauth-oauth2 (>= 1.7.2, < 2.0)
+
+GIT
   remote: https://github.com/decidim/decidim.git
   revision: 8f4f1c213c3e141b1d33f41ce2ee9e1f95f0048b
   tag: v0.29.3
@@ -991,6 +1000,7 @@ DEPENDENCIES
   memory_profiler
   net-imap (>= 0.5.6)
   nokogiri (>= 1.18.4)
+  omniauth-publik!
   parallel_tests (~> 4.2)
   puma (>= 6.3.1)
   rack (~> 2.2.14)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -113,3 +113,4 @@ ignore_unused:
   - date.formats.order
   - decidim.participatory_processes.create_initiative.*
   - decidim.participatory_processes.form.*
+  - decidim.system.organizations.omniauth_settings.publik.*

--- a/config/initializers/omniauth_publik.rb
+++ b/config/initializers/omniauth_publik.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+if Rails.application.secrets.dig(:omniauth, :publik).present?
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider(
+      :publik,
+      setup: lambda { |env|
+        request = Rack::Request.new(env)
+        organization = Decidim::Organization.find_by(host: request.host)
+        provider_config = organization.enabled_omniauth_providers[:publik]
+        env["omniauth.strategy"].options[:client_id] = provider_config[:client_id]
+        env["omniauth.strategy"].options[:client_secret] = provider_config[:client_secret]
+        env["omniauth.strategy"].options[:site] = provider_config[:site_url]
+      },
+      scope: "openid email profile"
+    )
+  end
+end
+
+Rails.application.config.after_initialize do
+  Decidim.icons.register(
+    name: "publik-fill",
+    icon: "publik-fill",
+    category: "system",
+    description: "Publik authentication provider icon",
+    engine: :core
+  )
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,13 @@ en:
           address: 37 Homewood Drive Brownsburg, IN 46112
     scopes:
       global: Global scope
+    system:
+      organizations:
+        omniauth_settings:
+          publik:
+            client_id: Client ID
+            client_secret: Client secret
+            site_url: Site URL
   layouts:
     decidim:
       footer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -124,6 +124,13 @@ fr:
           address: 60 Boulevard Victor Hugo Saint-Jean-de-Luz, BP 64500
     scopes:
       global: Portée générale
+    system:
+      organizations:
+        omniauth_settings:
+          publik:
+            client_id: Client ID
+            client_secret: Client secret
+            site_url: Site URL
   layouts:
     decidim:
       footer:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -138,6 +138,11 @@ default: &default
       icon: google-fill
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
+    publik:
+      enabled: <%= ENV["OMNIAUTH_PUBLIK_CLIENT_SECRET"].present? %>
+      client_id: <%= ENV["OMNIAUTH_PUBLIK_CLIENT_ID"] %>
+      client_secret: <%= ENV["OMNIAUTH_PUBLIK_CLIENT_SECRET"] %>
+      site_url: <%= ENV["OMNIAUTH_PUBLIK_SITE_URL"] %>
   maps:
     provider: <%= Decidim::Env.new("MAPS_PROVIDER", "here") %>
     api_key: <%= ENV["MAPS_API_KEY"] %>
@@ -182,6 +187,11 @@ test:
   <<: *default
   secret_key_base: b91cc5364a7ff10a86700f87e712cdba9670fe0c85fdcf855cb626d14d1fdfc59076c33585500447ad3423159593db52bbc770c9f949fcfcd6e402c7366ced49
   omniauth:
+    publik:
+      enabled: true
+      client_id: 12345
+      client_secret: 12345
+      site_url: https://example.com/
     facebook:
       enabled: true
       app_id: fake-facebook-app-id

--- a/spec/system/sso/omniauth_publik_spec.rb
+++ b/spec/system/sso/omniauth_publik_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Omniauth Publik" do
+  let(:organization) { create(:organization) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.root_path
+  end
+
+  context "when using Publik" do
+    let(:omniauth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: "publik",
+        uid: "123545",
+        info: {
+          nickname: "foobar",
+          name: "Foo Bar",
+          email: "foo@bar.com"
+        }
+      )
+    end
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:publik] = omniauth_hash
+      OmniAuth.config.add_camelization "publik", "Publik"
+      OmniAuth.config.request_validation_phase = ->(env) {} if OmniAuth.config.respond_to?(:request_validation_phase)
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:publik] = nil
+      OmniAuth.config.camelizations.delete("publik")
+    end
+
+    context "when the user has confirmed the email in publik" do
+      it "creates a new User without sending confirmation instructions" do
+        find(".sign-up-link").click
+
+        click_link_or_button "Sign in with Publik"
+
+        expect(page).to have_content("Successfully")
+        expect_user_logged
+      end
+    end
+  end
+end

--- a/spec/system/sso/omniauth_publik_spec.rb
+++ b/spec/system/sso/omniauth_publik_spec.rb
@@ -38,9 +38,9 @@ describe "Omniauth Publik" do
 
     context "when the user has confirmed the email in publik" do
       it "creates a new User without sending confirmation instructions" do
-        find(".sign-up-link").click
+        click_on("Log in", match: :first)
 
-        click_link_or_button "Sign in with Publik"
+        click_on("Publik", match: :first)
 
         expect(page).to have_content("Successfully")
         expect_user_logged


### PR DESCRIPTION
#### :tophat: Description

Add Omniauth Publik gem to 0.29

~~This an example description for a pull request. You can use this template to create your own PR description.~~

#### Testing

Example:
* Log in on the system http://localhost:3000/system
* Edit the organization that was created
* Scroll through SSO providers
* Make sure Publik is there
* Enable it (you can let it empty)
* Go to the platform
* Click on "Log In"
* Make sure Public is appearing as a provider to connect to the platform

#### :pushpin: Related Issues
- Fixes #786 

#### Tasks
- [ ] Add gem omniauth_publik
- [ ] Add secrets related to publik
- [ ] Add the logo of publik on the initializers
- [ ] Add the initializer from the module
- [ ] Add locales on the organization system
- [ ] Add specs