### PR TITLE
Feat: add module guest_meeting_registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "uri", ">= 1.0.3"
 gem "decidim-additional_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-additional_authorization_handler.git"
 gem "decidim-decidim_awesome", git: "https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome.git", branch: "fix/update_packages_dependancies"
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "bump/0.29"
+gem "decidim-guest_meeting_registration", git: "https://github.com/OpenSourcePolitics/guest-meeting-registration.git", branch: "bump/module_to_0.29"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "backport/fix_database_not_available"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/guest-meeting-registration.git
-  revision: 541757dfefad91c88f5329fa3abb804860f4720e
+  revision: a0ad48b581e1b1576d38e00f168ef8885a7d8133
   branch: bump/module_to_0.29
   specs:
     decidim-guest_meeting_registration (0.29.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,16 @@ GIT
       decidim-core (~> 0.29.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/guest-meeting-registration.git
+  revision: 541757dfefad91c88f5329fa3abb804860f4720e
+  branch: bump/module_to_0.29
+  specs:
+    decidim-guest_meeting_registration (0.29.2)
+      decidim-core (~> 0.29)
+      decidim-meetings (~> 0.29)
+      deface (>= 1.9)
+
+GIT
   remote: https://github.com/decidim/decidim.git
   revision: 8f4f1c213c3e141b1d33f41ce2ee9e1f95f0048b
   tag: v0.29.3
@@ -976,6 +986,7 @@ DEPENDENCIES
   decidim-decidim_awesome!
   decidim-dev!
   decidim-extra_user_fields!
+  decidim-guest_meeting_registration!
   decidim-initiatives!
   decidim-templates!
   decidim-term_customizer!


### PR DESCRIPTION
#### :tophat: Description
This PR adds the module guest_meeting_registration

#### Related to
Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=111943553&issue=OpenSourcePolitics%7Cdecidim-app%7C798

#### Testing

1. As an admin, go to a meeting, enable registration on the platform in the configuration form
2. In the managing meeting's page, in the configure registration page, enable registration without a user account, and enable "Allow cancellation of registration"
3. As a non logged-in user, in the FO, go to the meeting and click on the registration button. See that you have the choice to register with your account or as a guest (Test the 2 processes). See that you can cancel your registration.
4. As an admin, go back to the configure registration page of the meeting and click on "No longer require users to choose between login and guest mode to register for the meeting". Add Registration terms.
5. As a non logged-in user, in the FO, go to the meeting and click on the registration button. See that you can only register as a guest. See in the form that the registrations terms are displayed.
6. As an admin, go back to the configure registration page and click enable registration form. Configure the registration form by adding one question.
7. As a non logged-in user, in the FO, go to the meeting and click on the registration button. When you register, see that the question of the registration form is displayed. See that the labels are bold.

