### PR TITLE
fix: Change max results input type

### DIFF
--- a/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,0 +1,26 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <div class="row column">
+    <%= settings_fields.text_field :max_results,
+                                   label: label,
+                                   placeholder: "0-100",
+                                   oninput: "validateInput(this)",
+                                   pattern: "[0-9]{1,3}" %>
+  </div>
+<% end %>
+
+<script>
+  function validateInput(input) {
+    input.value = input.value.replace(/[^0-9]/g, '');
+
+    if (input.value !== '') {
+      let value = parseInt(input.value, 10);
+      if (value > 100) {
+        value = 100;
+      }
+      if (value < 0) {
+        value = 0;
+      }
+      input.value = value.toString();
+    }
+  }
+</script>

--- a/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,0 +1,26 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <div class="row column">
+    <%= settings_fields.text_field :max_results,
+                                   label: label,
+                                   placeholder: "0-100",
+                                   oninput: "validateInput(this)",
+                                   pattern: "[0-9]{1,3}" %>
+  </div>
+<% end %>
+
+<script>
+  function validateInput(input) {
+    input.value = input.value.replace(/[^0-9]/g, '');
+
+    if (input.value !== '') {
+      let value = parseInt(input.value, 10);
+      if (value > 100) {
+        value = 100;
+      }
+      if (value < 0) {
+        value = 0;
+      }
+      input.value = value.toString();
+    }
+  }
+</script>

--- a/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,0 +1,26 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <div class="row column">
+    <%= settings_fields.text_field :max_results,
+                                   label: label,
+                                   placeholder: "0-100",
+                                   oninput: "validateInput(this)",
+                                   pattern: "[0-9]{1,3}" %>
+  </div>
+<% end %>
+
+<script>
+  function validateInput(input) {
+    input.value = input.value.replace(/[^0-9]/g, '');
+
+    if (input.value !== '') {
+      let value = parseInt(input.value, 10);
+      if (value > 100) {
+        value = 100;
+      }
+      if (value < 0) {
+        value = 0;
+      }
+      input.value = value.toString();
+    }
+  }
+</script>


### PR DESCRIPTION
#### :tophat: Description

Change the max results input type from a select of [6, 9, 12] to a free text field but with stricter restrictions than the current Decidim 0.30 solution.

Please note that this fixes the behavior from 0.29, which only allowed 3 options, but the option currently available in 0.30 is not satisfactory as it has multiple issues, such as:

- You can enter letters inside the input ("E" for Chrome, any letter on Firefox)
- You can enter any amount you want, which is not restrictive enough

This may be a temporary solution while waiting for problems concerning their current solution to be reported and updated to the association.

#### Testing

* Log in as admin
* Access Backoffice
* Go to participatory_processes or assemblies
* Edit one of them
* Go to "Landing Page"
* Try to edit "Related Assemblies" "Related Participatory Processes" or "Related Conferences"
* Make sure default is "6" but that you can erase it and write any number from 0 to 100 without going below or further

---------

* To test for Highlighted conferences, Go to settings
* Go to "Homepage"
* Create a new component "Highlighted Conferences" (You can also try "Highlighted Participatory Processes & Highlighted Assemblies" which use the same cell
* Make sure default is "6" but that you can erase it and write any number from 0 to 100 without going below or further

#### :pushpin: Related Issues
- Fixes #794 

#### Tasks
- [x] Override cells