### PR TITLE
Fix: override hero cell show to remove linear-gradient from homepage img

### DIFF
--- a/app/cells/decidim/content_blocks/hero/show.erb
+++ b/app/cells/decidim/content_blocks/hero/show.erb
@@ -1,0 +1,13 @@
+<section id="hero-<%= model.id %>" class="hero__container" style="background-image:url('<%= background_image %>')" data-process-hero>-->
+  <div class="hero">
+    <h1 class="hero__title">
+      <% if translated_welcome_text.blank? %>
+        <%= t("decidim.pages.home.hero.welcome", organization: current_organization_name) %>
+      <% else %>
+        <%= decidim_sanitize_admin translated_welcome_text %>
+      <% end %>
+    </h1>
+
+    <%= render :cta_button %>
+  </div>
+</section>


### PR DESCRIPTION
#### :tophat: Description
This PR removes linear-gradient from homepage background-image.

#### Related_to
Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=111558689&issue=OpenSourcePolitics%7Cdecidim-app%7C782

#### Testing
As a user, go to the homepage and see that there is no linear-gradient on banne image.

#### :camera: Screenshots
<img width="1340" alt="Capture d’écran 2025-05-27 à 14 02 55" src="https://github.com/user-attachments/assets/f675be16-bbb7-47ea-8982-3e944e79ec58" />
