### PR TITLE
feat: add module 2FA 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/dec
 gem "decidim-guest_meeting_registration", git: "https://github.com/OpenSourcePolitics/guest-meeting-registration.git", branch: "bump/module_to_0.29"
 gem "decidim-survey_multiple_answers", git: "https://github.com/OpenSourcePolitics/decidim-module-survey_multiple_answers.git", branch: "bump/0.29"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "backport/fix_database_not_available"
+gem "decidim-admin_multi_factor", git: "https://github.com/OpenSourcePolitics/decidim-module-admin_multi_factor.git", branch: "rc-0.29"
 
 group :development, :test do
   gem "brakeman", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,15 @@ GIT
       decidim-core (~> 0.29.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-admin_multi_factor.git
+  revision: e436cc6d3dbb83da3bb250fba9fd123041566b5a
+  branch: rc-0.29
+  specs:
+    decidim-admin_multi_factor (0.29.3)
+      countries (~> 5.1, >= 5.1.2)
+      decidim-core (~> 0.29.3)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-cleaner.git
   revision: 2199b9ad30c2ef596843ec467d3b98bf5b107399
   branch: bump/0.29
@@ -35,11 +44,11 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git
-  revision: 7428d7f0c797506ad0919e13ed7d8a78e46e448c
+  revision: 6406aff4fecde79cead61218e5874a2dbe9bdfcb
   branch: bump/0.29
   specs:
     decidim-extra_user_fields (0.29.0)
-      country_select (~> 4.0)
+      country_select (~> 9.0)
       decidim-core (>= 0.29)
       deface (~> 1.5)
 
@@ -429,13 +438,10 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
-    country_select (4.0.0)
-      countries (~> 3.0)
-      sort_alphabetical (~> 1.0)
+    countries (5.7.2)
+      unaccent (~> 0.3)
+    country_select (9.0.0)
+      countries (> 5.0, < 7.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -584,7 +590,6 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    i18n_data (0.11.0)
     icalendar (2.10.3)
       ice_cube (~> 0.16)
       ostruct
@@ -934,13 +939,10 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    sixarm_ruby_unaccent (1.2.2)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sort_alphabetical (1.1.0)
-      unicode_utils (>= 1.2.2)
     spring (4.2.1)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -957,8 +959,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.6.0)
-    unicode_utils (1.4.0)
     uniform_notifier (1.16.0)
     uri (1.0.3)
     valid_email2 (4.0.6)
@@ -1028,6 +1030,7 @@ DEPENDENCIES
   dalli
   decidim!
   decidim-additional_authorization_handler!
+  decidim-admin_multi_factor!
   decidim-budgets_booth!
   decidim-cleaner!
   decidim-conferences!

--- a/db/migrate/20250620142243_create_decidim_admin_multi_factor_settings.rb
+++ b/db/migrate/20250620142243_create_decidim_admin_multi_factor_settings.rb
@@ -1,0 +1,17 @@
+# This migration comes from decidim_admin_multi_factor (originally 20241126021907)
+
+# frozen_string_literal: true
+
+class CreateDecidimAdminMultiFactorSettings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_admin_multi_factor_settings do |t|
+      t.boolean :enable_multifactor, default: false
+      t.boolean :email, default: false
+      t.boolean :sms, default: false
+      t.boolean :webauthn, default: false
+      t.references :decidim_organization, foreign_key: true, index: { name: :index_decidim_admin_multi_factor_settings_on_organization_id }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_22_141917) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_20_142243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
@@ -116,6 +116,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_22_141917) do
     t.index ["resource_type", "resource_id"], name: "index_action_logs_on_resource_type_and_id"
     t.index ["version_id"], name: "index_decidim_action_logs_on_version_id"
     t.index ["visibility"], name: "index_decidim_action_logs_on_visibility"
+  end
+
+  create_table "decidim_admin_multi_factor_settings", force: :cascade do |t|
+    t.boolean "enable_multifactor", default: false
+    t.boolean "email", default: false
+    t.boolean "sms", default: false
+    t.boolean "webauthn", default: false
+    t.bigint "decidim_organization_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_organization_id"], name: "index_decidim_admin_multi_factor_settings_on_organization_id"
   end
 
   create_table "decidim_amendments", force: :cascade do |t|
@@ -2178,6 +2189,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_22_141917) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "decidim_admin_multi_factor_settings", "decidim_organizations"
   add_foreign_key "decidim_area_types", "decidim_organizations"
   add_foreign_key "decidim_areas", "decidim_area_types", column: "area_type_id"
   add_foreign_key "decidim_areas", "decidim_organizations"


### PR DESCRIPTION
#### :tophat: Description
This PR adds the module decidim-admin_multi_factor, and also and bump extra_user_fields to ensure compatibility between the 2 modules (updates version of country_select in extra_user_fields, so that the version of its dependance countries is compatible with the one in 2FA)

#### Testing
1. Log in as admin and access back office
2. In the settings, go to Multifactors settings, check the 3 checkboxes and update
3. Log out
4. Log in again and try to access admin dashboard from the menu
5. Choose email and go to letter_opener to get the verification code
6. See that you get access to BO
7. Log out
8. Log in again and try to access admin dashboard from the menu
9. Choose sms and search in your logs for "verification code is", and type the code
10. See that you get access to BO

Example:
* Log in as admin
* Access Backoffice
* Go to organization settings
* See ...

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=116211685&issue=OpenSourcePolitics%7Cintern-tasks%7C51
