### PR TITLE
fix: remove linear gradient from home section image

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -9,3 +9,9 @@
 .card__grid-metadata {
   @apply overflow-x-hidden
 }
+.home__section-image {
+  /* stylelint-disable-next-line number-leading-zero */
+  background-image: var(--hero-image);
+
+  @apply bg-center bg-cover;
+}


### PR DESCRIPTION
#### :tophat: Description
This PR removes the linear gradient from home section image

#### Testing

1. As an admin, in the BO go to Setitngs > Appeareance adn add a 'highligted content banner"
2. In the FO, see that the banner added as no linear gradient.

Example:
* Log in as admin
* Access Backoffice
* Go to organization settings
* See ...

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=116527501&issue=OpenSourcePolitics%7Cdecidim-app%7C818

#### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*

![Uploading Capture d’écran 2025-06-24 à 10.22.11.png…]()
