### PR TITLE
Fix publik translation of log_in button to customize it with term customizer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module DecidimApp
       require "extends/controllers/decidim/participatory_processes/participatory_processes_controller_extends"
       # helpers
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
+      require "extends/helpers/decidim/omniauth_helper_extends"
       # cells
       require "extends/cells/decidim/system/system_checks_cell_extends"
       require "extends/cells/decidim/comments/comment_metadata_cell_extends"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -94,6 +94,7 @@ ignore_missing:
   - time.buttons.select
   - decidim.admin.models.assembly.fields.promoted
   - decidim.metadata.progress.remaining
+  - decidim.devise.shared.links.log_in_with_user
 
 # Consider these keys used:
 ignore_unused:
@@ -119,3 +120,4 @@ ignore_unused:
   - decidim.menu.help
   - decidim.pages.home.extended.meetings
   - decidim.profiles.show.activity
+  - decidim.devise.shared.links.log_in_with_user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,10 @@ en:
           global:
             require_category: Category is required
             require_scope: Scope is required
+    devise:
+      shared:
+        links:
+          log_in_with_provider: Log in with %{provider}
     events:
       proposals:
         author_confirmation_proposal_event:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -46,6 +46,10 @@ fr:
           global:
             require_category: La catégorie est obligatoire
             require_scope: Le secteur est obligatoire
+    devise:
+      shared:
+        links:
+          log_in_with_provider: Connectez-vous avec %{provider}
     events:
       proposals:
         author_confirmation_proposal_event:

--- a/lib/extends/helpers/decidim/omniauth_helper_extends.rb
+++ b/lib/extends/helpers/decidim/omniauth_helper_extends.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module OmniauthHelperExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def normalize_provider_name(provider)
+      return "x" if provider == :twitter
+      # customize the name of the omniauth btn login with publik
+      if provider == :publik && Decidim::TermCustomizer::Translation.where(key: "decidim.devise.shared.links.log_in_with_provider").present?
+        return I18n.t("decidim.devise.shared.links.log_in_with_provider")
+      end
+
+      provider.to_s.split("_").first
+    end
+  end
+end
+
+Decidim::OmniauthHelper.include(OmniauthHelperExtends)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,3 +3,4 @@
 require "decidim/core/test/factories"
 require "decidim/comments/test/factories"
 require "decidim/proposals/test/factories"
+require "decidim/term_customizer/test/factories"

--- a/spec/helpers/decidim/omniauth_helper_spec.rb
+++ b/spec/helpers/decidim/omniauth_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe OmniauthHelper do
+    let(:facebook_enabled) { true }
+    let(:twitter_enabled) { true }
+    let(:publik_enabled) { true }
+    let(:secrets) do
+      {
+        omniauth: {
+          facebook: { enabled: facebook_enabled },
+          twitter: { enabled: twitter_enabled },
+          publik: { enabled: publik_enabled }
+        }
+      }
+    end
+
+    before do
+      allow(Rails.application).to receive(:secrets).and_return(secrets)
+    end
+
+    describe "#normalize_provider_name" do
+      context "when provider is google_oauth2" do
+        it "returns just google" do
+          expect(helper.normalize_provider_name(:google_oauth2)).to eq("google")
+        end
+      end
+
+      context "when provider is publik" do
+        let(:translation_set) { create(:translation_set) }
+        let!(:translation) { create(:translation, key: "decidim.devise.shared.links.log_in_with_provider", value: "Login with MyPublik") }
+
+        before do
+          allow(I18n).to receive(:t).with("decidim.devise.shared.links.log_in_with_provider").and_return("Login with MyPublik")
+        end
+
+        it "returns the specific translation key" do
+          expect(helper.normalize_provider_name(:publik)).to eq("Login with MyPublik")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR allows to to change the translation of the log in button via the term customizer when Publik is enabled on the platform.

#### Testing

1. Go to an application where publik is enabled
2. As an admin, in the BO, go to Term customizer tab
3. Create a new translation set
4. Inside it, create a new translation with translation key "decidim.devise.shared.links.log_in_with_provider", set a customized term to it and save
5. As a non logged in user, go to the log_in page and see that the log_in btn for publik displays the customized term

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=116529871&issue=OpenSourcePolitics%7Cdecidim-app%7C819

#### Tasks
- [X] Add specs
