### PR TITLE
feat: bump extra_user_fields 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git
-  revision: 6406aff4fecde79cead61218e5874a2dbe9bdfcb
+  revision: 32c4f18b948a09fb6b1fb191f2c7b727cad625e2
   branch: bump/0.29
   specs:
     decidim-extra_user_fields (0.29.0)


### PR DESCRIPTION
#### :tophat: Description
This PR bumps decidim-module-extra_user_fields to include style udpate on date_of_birth field

#### Testing

1. As an admin, in the BO, go to settings and then to Manage extra user fields 
2. Enable extra user fields and Enable date of birth field, and two more fields
3. In the FO, go to my account
4. See that the date of birth field is displayed without extra space compare to other fields
5. Log out
6. Go to signup page and see that the date of birth field is displayed without extra space compare to other fields

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=117229980&issue=OpenSourcePolitics%7Cintern-tasks%7C52


#### :camera: Screenshots
**Account form**
<img width="1183" alt="Capture d’écran 2025-06-27 à 10 36 09" src="https://github.com/user-attachments/assets/91942cdf-878e-474b-93f0-a7c93674cf83" />

**Sign up form**
<img width="964" alt="Capture d’écran 2025-06-27 à 10 35 29" src="https://github.com/user-attachments/assets/ce1d72cd-8557-4994-8488-b1c192b221ff" />

