### PR TITLE
Fix: override decidim geo to fix component update

### DIFF
--- a/app/overrides/replace_default_meetings_map.rb
+++ b/app/overrides/replace_default_meetings_map.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# TODO, delete this override when issue
+# https://git.octree.ch/decidim/decidim-module-geo/-/issues?show=eyJpaWQiOiIxNjYiLCJmdWxsX3BhdGgiOiJkZWNpZGltL2RlY2lkaW0tbW9kdWxlLWdlbyIsImlkIjo0ODI0fQ%3D%3D
+# has been fixed
+
 # Meetings
 
 Deface::Override.new(virtual_path: "decidim/meetings/shared/_index",

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module DecidimApp
       require "extends/commands/decidim/participatory_processes/admin/copy_participatory_process_extends"
       require "extends/commands/decidim/create_omniauth_registration_extends"
       require "extends/commands/decidim/assemblies/admin/update_assembly_extends"
+      require "extends/commands/decidim/admin/update_component_extends"
       # forms
       require "extends/forms/decidim/assemblies/admin/assembly_copy_form_extends"
       require "extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends"

--- a/lib/extends/commands/decidim/admin/update_component_extends.rb
+++ b/lib/extends/commands/decidim/admin/update_component_extends.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# TODO: delete this extends when issue https://git.octree.ch/decidim/decidim-module-geo/-/issues/168 has been fixed
+# TODO, delete this extends when issue
+# https://git.octree.ch/decidim/decidim-module-geo/-/issues/168 has been fixed
 
 require "active_support/concern"
 

--- a/lib/extends/commands/decidim/admin/update_component_extends.rb
+++ b/lib/extends/commands/decidim/admin/update_component_extends.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# TODO: delete this extends when issue https://git.octree.ch/decidim/decidim-module-geo/-/issues/168 has been fixed
+
+require "active_support/concern"
+
+module UpdateComponentExtends
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def update_component
+      decidim_original_update_component
+
+      avoid_index_relation = @component.decidim_geo_avoid_index || Decidim::Geo::NoIndex.new
+      avoid_index_relation.decidim_component_id = @component.id
+      avoid_index_relation.no_index = form.decidim_geo_avoid_index.nil? ? false : form.decidim_geo_avoid_index
+      @component.decidim_geo_avoid_index = avoid_index_relation
+      @component.save!
+      # Update geo index linked resources
+      Decidim::Geo::Index.where(
+        component_id: @component.id,
+        resource_type: @component.manifest_name
+      ).update(avoid_index: avoid_index_relation.no_index)
+    end
+  end
+end
+
+Decidim::Admin::UpdateComponent.include(UpdateComponentExtends)

--- a/lib/extends/commands/decidim/assemblies/admin/update_assembly_extends.rb
+++ b/lib/extends/commands/decidim/assemblies/admin/update_assembly_extends.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# TODO, delete this extends when issue
+# https://git.octree.ch/decidim/decidim-module-geo/-/issues?show=eyJpaWQiOiIxNjciLCJmdWxsX3BhdGgiOiJkZWNpZGltL2RlY2lkaW0tbW9kdWxlLWdlbyIsImlkIjo0OTE2fQ%3D%3D
+# has been fixed
+
 require "active_support/concern"
 module UpdateAssemblyExtends
   extend ActiveSupport::Concern


### PR DESCRIPTION
#### :tophat: Description
This PR adds an override of decidim_geo to fix an error when updating a component  in the BO.
It overrides the file lib/decidim/geo/components/overrides/update_component_command_override.rb line 17 to add a false value if form.decidim_geo_avoid_index is nil

It also adds comments on other decidim_geo overrides to remember to delete them when the issues will be fixed on the module itself.

#### Testing
As an admin, go to a component in the BO and try to update it.
See that you don't have error.

#### :camera: Screenshots
Screen of the error 

<img width="1223" alt="error" src="https://github.com/user-attachments/assets/27b0471e-9b61-434a-81a9-15482c7e23c2" />

