### PR TITLE
fix: show map only if component enables maps

### DIFF
--- a/app/overrides/replace_default_meetings_map.rb
+++ b/app/overrides/replace_default_meetings_map.rb
@@ -7,7 +7,7 @@ Deface::Override.new(virtual_path: "decidim/meetings/shared/_index",
                      replace: "erb[silent]:contains('if display_map')",
                      closing_selector: "erb[silent]:contains('end')",
                      text: <<~ERB
-                        <% if defined? current_participatory_space %>
+                        <% if display_map && defined? current_participatory_space %>
                          <%= cell("decidim/geo/content_blocks/geo_maps", current_participatory_space,
                            id: "Meetings",
                            hide_empty: true,


### PR DESCRIPTION
#### :tophat: Description
This PR adds the condition `display_map` to the override of decidim_geo map for meetings index page.

#### Related to
Github card https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=118470869&issue=OpenSourcePolitics%7Cintern-tasks%7C56

#### Testing

1. As an admin, go in the BO to a meetings component
2. Disable the maps
3. In the FO, go to the meetings index page and see that the map is not displayed
4. In the BO, enable the maps again on the meeting component
5. In the FO, go to the meetings index page and see that the map is displayed
