### PR TITLE
feat: bump emitter 0.29 to latest version without component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-emitter.git
-  revision: 4ce3f32a268351dcfcb94f8be75926d73f221c86
+  revision: d25e43f2b5267213d435611f1a34df275e0b56d0
   branch: bump/0.29
   specs:
     decidim-emitter (1.0.0)


### PR DESCRIPTION
#### :tophat: Description
This PR bumps the decidim-module-emitter to the latest version that removes the registration of the module as a component.

#### Testing

1. As an admin, go to a process
2. Click on Components, and then on "Add component"
3. See that emitter doesn't appear in the list of components
4. As an admin, go back to "About this process", add an emitter to check that it works as usual.

#### :pushpin: Related Issues
- Github card https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=118711068&issue=OpenSourcePolitics%7Cintern-tasks%7C57

#### :camera: Screenshots
<img width="1317" alt="Capture d’écran 2025-07-08 à 15 27 29" src="https://github.com/user-attachments/assets/356029c6-1996-4882-83d3-301fd98809c7" />

