### PR TITLE
feat: bump budgets_booth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: d6aee2da0577cb882235be0cbdb42fe5b9e673fe
+  revision: c089979c5ed5561e4973806ccd678f2e70491957
   branch: bump/0.29-budgets_booth
   specs:
     decidim-budgets_booth (0.29.0)


### PR DESCRIPTION
#### :tophat: Description
This PR bumps the decidim module budgets_booth to its lates version, which includes:
- not show the vote button on projects when vote is finished
- display metadata in projects grid cards

#### Testing
1. Testing that vote button is not present when vote is finished

- in the BO, go to a process => configure budget component => select in the Step settings "Voting
finished"
- in the FO, go to the budget => projects and see that the button to vote for a project is not displayed in grid mode and in list mode

2. Testing metadata

- As a user, vote for a budget
- Log out and log in with another account
- Go to the projects index of the voted budget and see in grid mode that the number of votes is displayed on the card

#### :pushpin: Related Issues
Github cards:
https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=119136483&issue=OpenSourcePolitics%7Cdecidim-app%7C839
https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=119139553&issue=OpenSourcePolitics%7Cdecidim-app%7C840


#### :camera: Screenshots
<img width="1319" alt="Capture d’écran 2025-07-09 à 17 17 36" src="https://github.com/user-attachments/assets/b5663454-6425-4fb9-bbe1-fc2d5b0fdcca" />
