### PR TITLE
feat: Add deface precompile step to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY . .
 
 RUN bundle exec rake decidim:webpacker:install && \
     bundle exec rake assets:precompile && \
+    bundle exec rails deface:precompile && \
     bundle exec rails shakapacker:compile
 
 RUN rm -rf node_modules tmp/cache vendor/bundle/spec \


### PR DESCRIPTION
#### :tophat: Description

Add missing deface:precompile command to the dockerfile to avoid enabling it using `DEFACE_ENABLED=true` that may cause some issues


Example:
* Using docker setup your application
* Access Backoffice
* Go to organization settings
* Go to "Manage registration fields" make sure to enable it and to add some custom user fields.
* Using a private navigation make sure the custom registration has been changed
* Change an other time by adding or removing some fields
* Make sure it changed correctly

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #835 
