### PR TITLE
fix: Initiatives Edit if there is only one initiative_type

### DIFF
--- a/app/overrides/decidim/initiatives/admin/initiatives/_form/replace_condition_single_initiative.html.erb.deface
+++ b/app/overrides/decidim/initiatives/admin/initiatives/_form/replace_condition_single_initiative.html.erb.deface
@@ -1,0 +1,31 @@
+<!-- replace "div.row:has(erb[silent]:contains('unless single_initiative_type?'))" -->
+<div class="row">
+  <% if single_initiative_type? %>
+    <%= form.hidden_field :type_id,
+                          value: initiative_type_options.first.last,
+                          "data-scope-selector": "initiative_decidim_scope_id",
+                          "data-scope-id": form.object.decidim_scope_id.to_s,
+                          "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                          "data-signature-types-selector": "initiative_signature_type",
+                          "data-signature-type": current_initiative.signature_type,
+                          "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url %>
+  <% else %>
+    <div class="columns">
+      <%= form.select :type_id,
+                      initiative_type_options,
+                      {},
+                      {
+                        disabled: !@form.signature_type_updatable?,
+                        "data-scope-selector": "initiative_decidim_scope_id",
+                        "data-scope-id": form.object.decidim_scope_id.to_s,
+                        "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                        "data-signature-types-selector": "initiative_signature_type",
+                        "data-signature-type": current_initiative.signature_type,
+                        "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
+                      } %>
+    </div>
+  <% end %>
+  <div class="columns">
+    <%= form.select :decidim_scope_id, [], {}, { disabled: !@form.signature_type_updatable? } %>
+  </div>
+</div>


### PR DESCRIPTION
#### :tophat: Description

There was an issue when the initiative_type was unique, it didn't manage to get the scope and all following informations causing the initiative to be impossible to edit.

#### Testing
**You will need to access DB to delete every existing initiatives_types if you want to test it properly as three are already existing by default**

**You will need to run `bundle exec rake deface:precompile` to ensure the modifications are applied !**

Example:
* Log in as admin
* Access Backoffice
* Go to initiatives
* Create a new initiative_type (make sure it is the only one existing)
* Create a new initiative on the front-office as a user
* Send it to technical validation
* Access back-office and try to edit your initiative
* Make sure everything works correctly

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #855 

#### Tasks
- [x] Add deface override to change the condition and add an hidden field
