### PR TITLE
fix: Survey's attachments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ gem "rack-attack", "~> 6.7"
 gem "rgeo"
 gem "rgeo-activerecord"
 
+# Fix for WickedPdf compatibility issues
+gem "sprockets", "~> 4.0"
+gem "wicked_pdf", "~> 2.8", ">= 2.8.2"
+
 # gems updated with bundle-audit
 gem "actionpack", "~> 7.0.8.7"
 gem "graphql", "~> 2.2.17"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1012,6 +1012,9 @@ GEM
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
     stackprof (0.2.26)
     stringio (3.1.2)
     swd (2.0.3)
@@ -1148,9 +1151,11 @@ DEPENDENCIES
   sidekiq (~> 6.0)
   sidekiq-scheduler (~> 5.0)
   spring
+  sprockets (~> 4.0)
   stackprof
   uri (>= 1.0.3)
   web-console (~> 4.2)
+  wicked_pdf (~> 2.8, >= 2.8.2)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,8 @@ module DecidimApp
       require "extends/cells/decidim/system/system_checks_cell_extends"
       require "extends/cells/decidim/comments/comment_metadata_cell_extends"
       require "extends/cells/decidim/proposals/proposal_metadata_cell_extends"
+      # presenters
+      require "extends/presenters/decidim/forms/admin/questionnaire_answer_presenter_extends"
     end
 
     config.to_prepare do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,8 @@ en:
           email_subject: Your proposal has been published!
           notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is now live.
     forms:
+      questionnaire_answer_presenter:
+        download_attachment: Download attachment
       user_answers_serializer:
         email: Email
         name: Name

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -76,6 +76,8 @@ fr:
           email_subject: Votre proposition a été publiée !
           notification_title: Votre proposition <a href="%{resource_path}">%{resource_title}</a> est maintenant en ligne.
     forms:
+      questionnaire_answer_presenter:
+        download_attachment: Télécharger la pièce jointe
       user_answers_serializer:
         email: Email
         name: Nom

--- a/lib/extends/presenters/decidim/forms/admin/questionnaire_answer_presenter_extends.rb
+++ b/lib/extends/presenters/decidim/forms/admin/questionnaire_answer_presenter_extends.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module QuestionnaireAnswerPresenterExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def pretty_attachment(attachment)
+      # rubocop:disable Style/StringConcatenation
+      # Interpolating strings that are `html_safe` is problematic with Rails.
+      content_tag :li do
+        link_to(attachment_url(attachment), target: "_blank", rel: "noopener noreferrer") do
+          content_tag(:span) do
+            translated_attribute(attachment.title).presence ||
+              I18n.t("download_attachment", scope: "decidim.forms.questionnaire_answer_presenter")
+          end + " " + content_tag(:small) do
+            "#{attachment.file_type} #{number_to_human_size(attachment.file_size)}"
+          end
+        end
+      end
+      # rubocop:enable Style/StringConcatenation
+    end
+
+    private
+
+    # Return the URL of the attachment, depending on its type.
+    # It should be a file, but we also support ActiveStorage blobs and other types.
+    def attachment_url(attachment)
+      if attachment.is_a?(ActiveStorage::Blob)
+        Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true)
+      elsif attachment.respond_to?(:file) && attachment.file.attached?
+        Rails.application.routes.url_helpers.rails_blob_url(attachment.file.blob, only_path: true)
+      elsif attachment.respond_to?(:url)
+        attachment.url
+      else
+        "#"
+      end
+    end
+  end
+end
+
+Decidim::Forms::Admin::QuestionnaireAnswerPresenter.class_eval do
+  include(QuestionnaireAnswerPresenterExtends)
+end


### PR DESCRIPTION
#### :tophat: Description

Had multiple issues regarding survey's attachments related to user's answers

- Due to Sprockets issues we couldn't upload an attachment
- Retrieval of the attachments in the back-office was impossible due to the "absolute" link of the s3 bucket and not the relative link

#### Testing

* Log in as admin
* Access Backoffice
* Go to participatory processes
* Access a survey component
* Configure an "attachment answer"
* Answer the survey as a user
* Make sure you can upload correctly the attachment
* Access your survey component on the back office with admin
* Try to open the link of the answer's attachment
* Make sure the link matches `/rails/active_storage/blobs/redirect/` 

#### :pushpin: Related Issues
- Fixes #857 