### PR TITLE
feat: remove admin expiration of password 

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -47,7 +47,7 @@ decidim_default: &decidim_default
   service_urls_expires_in: <%= Decidim::Env.new("DECIDIM_SERVICE_URLS_EXPIRES_IN", "1") %>
   skip_first_login_authorization: <%= Decidim::Env.new("SKIP_FIRST_LOGIN_AUTHORIZATION").to_boolean_string %>
   admin_password:
-    expiration_days: <%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 90).to_i %>
+    expiration_days: <%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 0).to_i %>
     min_length: <%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_MIN_LENGTH", 15).to_i %>
     repetition_times: <%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES", 5).to_i %>
     strong: <%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_STRONG", true).to_boolean_string %>

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -123,8 +123,9 @@ describe "Registration" do
     context "with a weak password" do
       let(:password) { "sekritpass123" }
 
-      it "requires a password change" do
-        expect(page).to have_content("Password change")
+      # with admin_password expiration_days set to 0, no password change will be triggered
+      it "does not require a password change" do
+        expect(page).to have_no_content("Password change")
       end
     end
 


### PR DESCRIPTION
#### :tophat: Description
This PR updates the value of admin_password expiration_days to 0, so that the admin password no longer expires.

#### Testing

1. As an admin, log in and see that you are not asked to change your password
2. Logout
3. Go to the rails console in your terminal with `bundle exec rails c`
4. Update the admin password_updated_at to a date superior to 90 days (which was the previous value for updating your password), with `Decidim::User.where(admin: true).first.update_column("password_updated_at", 200.days.ago)`
5. Check that the column has been updated with `Decidim::User.where(admin: true).first.password_updated_at`
6. Restart you rails server
7. Log in as admin and see that you are not asked to change your password, even if the password_updated_at value is superior to 90 days 

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=122117354&issue=OpenSourcePolitics%7Cintern-tasks%7C71
