### PR TITLE
Fix deleted comments still on public profile

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,7 @@ module DecidimApp
       require "extends/cells/decidim/system/system_checks_cell_extends"
       require "extends/cells/decidim/comments/comment_metadata_cell_extends"
       require "extends/cells/decidim/proposals/proposal_metadata_cell_extends"
+      require "extends/cells/decidim/user_activity_cell_extends"
     end
 
     config.to_prepare do

--- a/lib/extends/cells/decidim/user_activity_cell_extends.rb
+++ b/lib/extends/cells/decidim/user_activity_cell_extends.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module UserActivityCellExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def activities
+      # filter from activities the deleted comments
+      resource_ids_to_filter = context[:activities].select { |log| log[:action] == "delete" && log[:resource_type] == "Decidim::Comments::Comment" }.map(&:resource_id)
+      if resource_ids_to_filter.any?
+        context[:activities].where.not("resource_id in (?) AND resource_type = ?", resource_ids_to_filter, "Decidim::Comments::Comment")
+      else
+        context[:activities]
+      end
+    end
+  end
+end
+
+Decidim::UserActivityCell.include(UserActivityCellExtends)

--- a/spec/cells/decidim/user_activity_cell_spec.rb
+++ b/spec/cells/decidim/user_activity_cell_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserActivityCell, type: :cell do
+  include Decidim::ApplicationHelper
+  include Decidim::TranslationsHelper
+
+  subject { my_cell.call }
+
+  let(:view_context) { Class.new(ActionView::Base).new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, []) }
+
+  let(:my_cell) do
+    cell(
+      "decidim/user_activity",
+      model,
+      context: {
+        activities:,
+        filter:,
+        resource_types:,
+        view_context:,
+        user: model
+      }
+    )
+  end
+  let(:model) { create(:user, :confirmed, organization: component.organization) }
+  let(:resource_types) do
+    %w(
+      Decidim::Proposals::CollaborativeDraft
+      Decidim::Comments::Comment
+      Decidim::Debates::Debate
+      Decidim::Initiative
+      Decidim::Meetings::Meeting
+      Decidim::Blogs::Post
+      Decidim::Proposals::Proposal
+    )
+  end
+  let(:filter) { Decidim::FilterResource::Filter.new({ resource_type: resource_types }) }
+  let(:current_user) { nil }
+  let(:component) { create(:component, :published) }
+  let(:commentable) { create(:dummy_resource, component:, published_at: Time.current) }
+  let(:comments) { create_list(:comment, 15, author: model, commentable:) }
+  let(:activities) do
+    Decidim::PublicActivities.new(
+      component.organization,
+      user: model,
+      current_user:,
+      resource_type: "all",
+      resource_name: filter.resource_type
+    ).query.page(current_page).per(10)
+  end
+  let(:current_page) { 1 }
+  let!(:logs) do
+    comments.map do |comment|
+      create(
+        :action_log,
+        action: "publish",
+        visibility: "all",
+        user: model,
+        resource: comment,
+        organization: component.organization,
+        participatory_space: component.participatory_space
+      )
+    end
+  end
+  let(:controller) { double(url_options: {}) }
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(component.organization)
+    allow(controller).to receive(:params).and_return(ActionController::Parameters.new({ nickname: model.nickname }))
+
+    allow(my_cell).to receive(:url_for).and_return("/")
+    allow(my_cell).to receive(:controller).and_return(controller)
+  end
+
+  it "displays the latest items on the first page and a pagination" do
+    logs.last(10).each do |log|
+      root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+      comment_link = "#{root_link}?commentId=#{log.resource.id}#comment_#{log.resource.id}"
+      title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+      expect(subject).to have_link(title, href: comment_link)
+    end
+
+    within ".pagination" do
+      expect(page).to have_css("li.page.current", text: "1")
+      expect(page).to have_css("li.page a", text: "2")
+      expect(page).to have_no_selector("li.page a", text: "3")
+    end
+  end
+
+  context "when comment is deleted" do
+    let!(:logs) do
+      comments.first(14).map do |comment|
+        create(
+          :action_log,
+          action: "publish",
+          visibility: "all",
+          user: model,
+          resource: comment,
+          organization: component.organization,
+          participatory_space: component.participatory_space
+        )
+      end
+    end
+    let!(:log_one) { create(:action_log, action: "create", visibility: "all", user: model, resource: comments.last, organization: component.organization, participatory_space: component.participatory_space) }
+    let!(:log_two) { create(:action_log, action: "delete", visibility: "all", user: model, resource: comments.last, organization: component.organization, participatory_space: component.participatory_space) }
+
+    it "does not display the references to the comment on the first page if comment has been deleted" do
+      logs.last(2) do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}#comment_#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+        expect(subject).to have_no_link(title, href: comment_link)
+      end
+    end
+  end
+
+  context "when on the second page" do
+    let(:current_page) { 2 }
+
+    it "displays the oldest items and a pagination" do
+      logs.first(5).each do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}#comment_#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+        expect(subject).to have_link(title, href: comment_link)
+      end
+
+      within ".pagination" do
+        expect(page).to have_css("li.page a", text: "1")
+        expect(page).to have_css("li.page.current", text: "2")
+      end
+    end
+  end
+
+  context "when there are moderated activity items that would span on the second page" do
+    before do
+      logs.first(5).each do |log|
+        create(
+          :moderation,
+          :hidden,
+          reportable: log.resource,
+          participatory_space: log.resource.commentable.participatory_space
+        )
+      end
+    end
+
+    it "displays only the non-moderated items on the first page without a pagination" do
+      # The first five items should be hidden through moderation
+      logs.first(5).each do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}#comment_#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+        expect(subject).to have_no_link(title, href: comment_link)
+      end
+      logs.last(10).each do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}#comment_#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+        expect(subject).to have_link(title, href: comment_link)
+      end
+
+      expect(subject).to have_no_selector(".pagination")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR removes deleted comments from public profile page.

#### Testing
1. As a logged_in user, add a comment to a proposal for instance.
2. Go to "My public profile" page and check in Activity that you see your comment (cf screenshot ONE).
3. Delete the comment added to the proposal
4. Go back to "My public profile" page and see that the deleted comment is not displayed (cf screenshot TWO).

#### :pushpin: Related Issues
- Github page https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=128913063&issue=OpenSourcePolitics%7Cdecidim-cdc%7C56
- Issue https://github.com/decidim/decidim/issues/15180
#### Tasks
- [X] Add specs

#### :camera: Screenshots
**ONE**
<img width="1267" height="704" alt="before" src="https://github.com/user-attachments/assets/06326cbf-c800-48fa-b41e-014538aa7bbf" />

**TWO**
<img width="1323" height="770" alt="after" src="https://github.com/user-attachments/assets/0d211f92-611b-48b1-93c0-a5d203543826" />

