### PR TITLE
bump: guest_meeting_registration module to have missing translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/guest-meeting-registration.git
-  revision: 19e3998acafa5af237dc04fb7b605de20c0dd18d
+  revision: ec9b95ec43831e994aa6ec121f69ed5fbf21c96d
   branch: bump/module_to_0.29
   specs:
     decidim-guest_meeting_registration (0.29.2)


### PR DESCRIPTION
#### :tophat: Description
This PR updates guest-meeting-registration module branch bump/0.29 to its latest commit to get missing fr translations for buttons.

#### Testing
As an admin, in the managing meeting's page, in the configure registration page, enable registration without a user account
Log out.
As a non logged-in user using fr language, in the FO, register to the meeting and see that the modal btns are translated in french.

#### :camera: Screenshots

<img width="986" height="407" alt="good" src="https://github.com/user-attachments/assets/a1baa7b6-5feb-4d6c-ab3c-7f856fb65b3c" />
