### PR TITLE
fix: update image_tag to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 image_name = decidim-app
-image_tag = 3.4.0
+image_tag = 3.5.0
 
 run: up
 	@make create-seeds


### PR DESCRIPTION
#### :tophat: Description
This PR updates the version of image_tag in Makefile to follow the latest release tag version.

