### PR TITLE
Fix: long name label cut 

### DIFF
--- a/app/views/decidim/shared/filters/_dropdown_label.html.erb
+++ b/app/views/decidim/shared/filters/_dropdown_label.html.erb
@@ -1,0 +1,59 @@
+<%
+  #  OVERRIDE of Decidim partial:
+  #  decidim-core/app/views/decidim/shared/filters/_dropdown_label.html.erb
+  #
+  #  Reason: ensure long category labels are fully displayed
+  #  (insert <wbr> after each space). -> soft = leaf.label.gsub(/\s+/, '\0<wbr>').html_safe 
+  #
+  #  Date: 2025-09-26
+%>
+
+<% leaf = item.tree_node? ? item.leaf : item %>
+<% data_checkboxes_tree_id = [check_boxes_tree_id, leaf.value].join("_") %>
+<% is_blank_root = leaf.value.blank? %>
+<% data = item.tree_node? && item.node.present? ? { checkboxes_tree: data_checkboxes_tree_id } : {} %>
+<% check_box_label = capture do %>
+  <% soft = leaf.label.gsub(/\s+/, '\0<wbr>').html_safe %>
+  <%= filter_text_for(soft, id: "dropdown-title-#{data_checkboxes_tree_id}") %>
+<% end %>
+
+<% if leaf.value == "" %>
+  <%= hidden_field_tag "#{form.object_name}[#{method}][]", "", id: "#{form.options[:namespace] rescue "default"}_filter_#{method}_all" %>
+<% end %>
+
+<div class="filter">
+  <%= form.check_box(
+        method,
+        check_boxes_tree_options(
+          leaf.value,
+          check_box_label,
+          class: "reset-defaults",
+          data:,
+          is_root_check_box: is_blank_root,
+          parent_id:
+        ),
+        leaf.value.to_s,
+        nil
+      ) %>
+  <% if !is_blank_root && item.tree_node? && item.node.present? %>
+    <button id="dropdown-trigger-<%= data_checkboxes_tree_id %>" data-controls="panel-dropdown-menu-<%= data_checkboxes_tree_id %>" aria-labelledby="dropdown-title-<%= data_checkboxes_tree_id %>">
+      <%= icon "arrow-down-s-fill" %>
+      <%= icon "arrow-up-s-fill" %>
+    </button>
+  <% end %>
+</div>
+
+<% if item.tree_node? && item.node.present? %>
+  <% subitems_content = capture do %>
+    <% item.node.each do |subitem| %>
+      <%= form.dropdown_label(subitem, method, check_boxes_tree_id:, parent_id: data_checkboxes_tree_id || "") %>
+    <% end %>
+  <% end %>
+
+  <%# Put the depending elements at the same level if the leaf is blank root (all) %>
+  <% if is_blank_root %>
+    <%= subitems_content %>
+  <% else %>
+    <%= content_tag :div, subitems_content, id: "panel-dropdown-menu-#{data_checkboxes_tree_id}" %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
#### :tophat: Description
This PR fixes the issue where long category labels in the filters panel were cut off and not fully displayed in the front office. 

#### Testing
**CONFIG IN DASHBOARD**
1. As admin go to particypatory process
2. Go to category
3. Add one with long name. Exemple: "Hello world Hello world Hello world Hello world Hello world"

**FRONT**
1. Go to your participatory process where you had had your new category
2. Go to proposals.  
3. Open the filters dropdown (categories).  
4. Check that long category names wrap correctly onto multiple lines.  
<img width="1168" height="687" alt="Capture d’écran 2025-09-26 à 12 24 07" src="https://github.com/user-attachments/assets/1546e81e-d71d-4f7b-92ef-654be13accc9" />

#### :pushpin: Related Issues
*Link your PR to an issue*
[[Bug catégories] Les noms des catégories sont coupés lorsque longs ](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=130503557&issue=OpenSourcePolitics%7Cintern-tasks%7C118)

#### Tasks
- [ ] Add note about overrides in OVERLOADS.md

#### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*

#### Extra information