### PR TITLE
Fix area filter displayed without area

### DIFF
--- a/lib/extends/helpers/decidim/check_boxes_tree_helper_extends.rb
+++ b/lib/extends/helpers/decidim/check_boxes_tree_helper_extends.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 module CheckBoxesTreeHelperExtends
+  def filter_areas_values
+    areas_or_types = areas_for_select(current_organization)
+
+    areas_values = if areas_or_types.first.is_a?(Decidim::Area)
+                     filter_areas(areas_or_types)
+                   else
+                     filter_areas_and_types(areas_or_types)
+                   end
+    return if areas_values.blank?
+
+    Decidim::CheckBoxesTreeHelper::TreeNode.new(
+      Decidim::CheckBoxesTreeHelper::TreePoint.new("", t("decidim.core.application_helper.filter_area_values.all")),
+      areas_values
+    )
+  end
+
   def filter_scopes_values
     return filter_scopes_values_from_parent(current_component.scope) if current_component.scope.present?
 
@@ -37,6 +53,15 @@ module CheckBoxesTreeHelperExtends
     scopes_values.prepend(Decidim::CheckBoxesTreeHelper::TreePoint.new("global", t("decidim.scopes.global"))) if participatory_space&.scope.blank?
 
     filter_tree_from(scopes_values)
+  end
+
+  def filter_tree_from(scopes_values)
+    if scopes_values.present?
+      Decidim::CheckBoxesTreeHelper::TreeNode.new(
+        Decidim::CheckBoxesTreeHelper::TreePoint.new("", t("decidim.core.application_helper.filter_scope_values.all")),
+        scopes_values
+      )
+    end
   end
 
   def scope_children_to_tree(scope, participatory_space = nil)

--- a/spec/helpers/check_boxes_tree_helper_spec.rb
+++ b/spec/helpers/check_boxes_tree_helper_spec.rb
@@ -18,6 +18,8 @@ module Decidim
     before do
       allow(helper).to receive(:current_participatory_space).and_return(participatory_space)
       allow(helper).to receive(:current_component).and_return(component)
+      allow(helper).to receive(:current_organization).and_return(organization)
+      allow(helper).to receive(:areas_for_select).with(organization).and_return(organization.areas)
     end
 
     describe "#filter_scopes_values" do
@@ -70,6 +72,31 @@ module Decidim
           expect(leaf.value).to eq("")
           expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
           expect(root.node.count).to eq(5)
+        end
+      end
+    end
+
+    describe "#filter_areas_values" do
+      let(:root) { helper.filter_areas_values }
+
+      context "when the organization does not have areas" do
+        it "does not return any area" do
+          expect(root).to be_nil
+        end
+      end
+
+      context "when the organization has areas" do
+        let!(:areas) { create_list(:area, 2, organization:) }
+        let(:participatory_space) { create(:participatory_process, organization:) }
+        let(:root) { helper.filter_areas_values }
+        let(:leaf) { helper.filter_areas_values.leaf }
+        let(:nodes) { helper.filter_areas_values.node }
+
+        it "returns all the areas" do
+          expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
+          expect(leaf.value).to eq("")
+          expect(leaf.label).to eq("All")
+          expect(nodes.count).to eq(2)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: Description

This PR prevents area's filter from being displayed if there is no area on the organization.

#### Testing
1. As an admin, go in the BO to settings > Areas and delete all the areas created
2. In the FO, go to the index of processes or assemblies, and see that the area's filter is not displayed
3. In the BO, create a new Area
4. Go back in the FO to the index of processes or assemblies, and see that the area's filter is now displayed

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=130709686&issue=OpenSourcePolitics%7Cintern-tasks%7C124

#### Tasks
- [X] Add specs