### PR TITLE
Fix: add extends to fix error on accountability comment report

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,8 @@ module DecidimApp
       require "extends/cells/decidim/comments/comment_metadata_cell_extends"
       require "extends/cells/decidim/proposals/proposal_metadata_cell_extends"
       require "extends/cells/decidim/user_activity_cell_extends"
+      # models
+      require "extends/models/decidim/accountability/result_extends"
     end
 
     config.to_prepare do

--- a/lib/extends/models/decidim/accountability/result_extends.rb
+++ b/lib/extends/models/decidim/accountability/result_extends.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ResultExtends
+  extend ActiveSupport::Concern
+  included do
+    include Decidim::Reportable
+  end
+end
+
+Decidim::Accountability::Result.include(ResultExtends)


### PR DESCRIPTION
#### :tophat: Description
This PR adds, via an extends, the module Reportable to the result model, to prevent a 500 error when reporting a comment on an accountability result.

#### Testing

1. As a user, go to the accountability of a process, go to a result with comment sand report one comment.
2. See that you stay on the same page, and that a flash message is displayed to let you know the report has been created (screenshot one)
3. As an admin, go to the global moderation, on the created report, click on the Visit url (screenshot two) and see that you are redirected on the accountability result page where the reported comment is displayed. 

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=129203267&issue=OpenSourcePolitics%7Cdecidim-app%7C881

#### :camera: Screenshots
**ONE**
<img width="1246" height="598" alt="Capture d’écran 2025-10-06 à 11 54 56" src="https://github.com/user-attachments/assets/899e2c8a-bbc6-4af3-ba0d-484d076d6e78" />

**TWO**
<img width="1506" height="372" alt="Capture d’écran 2025-10-06 à 11 56 59" src="https://github.com/user-attachments/assets/a03de140-9977-4cfa-ad27-19a2142cd76e" />


