### PR TITLE
add constrain for graphql-ws dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "postcss-scss": "^4.0.9",
     "sass-embedded": "^1.89.2"
   },
+  "resolutions": {
+    "graphql-ws": "<6.0.0"
+  },
   "browserslist": [
     "extends @decidim/browserslist-config"
   ]


### PR DESCRIPTION
#### :tophat: Description

This pull request add a constraint to the `graphql-ws` dependency. Without it, the app can't be install.
This change is needed since graphql-ws version 6.0.0 was released, 9 months ago.

Version 6.0 and above now requires node engine version superior to 20, which is not the case in this repo.
With this change, I was able to install the app, and I checked that the version matched with other member of the team.

#### Testing

N/A

I don't know if the file is used by docker, maybe I should check that ?

#### :pushpin: Related Issues

Fixes #898 

#### Tasks
N/A

#### :camera: Screenshots
N/A
#### Extra information