### PR TITLE
Fix English date format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
         copy_landing_page_blocks: Copy landing page blocks
   date:
     formats:
-      order: "d-m-y"
+      order: d-m-y
   decidim:
     account:
       omniauth_synced_profile:


### PR DESCRIPTION
#### :tophat: Description

This is a really straightforward fix for the date format.

The docs on localization changed pretty recently, you can see them here: https://docs.decidim.org/en/develop/customize/localization.html

It is explained that the only 2 options for date format are "d-m-y" and "m-d-y".
The date format for English was wrong, which caused issues.

If necessary, we can use these settings for display:
```
  date:
    formats:
      decidim_short: "%d/%m/%Y"
      decidim_short_dashed: "%d-%m-%Y"
      decidim_short_with_month_name_short: "%d %b %Y"
      decidim_with_day_and_month_name: "%A %d %b %Y"
      decidim_with_month_name: "%d %B %Y"
      decidim_with_month_name_short: "%d %b"
      help:
        date_format: 'Format: dd/mm/yyyy'
      order: d-m-y
      separator: "/"
```

But for the form, the only 2 possible values are "d-m-y" and "m-d-y"

#### Testing

Like in the linked issue:

* Log in as admin
* Access Backoffice
* Create an assembly
* use the widget to select the start date of 25th December 2025
* see it is now in the correct order

#### :pushpin: Related Issues

- Fixes #906 

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

#### :camera: Screenshots

<img width="997" height="587" alt="Capture d’écran 2025-10-14 à 11 33 43" src="https://github.com/user-attachments/assets/f44e7251-2ff3-4752-a4d5-12fa10db13d7" />

#### Extra information