### PR TITLE
Fix add translation key for budgets_booth

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,3 +141,4 @@ ignore_unused:
   - decidim.devise.shared.links.log_in_with_user
   - decidim.authorization_handlers.data_authorization_handler.(explanation|name)
   - decidim.system.organizations.omniauth_settings.cultuur_connect.*
+  - layouts.decidim.budgets.voting_menubar.cancel_voting

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,9 @@ en:
             osp_authorization_workflow: Verify with the identity verification form
   layouts:
     decidim:
+      budgets:
+        voting_menubar:
+          cancel_voting: Exit voting booth
       footer:
         help: Help
   time:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -253,6 +253,9 @@ fr:
             osp_authorization_workflow: Vérifier avec le formulaire de vérification de l'identité
   layouts:
     decidim:
+      budgets:
+        voting_menubar:
+          cancel_voting: Sortir de la cabine de vote
       footer:
         help: Aide
   time:


### PR DESCRIPTION
#### :tophat: Description
This PR adds the translation keys for "Exit voting booth", so that it can be customized with term custo.

#### Testing

1. As an admin, go to Term csutomizer and add a new translation for this key layouts.decidim.budgets.voting_menubar.cancel_voting (screenshot one)
2. As a user, in the FO, go to a process > budgets > vote, and see that your translation is displayed instead of "Exit voting booth" (screenshot two)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=131837921&issue=OpenSourcePolitics%7Cintern-tasks%7C141


#### :camera: Screenshots
ONE
<img width="1411" height="384" alt="Capture d’écran 2025-10-27 à 16 36 46" src="https://github.com/user-attachments/assets/c240e349-9257-47ce-a7e4-4f191d5a7307" />

TWO
<img width="853" height="392" alt="Capture d’écran 2025-10-27 à 16 36 54" src="https://github.com/user-attachments/assets/c548d88f-54ae-46f8-b3ec-a3411903f53a" />


