### PR TITLE
Fix: override markers.js to fix error

### DIFF
--- a/app/packs/src/decidim/map/controller/markers.js
+++ b/app/packs/src/decidim/map/controller/markers.js
@@ -1,0 +1,78 @@
+import "src/decidim/vendor/jquery-tmpl"
+import MapController from "src/decidim/map/controller"
+import "leaflet.markercluster";
+
+// TODO remove this file when PR https://github.com/decidim/decidim/pull/15463 will be present in 0.29
+
+export default class MapMarkersController extends MapController {
+    start() {
+        this.markerClusters = null;
+
+        if (Array.isArray(this.config.markers) && this.config.markers.length > 0) {
+            this.addMarkers(this.config.markers);
+        } else {
+            this.map.fitWorld();
+        }
+    }
+
+    addMarkers(markersData) {
+        if (this.markerClusters === null) {
+            this.markerClusters = new L.MarkerClusterGroup();
+            this.map.addLayer(this.markerClusters);
+        }
+
+        // Pre-compiles the template
+        $.template(
+            this.config.popupTemplateId,
+            $(`#${this.config.popupTemplateId}`).html()
+        );
+
+        const bounds = new L.LatLngBounds(
+            markersData.map(
+                (markerData) => [markerData.latitude, markerData.longitude]
+            )
+        );
+
+        markersData.forEach((markerData) => {
+            let marker = new L.Marker([markerData.latitude, markerData.longitude], {
+                icon: this.createIcon(),
+                keyboard: true,
+                title: markerData.title
+            });
+
+            let node = document.createElement("div");
+
+            $.tmpl(this.config.popupTemplateId, markerData).appendTo(node);
+            marker.bindPopup(node, {
+                // The popup width is equal to 80% of the map width
+                maxWidth: this.map.getSize().x * 0.8,
+                keepInView: true,
+                closeButton: false
+            }).openPopup();
+
+            this.markerClusters.addLayer(marker);
+        });
+
+        // Make sure there is enough space in the map for the padding to be
+        // applied. Otherwise the map will automatically zoom out (test it on
+        // mobile). Make sure there is at least the same amount of width and
+        // height available on both sides + the padding (i.e. 4x padding in
+        // total).
+        const size = this.map.getSize();
+        if (size.y >= 400 && size.x >= 400) {
+            this.map.fitBounds(bounds, { padding: [100, 100] });
+        } else if (size.y >= 120 && size.x >= 120) {
+            this.map.fitBounds(bounds, { padding: [30, 30] });
+        } else {
+            this.map.fitBounds(bounds);
+        }
+    }
+
+    clearMarkers() {
+        if (this.markerClusters !== null){
+            this.map.removeLayer(this.markerClusters);
+        }
+        this.markerClusters = new L.MarkerClusterGroup();
+        this.map.addLayer(this.markerClusters);
+    }
+}


### PR DESCRIPTION
#### :tophat: Description
This PR fixes a js error when on /meeting page, and there is no upcoming meetings, and you select "All" in the date filters, the markers were not displayed on the map, until you refresh the page. 
The update is on line 72 of markers.js file (condition added).

#### Testing

1. As an admin, ensure that there is no upcoming meetings
2. Go in the FO to /meetings and see that there is no upcoming meetings
3. Select "All" in the Date filter, and see that the meeting's markers are displayed on the map

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=134576491&issue=OpenSourcePolitics%7Cintern-tasks%7C195
