### PR TITLE
fix: update default partial to display custom publik translation

### DIFF
--- a/app/views/decidim/devise/shared/omniauth_buttons/_default.html.erb
+++ b/app/views/decidim/devise/shared/omniauth_buttons/_default.html.erb
@@ -1,6 +1,7 @@
 <% link_classes = "login__omniauth-button button--#{normalize_provider_name(provider)}" %>
 <% display_name = current_organization.enabled_omniauth_providers.dig(provider.to_sym, :display_name) %>
 <% provider_name = display_name.present? ? display_name : normalize_provider_name(provider).titleize %>
+<% provider_name = I18n.t("decidim.devise.shared.links.log_in_with_provider") if custom_publik_translation?(provider) %>
 <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: link_classes, method: :post, title: t("devise.shared.links.log_in_with_provider", provider: provider_name) do %>
   <%= oauth_icon provider %>
   <span>

--- a/lib/extends/helpers/decidim/omniauth_helper_extends.rb
+++ b/lib/extends/helpers/decidim/omniauth_helper_extends.rb
@@ -24,9 +24,7 @@ module OmniauthHelperExtends
   def normalize_provider_name(provider)
     return "x" if provider == :twitter
     # customize the name of the omniauth btn login with publik
-    if custom_publik_translation?(provider)
-      return I18n.t("decidim.devise.shared.links.log_in_with_provider")
-    end
+    return I18n.t("decidim.devise.shared.links.log_in_with_provider") if custom_publik_translation?(provider)
 
     provider.to_s.split("_").first
   end

--- a/lib/extends/helpers/decidim/omniauth_helper_extends.rb
+++ b/lib/extends/helpers/decidim/omniauth_helper_extends.rb
@@ -24,11 +24,15 @@ module OmniauthHelperExtends
   def normalize_provider_name(provider)
     return "x" if provider == :twitter
     # customize the name of the omniauth btn login with publik
-    if provider == :publik && Decidim::TermCustomizer::Translation.where(key: "decidim.devise.shared.links.log_in_with_provider").present?
+    if custom_publik_translation?(provider)
       return I18n.t("decidim.devise.shared.links.log_in_with_provider")
     end
 
     provider.to_s.split("_").first
+  end
+
+  def custom_publik_translation?(provider)
+    provider == :publik && Decidim::TermCustomizer::Translation.where(key: "decidim.devise.shared.links.log_in_with_provider").present?
   end
 end
 


### PR DESCRIPTION
#### :tophat: Description
This PR updates the default partial so that it takes into account the custom translation of Publik name via term customizer.

#### Testing

1. As an admin, go to term customizer, and add a custom translation for key `decidim.devise.shared.links.log_in_with_provider` (screenshot one)
2. As a system admin, go to /system, and add settings for Publik (you can copy the settings of https://staging-jeparticipe.k8s.osp.cat/ for instance)
3. As a non logged in user, go to "Log in" page and check that the custom translation is applied for the publik button (cf screenshot two)
4. As a non logged in user, go to a process > meetings > try to register to a meeting and see in the modal that the custom translation is applied for the publik button (cf screenshot three)

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=150682712&issue=OpenSourcePolitics%7Cintern-tasks%7C332
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=116529871&issue=OpenSourcePolitics%7Cdecidim-app%7C819


#### :camera: Screenshots
**ONE**
<img width="1205" height="269" alt="Capture d’écran 2026-02-12 à 15 25 02" src="https://github.com/user-attachments/assets/160014da-f4e6-4666-a20d-a631111dbdcd" />

**TWO**
<img width="741" height="644" alt="Capture d’écran 2026-02-12 à 15 28 21" src="https://github.com/user-attachments/assets/8b59fee2-c3f9-419b-ab2c-956cfce115b9" />

**THREE**
<img width="1164" height="924" alt="Capture d’écran 2026-02-12 à 15 30 25" src="https://github.com/user-attachments/assets/6761e579-3b93-4a8b-9541-bd525ccedafc" />


