### PR TITLE
fix: Unescape HTML entities in component index checkbox tree

### DIFF
--- a/app/overrides/decidim/shared/filters/_dropdown_label/unescape_check_box_label.html.erb.deface
+++ b/app/overrides/decidim/shared/filters/_dropdown_label/unescape_check_box_label.html.erb.deface
@@ -1,0 +1,1 @@
+<!-- replace "erb[loud]:contains('filter_text_for(leaf.label')" --><%= filter_text_for(CGI.unescapeHTML(leaf.label), id: "dropdown-title-#{data_checkboxes_tree_id}") %>

--- a/spec/system/explore_projects_index_spec.rb
+++ b/spec/system/explore_projects_index_spec.rb
@@ -98,7 +98,7 @@ describe "Explore projects", :slow do
         visit_budget
 
         within "#panel-dropdown-menu-category" do
-          click_filter_item decidim_escape_translated(category.name)
+          click_filter_item translated(category.name)
         end
 
         within "#projects" do


### PR DESCRIPTION
#### :tophat: Description
When creating a category name with special characters (like `"` or `'`), the checkbox filter in the component index on the front end are labeled escape HTML entities (like `&quot;`). 

<img width="749" height="748" alt="image" src="https://github.com/user-attachments/assets/3adb5af2-8a12-49ae-85e2-9b25ea08db65" />


see example [here](https://develop.decidim-app.k8s.osp.cat/processes/test-a/f/627/proposals) (admin sign in needed)

This fix add a deface override on the checkbox tree shared template to unescape these entities.