### PR TITLE
fix: awesome private body registration

### DIFF
--- a/lib/extends/commands/decidim/proposals/create_proposal_extends.rb
+++ b/lib/extends/commands/decidim/proposals/create_proposal_extends.rb
@@ -31,6 +31,10 @@ module CreateProposalExtends
           proposal.longitude = form.longitude if form.longitude.present?
           proposal.add_coauthor(@current_user, user_group:)
           proposal.save!
+          # from decidim_awesome
+          # Update the proposal with the private body, to
+          # avoid tracebility on private fields.
+          proposal.update_private_body!(form.private_body) if form.private_body.present?
           @attached_to = proposal
           proposal
         end

--- a/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -157,6 +157,46 @@ module Decidim
             end
           end
 
+          context "with a private body" do
+            let(:form_params) do
+              {
+                title: "A reasonable proposal title",
+                body: "A reasonable proposal body",
+                user_group_id: user_group.try(:id),
+                private_body: "A valid private proposal body"
+              }
+            end
+            let(:proposal) { Decidim::Proposals::Proposal.last }
+
+            it "broadcasts :ok and creates a private_body" do
+              expect { command.call }.to broadcast(:ok)
+              expect(proposal.title["en"]).to eq("A reasonable proposal title")
+              expect(proposal.body["en"]).to eq("A reasonable proposal body")
+              expect(proposal.private_body).to eq("A valid private proposal body")
+              expect(proposal.extra_fields.private_body).to eq("A valid private proposal body")
+            end
+          end
+
+          context "with no private body" do
+            let(:form_params) do
+              {
+                title: "A reasonable proposal title",
+                body: "A reasonable proposal body",
+                user_group_id: user_group.try(:id),
+                private_body: nil
+              }
+            end
+            let(:proposal) { Decidim::Proposals::Proposal.last }
+
+            it "broadcasts :ok and creates a private_body" do
+              expect { command.call }.to broadcast(:ok)
+              expect(proposal.title["en"]).to eq("A reasonable proposal title")
+              expect(proposal.body["en"]).to eq("A reasonable proposal body")
+              expect(proposal.private_body).to be_nil
+              expect(proposal.extra_fields).to be_nil
+            end
+          end
+
           describe "the proposal limit excludes withdrawn proposals" do
             let(:component) do
               create(:proposal_component, settings: { "proposal_limit" => 1 })


### PR DESCRIPTION
#### :tophat: Description
This PR update the create_proposal extends to integrate the registration of the private_body from awesome. 

#### Testing

1. As an admin, in the BO, go to decidim awesome tab > Proposals custom fields > Private fields, add some fields (screenshot one)
2. As an admin, go to the proposal's process where you added the private fields, create a new proposal from the BO. Ensure it is well saved. Click en "Answer proposal" button and check that the private body is filled (screenshot two).
3. As a user in the FO, create a new proposal and publish it.
4. As an admin repeat step 2 for this proposal
5. As an admin, export the proposals and ensure the private fields are well filled.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=158789385&issue=OpenSourcePolitics%7Cintern-tasks%7C376

#### Tasks
- [X] Add specs

#### :camera: Screenshots
ONE
<img width="1297" height="814" alt="Capture d’écran 2026-02-24 à 15 45 12" src="https://github.com/user-attachments/assets/da1541da-b233-4c8d-a13a-6f13f036b823" />

TWO
<img width="1193" height="493" alt="Capture d’écran 2026-02-24 à 15 50 23" src="https://github.com/user-attachments/assets/68733b9b-144c-45eb-bc2a-c0b08eb260c3" />

THREE
<img width="812" height="851" alt="Capture d’écran 2026-02-24 à 15 53 05" src="https://github.com/user-attachments/assets/e77356d6-635d-4d1e-94df-5ac3856bf4ec" />
