### PR TITLE
feat: update translation for email key / DO_NOT_MERGE

### DIFF
--- a/app/cells/decidim/newsletter_templates/basic_only_text/show.erb
+++ b/app/cells/decidim/newsletter_templates/basic_only_text/show.erb
@@ -1,3 +1,9 @@
+<style>
+    .decidim-bar, th.decidim-bar, td.decidim-bar {
+        background-color: #FFFFFF !important;
+    }
+</style>
+
 <table class="main container">
   <tr>
     <td class="decidim-bar">

--- a/app/cells/decidim/newsletter_templates/image_text_cta/show.erb
+++ b/app/cells/decidim/newsletter_templates/image_text_cta/show.erb
@@ -3,6 +3,9 @@
       table.button table td {
           background: <%= organization_primary_color %> !important
       }
+      .decidim-bar, th.decidim-bar, td.decidim-bar {
+          background-color: #FFFFFF !important;
+      }
   </style>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,7 @@ en:
     events:
       proposals:
         author_confirmation_proposal_event:
-          email_intro: 'Your proposal " %{resource_title} " was successfully received and is now public. Thank you for participating ! You can view it here:'
+          email_intro: 'Your proposal " %{resource_title} " is live. Thank you for participating ! You can view it here:'
           email_outro: You received this notification because you are the author of the proposal. You can unfollow it by visiting the proposal page (" %{resource_title} ") and clicking on " Unfollow ".
           email_subject: Your proposal has been published!
           notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is now live.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -122,7 +122,7 @@ fr:
     events:
       proposals:
         author_confirmation_proposal_event:
-          email_intro: 'Votre proposition « %{resource_title} » a été reçue avec succès et est maintenant publique. Merci pour votre participation ! Vous pouvez la consulter ici :'
+          email_intro: 'Votre proposition « %{resource_title} » est en ligne. Merci pour votre participation ! Vous pouvez la consulter ici :'
           email_outro: Vous recevez cette notification car vous êtes l’auteur de la proposition. Vous pouvez vous désabonner en visitant la page de la proposition (« %{resource_title} ») et en cliquant sur « Ne plus suivre ».
           email_subject: Votre proposition a été publiée !
           notification_title: Votre proposition <a href="%{resource_path}">%{resource_title}</a> est maintenant en ligne.


### PR DESCRIPTION
#### :tophat: Description
This PR updates the translation key decidim.events.author_confirmation_proposal_event.email_intro with a specific text provided by the client.

This PR is not meant to be merged.

#### Testing

1. As a french logged in user, create a proposal and publish it.
2. Check that the text of the received email is the same as in screenshot.

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=162548216&issue=OpenSourcePolitics%7Cintern-tasks%7C383

#### :camera: Screenshots
<img width="625" height="433" alt="Capture d’écran 2026-03-11 à 09 27 58" src="https://github.com/user-attachments/assets/d96b1bdf-583d-403f-81e4-ae25270602e2" />

