### PR TITLE
Fix : full description on participatory space show page

### DIFF
--- a/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -1,0 +1,82 @@
+<h2 class="h2 decorator"><%= title_text %></h2>
+
+<% if short_description_text.present? %>
+  <div class="content-block__description editor-content">
+    <% if rich_text_processors? %>
+      <%= render_rich_text(resource, :short_description) %>
+    <% else %>
+      <%= short_description_text %>
+    <% end %>
+  </div>
+<% end %>
+
+<% if description_text.present? %>
+  <% should_truncate = strip_tags(description_text).length > 300 %>
+  <div class="content-block__description editor-content" <%= "data-controller='accordion'" if should_truncate %>>
+    <% if should_truncate %>
+      <% seed = SecureRandom.hex(4) %>
+      <div id="panel-view-more-<%= seed %>" class="editor-content">
+        <% if rich_text_processors? %>
+          <%= render_rich_text(resource, :description) %>
+        <% else %>
+          <%= description_text %>
+        <% end %>
+      </div>
+
+      <button class="button button__sm button__text-secondary mt-2" data-controls="panel-view-more-<%= seed %>" aria-expanded="false">
+        <span>
+          <%= t("view_more", scope: "layouts.decidim.announcements") %>
+        </span>
+        <%= icon "arrow-down-s-line" %>
+        <span>
+          <%= t("view_less", scope: "layouts.decidim.announcements") %>
+        </span>
+        <%= icon "arrow-up-s-line" %>
+      </button>
+    <% else %>
+      <% if rich_text_processors? %>
+        <%= render_rich_text(resource, :description) %>
+      <% else %>
+        <%= description_text %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
+<script>
+    // get the description visible when arriving on the show page of a participatory space
+    const button = document.querySelector('button[data-controls^="panel-view-more"]')
+    const divDescription = document.querySelector('div[id^="panel-view-more"]')
+
+    function showPanel() {
+        divDescription.setAttribute('aria-hidden', 'false')
+        divDescription.removeAttribute('inert')
+        button.setAttribute('aria-expanded', 'true')
+    }
+
+    function hidePanel() {
+        divDescription.setAttribute('aria-hidden', 'true')
+        divDescription.setAttribute('inert', 'true')
+        button.setAttribute('aria-expanded', 'false')
+    }
+    if (button) {
+        button.addEventListener('click', function () {
+            if (button.getAttribute('aria-expanded') === 'true') {
+                setTimeout(() => hidePanel(), 500)
+            } else {
+                setTimeout(() => showPanel(), 500)
+            }
+        })
+
+        button.addEventListener('keydown', function (e) {
+            // press space or enter
+            if (e.keyCode === 32 || e.keyCode === 13) {
+                e.preventDefault()
+                button.click()
+            }
+        })
+
+        document.addEventListener("DOMContentLoaded", function () {
+            setTimeout(() => showPanel(), 500)
+        })
+    }
+</script>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -107,6 +107,7 @@ ignore_missing:
   - decidim.accessibility.front_page_link
   - decidim.accessibility.logo
   - decidim.errors.not_found.back_home
+  - layouts.decidim.announcements.*
 
 # Consider these keys used:
 ignore_unused:

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -79,9 +79,10 @@ describe "Participatory Process show page" do
           end
 
           it "shows less or more description when clicking on button" do
+            sleep 5
             click_link_or_button "Show less"
             sleep 5
-            within ".content-block__description.editor-content[data-controller='accordion']" do
+            within "[data-content]" do
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               inert = page.find('div[id^="panel-view-more"]')["inert"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
@@ -89,6 +90,7 @@ describe "Participatory Process show page" do
               expect(inert).to eq("true")
               expect(aria_expanded).to eq("false")
             end
+            sleep 5
             click_link_or_button "More information"
             sleep 5
             within "[data-content]" do

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -80,8 +80,8 @@ describe "Participatory Process show page" do
 
           it "shows less or more description when clicking on button" do
             click_link_or_button "Show less"
-            sleep 2
-            within "[data-content]" do
+            sleep 5
+            within ".content-block__description.editor-content[data-controller='accordion']" do
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               inert = page.find('div[id^="panel-view-more"]')["inert"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
@@ -90,7 +90,7 @@ describe "Participatory Process show page" do
               expect(aria_expanded).to eq("false")
             end
             click_link_or_button "More information"
-            sleep 2
+            sleep 5
             within "[data-content]" do
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/has_contextual_help"
+
+describe "Participatory Process show page" do
+  let(:organization) { create(:organization) }
+  let(:hashtag) { true }
+  let(:base_description) { { en: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi. Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat. Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue. Praesent egestas leo in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue blandit sodales. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales hendrerit. Ut velit mauris, egestas sed, gravida nec, ornare ut, mi. Aenean ut orci vel massa suscipit pulvinar. Nulla sollicitudin. Fusce varius, ligula non tempus aliquam, nunc turpis ullamcorper nibh, in tempus sapien eros vitae ligula. Pellentesque rhoncus nunc et augue. Integer id felis. Curabitur aliquet pellentesque diam. Integer quis metus vitae elit lobortis egestas. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi vel erat non mauris convallis vehicula. Nulla et sapien. Integer tortor tellus, aliquam faucibus, convallis id, congue eu, quam. Mauris ullamcorper felis vitae erat. Proin feugiat, augue non elementum posuere, metus purus iaculis lectus, et tristique ligula justo vitae magna." } }
+  let(:short_description) { { en: "Short description", ca: "Descripció curta", es: "Descripción corta" } }
+
+  let(:base_process) do
+    create(
+      :participatory_process,
+      :active,
+      organization:,
+      description: base_description,
+      short_description:
+    )
+  end
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when going to the participatory process page" do
+    let!(:participatory_process) { base_process }
+    let!(:proposals_component) { create(:component, :published, participatory_space: participatory_process, manifest_name: :proposals) }
+    let!(:meetings_component) { create(:component, :unpublished, participatory_space: participatory_process, manifest_name: :meetings) }
+
+    before do
+      create_list(:proposal, 3, component: proposals_component)
+      allow(Decidim).to receive(:component_manifests).and_return([proposals_component.manifest, meetings_component.manifest])
+    end
+
+    describe "page title" do
+      it "has the participatory process title in the show page" do
+        visit decidim_participatory_processes.participatory_process_path(participatory_process)
+
+        expect(page).to have_title("#{translated(participatory_process.title)} - #{translated(organization.name)}")
+      end
+    end
+
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
+    end
+
+    context "when requesting the participatory process path" do
+      let(:blocks_manifests) { [] }
+
+      before do
+        blocks_manifests.each do |manifest_name|
+          create(:content_block, organization:, scope_name: :participatory_process_homepage, manifest_name:, scoped_resource_id: participatory_process.id)
+        end
+        visit decidim_participatory_processes.participatory_process_path(participatory_process)
+      end
+
+      context "when requesting the process path" do
+        context "when hero, main_data and phase and duration blocks are enabled" do
+          let(:blocks_manifests) { [:hero, :main_data, :extra_data, :metadata] }
+
+          it "shows the details of the given process" do
+            within "[data-content]" do
+              expect(page).to have_content("About this process")
+              expect(page).to have_content(translated(participatory_process.title, locale: :en))
+              expect(page).to have_content(translated(participatory_process.subtitle, locale: :en))
+              expect(page).to have_content(translated(participatory_process.description, locale: :en))
+              expect(page).to have_content(translated(participatory_process.short_description, locale: :en))
+              expect(page).to have_content(translated(participatory_process.meta_scope, locale: :en))
+              expect(page).to have_content(translated(participatory_process.developer_group, locale: :en))
+              expect(page).to have_content(translated(participatory_process.local_area, locale: :en))
+              expect(page).to have_content(translated(participatory_process.target, locale: :en))
+              expect(page).to have_content(translated(participatory_process.participatory_scope, locale: :en))
+              expect(page).to have_content(translated(participatory_process.participatory_structure, locale: :en))
+              expect(page).to have_content(I18n.l(participatory_process.start_date, format: :decidim_short_with_month_name_short))
+              expect(page).to have_content(I18n.l(participatory_process.end_date, format: :decidim_short_with_month_name_short))
+              expect(page).to have_content("Show less")
+            end
+          end
+
+          it "shows less or more description when clicking on button" do
+            click_link_or_button "Show less"
+            sleep 1
+            within "[data-content]" do
+              aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
+              inert = page.find('div[id^="panel-view-more"]')["inert"]
+              aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
+              expect(aria_hidden).to eq("true")
+              expect(inert).to eq("true")
+              expect(aria_expanded).to eq("false")
+            end
+            click_link_or_button "More information"
+            sleep 1
+            within "[data-content]" do
+              aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
+              aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
+              expect(aria_hidden).to eq("false")
+              expect(aria_expanded).to eq("true")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -80,7 +80,7 @@ describe "Participatory Process show page" do
 
           it "shows less or more description when clicking on button" do
             click_link_or_button "Show less"
-            sleep 1
+            sleep 2
             within "[data-content]" do
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               inert = page.find('div[id^="panel-view-more"]')["inert"]
@@ -90,7 +90,7 @@ describe "Participatory Process show page" do
               expect(aria_expanded).to eq("false")
             end
             click_link_or_button "More information"
-            sleep 1
+            sleep 2
             within "[data-content]" do
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]


### PR DESCRIPTION
🎩 Description
The aim of this PR is to have the description visible when arriving on the show page of a participatory space.

#### Testing

1. As an admin, go to a process or an assembly, and add a long description text (>300)
2. As a user in the FO go to the show page of this participatory space, and see that the description is fully visible (cf screenshot)
3. Click on the "show less" btn and see that the description is truncated.
4. Click on the "More information" btn and see that the description is fully visible

📌 Related Issues
Fixes https://github.com/OpenSourcePolitics/release-party-0.31/issues/33

#### Tasks
- [X] Add specs

#### :camera: Screenshots
<img width="1275" height="750" alt="Capture d’écran 2026-03-12 à 15 17 48" src="https://github.com/user-attachments/assets/d6ab6bfd-9d88-4832-9b66-c87384492273" />

