### PR TITLE
feat: Add collaborative_texts and elections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ ruby RUBY_VERSION
 DECIDIM_BRANCH = "release/0.31-stable"
 
 gem "decidim", github: "decidim/decidim", branch: DECIDIM_BRANCH
+gem "decidim-collaborative_texts", github: "decidim/decidim", branch: DECIDIM_BRANCH
 gem "decidim-conferences", github: "decidim/decidim", branch: DECIDIM_BRANCH
+gem "decidim-elections", github: "decidim/decidim", branch: DECIDIM_BRANCH
 gem "decidim-initiatives", github: "decidim/decidim", branch: DECIDIM_BRANCH
 gem "decidim-templates", github: "decidim/decidim", branch: DECIDIM_BRANCH
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GIT
     decidim-budgets (0.31.1)
       decidim-comments (= 0.31.1)
       decidim-core (= 0.31.1)
+    decidim-collaborative_texts (0.31.1)
+      decidim-core (= 0.31.1)
     decidim-comments (0.31.1)
       decidim-core (= 0.31.1)
       redcarpet (~> 3.5, >= 3.5.1)
@@ -165,6 +167,10 @@ GIT
       w3c_rspec_validators (~> 0.3.0)
       webmock (~> 3.18)
       wisper-rspec (~> 1.0)
+    decidim-elections (0.31.1)
+      decidim-admin (= 0.31.1)
+      decidim-core (= 0.31.1)
+      decidim-forms (= 0.31.1)
     decidim-forms (0.31.1)
       decidim-core (= 0.31.1)
     decidim-generators (0.31.1)
@@ -589,7 +595,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.1)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -652,7 +658,8 @@ GEM
     mime-types-data (3.2026.0203)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
     multi_xml (0.8.1)
@@ -776,7 +783,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     puma (6.6.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -1039,7 +1046,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     tilt (2.7.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     trailblazer-option (0.1.2)
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -1127,9 +1134,11 @@ DEPENDENCIES
   byebug (~> 11.0)
   dalli
   decidim!
+  decidim-collaborative_texts!
   decidim-conferences!
   decidim-decidim_awesome!
   decidim-dev!
+  decidim-elections!
   decidim-initiatives!
   decidim-templates!
   deface

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -165,3 +165,25 @@ ignore_unused:
   - layouts.decidim.admin.taxonomy_filters_selector.*
   - decidim.download_your_data.show.*
   - decidim.open_data.(help|index).*
+  # Addition of collaborative_texts & elections locales
+  - decidim.collaborative_texts.admin.documents.edit.*
+  - decidim.collaborative_texts.admin.documents.non_draft_options.*
+  - decidim.collaborative_texts.admin_log.suggestion.create
+  - decidim.collaborative_texts.document.*
+  - decidim.collaborative_texts.suggestion.*
+  - decidim.elections.actions.confirm_unpublish_election
+  - decidim.elections.admin.dashboard.calendar.*
+  - decidim.elections.admin.dashboard.main.*
+  - decidim.elections.admin.dashboard.publish_confirm
+  - decidim.elections.admin.dashboard.questions_table.*
+  - decidim.elections.admin.dashboard.results.*
+  - decidim.elections.admin.dashboard.title
+  - decidim.elections.admin.elections.dashboard.title
+  - decidim.elections.admin.elections.form.calendar_description
+  - decidim.elections.admin.elections.form.results_availability.after_end_help
+  - decidim.elections.admin.elections.form.results_availability.per_question_help
+  - decidim.elections.admin.elections.form.results_availability.real_time_help
+  - decidim.elections.admin.statuses.*
+  - decidim.elections.censuses.census_ready_html
+  - decidim.elections.censuses.census_size_html.*
+  - decidim.elections.status.scheduled

--- a/config/initializers/decidim_verifications.rb
+++ b/config/initializers/decidim_verifications.rb
@@ -9,7 +9,6 @@ Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workf
 
   workflow.options do |options|
     options.attribute :allowed_postal_codes, type: :string, default: "08001", required: false
-    options.attribute :allowed_scope_id, type: :scope, required: false
   end
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,38 @@ en:
         name: Identity Verification Form
       osp_authorization_workflow:
         name: Authorization procedure
+    collaborative_texts:
+      admin:
+        documents:
+          edit:
+            document_has_suggestions_html: <a href="%{url}">This document has suggestions</a> and cannot be edited directly. Please accept or reject the suggestions in order to generate a new draft version that can be edited.
+            draft: Draft version
+            version: Version %{version_number}, created on %{created_at} got %{suggestions_count} suggestions.
+          non_draft_options:
+            create_draft: Discard suggestions and create a new draft version
+            draft_help_html: A draft version is not public and can be edited by the admins. Remove the draft status to make this version public. <strong>Note that meanwhile the draft version is active, the participants will see the previous version and they will not be able to make suggestions.</strong>
+      admin_log:
+        suggestion:
+          create: "%{user_name} suggested changes to the %{resource_name} collaborative text in %{space_name}"
+      document:
+        consolidate:
+          confirm: This action will consolidate all accepted suggestions into a new version of the document. Non-accepted suggestions will be transferred to the new version for further review. This action will maintain the suggestions enabled status.
+          invalid: There was a problem consolidating the suggestions into the document (%{errors}).
+          new: Consolidate accepted suggestions
+        consolidate_counter: Consolidate will merge the %{applied} applied suggestions and move the %{pending} pending suggestions to the new version.
+        controls_label: Suggestion controls
+        draft_counter: Draft will merge the %{applied} applied suggestions and discard the %{pending} pending suggestions.
+        rollout:
+          confirm: This action will create a new draft version of the document and you will be redirected to the edit page for final refinements. The current version will remain public and suggestions will be disabled.
+          invalid: There was a problem creating a new version of the document (%{errors}).
+          new: Draft a new version
+        save: Suggest changes
+        status:
+          accepting_suggestions: To suggest changes, select or double-click on the text you want to edit, then click the 'Suggest changes' button.
+      suggestion:
+        add_html: <span class="type">Add:</span> <span class="text">%{text}</span>
+        remove_html: <span class="type">Remove:</span> <span class="text">%{text}</span>
+        replace_html: <span class="type">Replace:</span> <span class="text">%{text}</span>
     comments:
       comments:
         create:
@@ -304,6 +336,68 @@ en:
           body_2: These files are in CSV (Comma-Separated Values) format, which is a widely-used file format that can be opened and processed by a variety of software applications, including spreadsheet programs, text editors, and data analysis tools.
           title: What are these files?
         files_to_download: Files to download
+    elections:
+      actions:
+        confirm_unpublish_election: Are you sure you want to unpublish this election?
+      admin:
+        dashboard:
+          calendar:
+            end_at: 'End time:'
+            end_election: End election
+            manual_start: Manual
+            published_results_at: Results published at
+            start_at: 'Start time:'
+            start_election: Start election
+            title: Calendar
+          main:
+            labels:
+              calendar: Calendar
+              description: Description
+              image: Image gallery
+              results: Results availability
+              title: Title
+            title: Main
+          publish_confirm: Are you sure you want to publish this election?
+          questions_table:
+            answer: Answers
+            percentage: Percentage
+            total: Total
+            votes: Votes
+            votes_count:
+              one: 1 vote
+              other: "%{count} votes"
+          results:
+            not_started: Election has not started yet.
+            publish_button: Publish results
+            title: Results
+          title: Election status
+        elections:
+          dashboard:
+            title: Dashboard
+          form:
+            calendar_description: Check that the organization time zone is correct in the organization settings. The current configuration is %{timezone}.
+            results_availability:
+              after_end_help: publish results when the election is finished
+              per_question_help: manually handle voting and publish results for each question
+              real_time_help: automatically publish results during the election while voting
+        statuses:
+          enable_voting:
+            invalid: There was a problem enabling voting.
+            success: Voting enabled successfully.
+          end:
+            invalid: There was a problem ending the election.
+            success: Election ended successfully.
+          start:
+            invalid: There was a problem starting the election.
+            success: Election started successfully.
+          unknown: Unknown status
+      censuses:
+        census_ready_html: The census data is uploaded and prepared for its use in the <b>%{election_title}</b> election.
+        census_size_html:
+          one: There is currently <strong>1</strong> person eligible for voting in this election (this might change on a dynamic census).
+          other: There are currently <strong>%{count}</strong> people eligible for voting in this election (this might change on a dynamic census).
+      status:
+        scheduled: Scheduled
     events:
       proposals:
         author_confirmation_proposal_event:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -246,6 +246,38 @@ fr:
         name: Formulaire de vérification d'identité
       osp_authorization_workflow:
         name: Procédure d'autorisation
+    collaborative_texts:
+      admin:
+        documents:
+          edit:
+            document_has_suggestions_html: <a href="%{url}">Ce texte a des suggestions</a> et ne peut pas être édité directement. Veuillez accepter ou rejeter les suggestions afin de générer une nouvelle version brouillon qui peut être éditée.
+            draft: Version brouillon
+            version: Version %{version_number}, créée le %{created_at} a reçu %{suggestions_count} suggestions.
+          non_draft_options:
+            create_draft: Enlever les suggestions et créer une nouvelle version brouillon
+            draft_help_html: Une version brouillon n'est pas publique et peut être éditée par les administrateurs. Enlever le statut de brouillon pour rendre cette version publique. <strong>Notez que tant que la version brouillon est active, les participants verront la version précédente et ne pourront pas faire de suggestions.</strong>
+      admin_log:
+        suggestion:
+          create: "%{user_name} a suggéré des modifications au texte collaboratif %{resource_name} dans %{space_name}"
+      document:
+        consolidate:
+          confirm: Cette action appliquera toutes les suggestions acceptées dans une nouvelle version du document. Les suggestions non acceptées seront transférées à la nouvelle version pour un examen plus approfondi. Cette action maintiendra le statut des suggestions activé.
+          invalid: Il y a eu un problème lors de l'application des suggestions au document (%{errors}).
+          new: Appliquer les suggestions acceptées
+        consolidate_counter: La consolidation fusionnera les %{applied} suggestions acceptées et déplacera les %{pending} suggestions en attente vers la nouvelle version.
+        controls_label: Contrôles de suggestion
+        draft_counter: Le brouillon va fusionner les %{applied} suggestions acceptées et supprimer les %{pending} suggestions en attente.
+        rollout:
+          confirm: Cette action créera une nouvelle version brouillon du document et vous serez redirigé vers la page d'édition pour les ajustements finaux. La version actuelle restera publique et les suggestions seront désactivées.
+          invalid: Il y a eu un problème lors de la création d'une nouvelle version du document (%{errors}).
+          new: Brouillon d'une nouvelle version
+        save: Suggérer des modifications
+        status:
+          accepting_suggestions: Pour suggérer des modifications, sélectionnez ou double-cliquez sur le texte que vous souhaitez modifier, puis cliquez sur le bouton « Suggérer des modifications ».
+      suggestion:
+        add_html: <span class="type">Add:</span> <span class="text">%{text}</span>
+        remove_html: <span class="type">Remove:</span> <span class="text">%{text}</span>
+        replace_html: <span class="type">Replace:</span> <span class="text">%{text}</span>
     comments:
       comments:
         create:
@@ -312,6 +344,68 @@ fr:
           body_2: Ces fichiers sont au format CSV (valeurs séparées par des virgules), un format de fichier largement utilisé qui peut être ouvert et traité par diverses applications logicielles, notamment des tableurs, des éditeurs de texte et des outils d'analyse de données.
           title: Que sont ces fichiers ?
         files_to_download: Fichiers à télécharger
+    elections:
+      actions:
+        confirm_unpublish_election: Êtes-vous sûr de vouloir dépublier cette élection ?
+      admin:
+        dashboard:
+          calendar:
+            end_at: 'Heure de fin:'
+            end_election: Terminer l'élection
+            manual_start: Démarrer manuellement
+            published_results_at: Résultats publiés à
+            start_at: 'Heure de début:'
+            start_election: Démarrer l'élection
+            title: Calendrier
+          main:
+            labels:
+              calendar: Calendrier
+              description: Description
+              image: Galerie d'image
+              results: Disponibilité des résultats
+              title: Titre
+            title: Principal
+          publish_confirm: Êtes-vous sûr(e) de vouloir publier cette élection ?
+          questions_table:
+            answer: Réponses
+            percentage: Pourcentage
+            total: Total
+            votes: Votes
+            votes_count:
+              one: 1 vote
+              other: "%{count} votes"
+          results:
+            not_started: L'élection n'a pas encore commencé.
+            publish_button: Publier les résultats
+            title: Résultats
+          title: Statut de l'élection
+        elections:
+          dashboard:
+            title: Tableau de bord
+          form:
+            calendar_description: Vérifiez que le fuseau horaire de l'organisation est correct dans les paramètres de l'organisation. La configuration actuelle est %{timezone}.
+            results_availability:
+              after_end_help: publier les résultats lorsque l'élection est terminée
+              per_question_help: gérer manuellement le vote et publier les résultats pour chaque question
+              real_time_help: publier automatiquement les résultats pendant l'élection pendant le vote
+        statuses:
+          enable_voting:
+            invalid: Il y a eu un problème lors de l'activation du vote.
+            success: Le vote a été activé avec succès.
+          end:
+            invalid: Il y a eu un problème lors de la fin de l'élection.
+            success: L'élection s'est terminée avec succès.
+          start:
+            invalid: Il y a eu un problème lors du démarrage de l'élection.
+            success: L'élection a démarré avec succès.
+          unknown: Statut de l'élection inconnu.
+      censuses:
+        census_ready_html: Les données du recensement sont téléchargées et préparées pour leur utilisation dans l'élection <b>%{election_title}</b>.
+        census_size_html:
+          one: Il y a actuellement <strong>1</strong> personne éligible pour voter dans cette élection (ce nombre peut changer dans un recensement dynamique).
+          other: Il y a actuellement <strong>%{count}</strong> personnes éligibles pour voter dans cette élection (ce nombre peut changer dans un recensement dynamique).
+      status:
+        scheduled: Programmé
     events:
       proposals:
         author_confirmation_proposal_event:

--- a/db/migrate/20260311103831_create_decidim_elections_elections.decidim_elections.rb
+++ b/db/migrate/20260311103831_create_decidim_elections_elections.decidim_elections.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250422110900)
+class CreateDecidimElectionsElections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_elections_elections do |t|
+      t.integer :decidim_component_id
+      t.jsonb :title
+      t.jsonb :description
+      t.jsonb :announcement
+      t.timestamp :start_at, index: true
+      t.timestamp :end_at, index: true
+      t.string :results_availability, default: "after_end", null: false
+      t.integer :census_type, default: 0, null: false
+      t.timestamp :published_at, index: true
+      t.datetime :deleted_at, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103832_create_decidim_elections_questions_and_response_options.decidim_elections.rb
+++ b/db/migrate/20260311103832_create_decidim_elections_questions_and_response_options.decidim_elections.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250513090151)
+class CreateDecidimElectionsQuestionsAndResponseOptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_elections_questions do |t|
+      t.references :election, null: false, foreign_key: { to_table: :decidim_elections_elections }, index: { name: "index_questions_on_election_id" }
+
+      t.jsonb :body, null: false, default: {}
+      t.jsonb :description, default: {}
+      t.boolean :mandatory, default: false, null: false
+      t.string :question_type, null: false, default: "multiple_option"
+      t.integer :position
+
+      t.timestamps
+    end
+
+    create_table :decidim_elections_response_options do |t|
+      t.references :question, null: false, foreign_key: { to_table: :decidim_elections_questions }, index: { name: "index_response_options_on_question_id" }
+
+      t.jsonb :body, null: false, default: {}
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103833_add_census_fields_to_decidim_elections_elections.decidim_elections.rb
+++ b/db/migrate/20260311103833_add_census_fields_to_decidim_elections_elections.decidim_elections.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250521101318)
+class AddCensusFieldsToDecidimElectionsElections < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :decidim_elections_elections, :census_type
+    add_column :decidim_elections_elections, :census_manifest, :string
+    add_column :decidim_elections_elections, :census_settings, :jsonb, default: {}, null: false
+
+    add_index :decidim_elections_elections, :census_manifest
+  end
+end

--- a/db/migrate/20260311103834_create_decidim_elections_voters.decidim_elections.rb
+++ b/db/migrate/20260311103834_create_decidim_elections_voters.decidim_elections.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250523100636)
+class CreateDecidimElectionsVoters < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_elections_voters do |t|
+      t.references :election, null: false, foreign_key: { to_table: :decidim_elections_elections }
+      t.jsonb :data, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103835_add_published_fields_to_elections_and_questions.decidim_elections.rb
+++ b/db/migrate/20260311103835_add_published_fields_to_elections_and_questions.decidim_elections.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250616145355)
+class AddPublishedFieldsToElectionsAndQuestions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :decidim_elections_questions, :published_results_at, :datetime
+    add_column :decidim_elections_questions, :voting_enabled_at, :datetime
+    add_column :decidim_elections_elections, :published_results_at, :datetime
+  end
+end

--- a/db/migrate/20260311103836_create_decidim_elections_votes.decidim_elections.rb
+++ b/db/migrate/20260311103836_create_decidim_elections_votes.decidim_elections.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_elections (originally 20250703090427)
+class CreateDecidimElectionsVotes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :decidim_elections_votes do |t|
+      t.references :question, null: false, foreign_key: { to_table: :decidim_elections_questions }, index: true
+      t.references :response_option, null: false, foreign_key: { to_table: :decidim_elections_response_options }
+      t.string :voter_uid, null: false, index: true
+
+      t.timestamps
+
+      t.index [:question_id, :voter_uid, :response_option_id], unique: true, name: "index_elections_votes_on__voter_uid_and_response"
+    end
+
+    add_column :decidim_elections_response_options, :votes_count, :integer, default: 0, null: false
+    add_column :decidim_elections_questions, :votes_count, :integer, default: 0, null: false
+    add_column :decidim_elections_questions, :response_options_count, :integer, default: 0, null: false
+    add_column :decidim_elections_elections, :votes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260311103854_create_decidim_collaborative_texts_documents.decidim_collaborative_texts.rb
+++ b/db/migrate/20260311103854_create_decidim_collaborative_texts_documents.decidim_collaborative_texts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_collaborative_texts (originally 20250205215038)
+class CreateDecidimCollaborativeTextsDocuments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_collaborative_texts_documents do |t|
+      t.integer :decidim_component_id
+      t.string :title
+      t.jsonb :announcement
+      t.boolean :accepting_suggestions, null: false, default: false
+      t.timestamp :published_at, index: true
+      t.datetime :deleted_at, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103855_create_collaborative_texts_versions.decidim_collaborative_texts.rb
+++ b/db/migrate/20260311103855_create_collaborative_texts_versions.decidim_collaborative_texts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_collaborative_texts (originally 20250213113536)
+class CreateCollaborativeTextsVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_collaborative_texts_versions do |t|
+      t.references :document, null: false, index: true
+      t.string :body
+      t.boolean :draft, null: false, default: false
+      t.datetime :deleted_at, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103856_create_collaborative_texts_suggestions.decidim_collaborative_texts.rb
+++ b/db/migrate/20260311103856_create_collaborative_texts_suggestions.decidim_collaborative_texts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_collaborative_texts (originally 20250227204839)
+class CreateCollaborativeTextsSuggestions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_collaborative_texts_suggestions do |t|
+      t.references :document_version, null: false, index: { name: "index_collaborative_texts_suggestions_on_version_id" }
+      t.references :decidim_author, polymorphic: true, index: { name: "index_collaborative_texts_suggestions_on_author" }
+      t.jsonb :changeset, null: false, default: {}
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311103857_add_counter_caches_to_collaborative_texts_documents.decidim_collaborative_texts.rb
+++ b/db/migrate/20260311103857_add_counter_caches_to_collaborative_texts_documents.decidim_collaborative_texts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_collaborative_texts (originally 20250312140133)
+class AddCounterCachesToCollaborativeTextsDocuments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_collaborative_texts_documents, :coauthorships_count, :integer, null: false, default: 0
+    add_column :decidim_collaborative_texts_documents, :suggestions_count, :integer, null: false, default: 0
+    add_column :decidim_collaborative_texts_documents, :document_versions_count, :integer, null: false, default: 0
+
+    add_index :decidim_collaborative_texts_documents, :coauthorships_count, name: "idx_decidim_collaborative_texts_documents_coauthorships_count"
+    add_index :decidim_collaborative_texts_documents, :suggestions_count, name: "idx_decidim_collaborative_texts_documents_suggestions_count"
+    add_index :decidim_collaborative_texts_documents, :document_versions_count, name: "idx_decidim_collaborative_texts_documents_versions_count"
+  end
+end

--- a/db/migrate/20260311103858_add_counter_caches_to_collaborative_text_versions.decidim_collaborative_texts.rb
+++ b/db/migrate/20260311103858_add_counter_caches_to_collaborative_text_versions.decidim_collaborative_texts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_collaborative_texts (originally 20250408205231)
+class AddCounterCachesToCollaborativeTextVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_collaborative_texts_versions, :suggestions_count, :integer, null: false, default: 0
+    add_index :decidim_collaborative_texts_versions, :suggestions_count, name: "idx_decidim_collaborative_texts_versions_suggestions_count"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_20_102533) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_11_103858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
@@ -538,6 +538,50 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_20_102533) do
     t.index ["decidim_user_group_id"], name: "index_user_group_on_coauthorsihp"
   end
 
+  create_table "decidim_collaborative_texts_documents", force: :cascade do |t|
+    t.integer "decidim_component_id"
+    t.string "title"
+    t.jsonb "announcement"
+    t.boolean "accepting_suggestions", default: false, null: false
+    t.datetime "published_at", precision: nil
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "coauthorships_count", default: 0, null: false
+    t.integer "suggestions_count", default: 0, null: false
+    t.integer "document_versions_count", default: 0, null: false
+    t.index ["coauthorships_count"], name: "idx_decidim_collaborative_texts_documents_coauthorships_count"
+    t.index ["deleted_at"], name: "index_decidim_collaborative_texts_documents_on_deleted_at"
+    t.index ["document_versions_count"], name: "idx_decidim_collaborative_texts_documents_versions_count"
+    t.index ["published_at"], name: "index_decidim_collaborative_texts_documents_on_published_at"
+    t.index ["suggestions_count"], name: "idx_decidim_collaborative_texts_documents_suggestions_count"
+  end
+
+  create_table "decidim_collaborative_texts_suggestions", force: :cascade do |t|
+    t.bigint "document_version_id", null: false
+    t.string "decidim_author_type"
+    t.bigint "decidim_author_id"
+    t.jsonb "changeset", default: {}, null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_author_type", "decidim_author_id"], name: "index_collaborative_texts_suggestions_on_author"
+    t.index ["document_version_id"], name: "index_collaborative_texts_suggestions_on_version_id"
+  end
+
+  create_table "decidim_collaborative_texts_versions", force: :cascade do |t|
+    t.bigint "document_id", null: false
+    t.string "body"
+    t.boolean "draft", default: false, null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "suggestions_count", default: 0, null: false
+    t.index ["deleted_at"], name: "index_decidim_collaborative_texts_versions_on_deleted_at"
+    t.index ["document_id"], name: "index_decidim_collaborative_texts_versions_on_document_id"
+    t.index ["suggestions_count"], name: "idx_decidim_collaborative_texts_versions_suggestions_count"
+  end
+
   create_table "decidim_comments_comment_votes", id: :serial, force: :cascade do |t|
     t.integer "weight", null: false
     t.integer "decidim_comment_id", null: false
@@ -824,6 +868,74 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_20_102533) do
     t.datetime "updated_at", null: false
     t.index ["decidim_author_id"], name: "decidim_editor_images_author"
     t.index ["decidim_organization_id"], name: "decidim_editor_images_constraint_organization"
+  end
+
+  create_table "decidim_elections_elections", force: :cascade do |t|
+    t.integer "decidim_component_id"
+    t.jsonb "title"
+    t.jsonb "description"
+    t.jsonb "announcement"
+    t.datetime "start_at", precision: nil
+    t.datetime "end_at", precision: nil
+    t.string "results_availability", default: "after_end", null: false
+    t.datetime "published_at", precision: nil
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "census_manifest"
+    t.jsonb "census_settings", default: {}, null: false
+    t.datetime "published_results_at"
+    t.integer "votes_count", default: 0, null: false
+    t.index ["census_manifest"], name: "index_decidim_elections_elections_on_census_manifest"
+    t.index ["deleted_at"], name: "index_decidim_elections_elections_on_deleted_at"
+    t.index ["end_at"], name: "index_decidim_elections_elections_on_end_at"
+    t.index ["published_at"], name: "index_decidim_elections_elections_on_published_at"
+    t.index ["start_at"], name: "index_decidim_elections_elections_on_start_at"
+  end
+
+  create_table "decidim_elections_questions", force: :cascade do |t|
+    t.bigint "election_id", null: false
+    t.jsonb "body", default: {}, null: false
+    t.jsonb "description", default: {}
+    t.boolean "mandatory", default: false, null: false
+    t.string "question_type", default: "multiple_option", null: false
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "published_results_at"
+    t.datetime "voting_enabled_at"
+    t.integer "votes_count", default: 0, null: false
+    t.integer "response_options_count", default: 0, null: false
+    t.index ["election_id"], name: "index_questions_on_election_id"
+  end
+
+  create_table "decidim_elections_response_options", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.jsonb "body", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "votes_count", default: 0, null: false
+    t.index ["question_id"], name: "index_response_options_on_question_id"
+  end
+
+  create_table "decidim_elections_voters", force: :cascade do |t|
+    t.bigint "election_id", null: false
+    t.jsonb "data", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["election_id"], name: "index_decidim_elections_voters_on_election_id"
+  end
+
+  create_table "decidim_elections_votes", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.bigint "response_option_id", null: false
+    t.string "voter_uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id", "voter_uid", "response_option_id"], name: "index_elections_votes_on__voter_uid_and_response", unique: true
+    t.index ["question_id"], name: "index_decidim_elections_votes_on_question_id"
+    t.index ["response_option_id"], name: "index_decidim_elections_votes_on_response_option_id"
+    t.index ["voter_uid"], name: "index_decidim_elections_votes_on_voter_uid"
   end
 
   create_table "decidim_follows", force: :cascade do |t|
@@ -2346,6 +2458,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_20_102533) do
   add_foreign_key "decidim_debates_debates", "decidim_scopes"
   add_foreign_key "decidim_editor_images", "decidim_organizations"
   add_foreign_key "decidim_editor_images", "decidim_users", column: "decidim_author_id"
+  add_foreign_key "decidim_elections_questions", "decidim_elections_elections", column: "election_id"
+  add_foreign_key "decidim_elections_response_options", "decidim_elections_questions", column: "question_id"
+  add_foreign_key "decidim_elections_voters", "decidim_elections_elections", column: "election_id"
+  add_foreign_key "decidim_elections_votes", "decidim_elections_questions", column: "question_id"
+  add_foreign_key "decidim_elections_votes", "decidim_elections_response_options", column: "response_option_id"
   add_foreign_key "decidim_guest_meeting_registration_registration_requests", "decidim_meetings_meetings", column: "decidim_meetings_meetings_id"
   add_foreign_key "decidim_guest_meeting_registration_registration_requests", "decidim_organizations"
   add_foreign_key "decidim_guest_meeting_registration_settings", "decidim_organizations"


### PR DESCRIPTION
#### :tophat: Description

Addition of decidim_collaborative_texts and decidim_elections to decidim-app 0.31

#### Testing

### DECIDIM ELECTIONS 

- Connect as an administrator
- Go to back-office
- Go to a participatory process
- Go to "elections" or create a new component
- Create a new election or multiple elections with multiple settings
- Make sure you can create it easily without any error
- Open one or more elections
- Try to vote on them
- Make sure you can make the entire process of voting
- Try to close an election in the back-office

### DECIDIM COLLABORATIVE TEXTS 
- Connect as an administrator
- Go to back-office
- Access a participatory process
- Go to "Collaborative texts" or create a new component
- Create a new collaborative text with mutliple paragraphs to make sure you can edit each one of them independantly
- Publish it and **allow suggestions in the options** 
- Access front office with an other user account (ex : user@example.org)
- Try to submit some suggestions as a user
- Disconnect and log again as an administrator
- Make sure you can see each one of the suggestion you made as a user
- Try to accept some of them and ignore others
- Submit the changes and make sure the text is edited correctly and that suggestions you didn't accept were dropped

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=158409462&issue=OpenSourcePolitics%7Cintern-tasks%7C373

#### Tasks
- [x] Add missing locales
- [x] Add gems
- [x] Add db migrations
- [x] Update schema.rb