### PR TITLE
fix: Add colored_cards votes into proposals exports

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,8 @@ module DecidimApp
       require "extends/permissions/initiatives/permissions_extends"
       # presenters
       require "extends/presenters/decidim/forms/admin/questionnaire_answer_presenter_extends"
+      # serializers
+      require "extends/serializers/decidim/proposals/proposal_serializer_extends"
     end
 
     config.to_prepare do

--- a/lib/extends/serializers/decidim/proposals/proposal_serializer_extends.rb
+++ b/lib/extends/serializers/decidim/proposals/proposal_serializer_extends.rb
@@ -4,9 +4,9 @@ module Extends
   module Proposals
     module ProposalSerializerExtends
       WEIGHT_LABELS = {
-        "1" => :votes_green,
-        "2" => :votes_yellow,
-        "3" => :votes_red
+        "1" => :votes_red_disapproval,
+        "2" => :votes_yellow_neutral,
+        "3" => :votes_green_approval
       }.freeze
 
       def serialize

--- a/lib/extends/serializers/decidim/proposals/proposal_serializer_extends.rb
+++ b/lib/extends/serializers/decidim/proposals/proposal_serializer_extends.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Extends
+  module Proposals
+    module ProposalSerializerExtends
+      WEIGHT_LABELS = {
+        "1" => :votes_green,
+        "2" => :votes_yellow,
+        "3" => :votes_red
+      }.freeze
+
+      def serialize
+        inject_after(super, :votes, vote_weights_summary)
+      end
+
+      private
+
+      def inject_after(hash, after_key, extra)
+        hash.each_with_object({}) do |(k, v), result|
+          result[k] = v
+          result.merge!(extra) if k == after_key
+        end
+      end
+
+      def vote_weights_summary
+        return {} unless vote_weights_enabled?
+
+        extra_field = Decidim::DecidimAwesome::ProposalExtraField
+                      .find_by(decidim_proposal_id: proposal.id, decidim_proposal_type: proposal.class.name)
+
+        return {} unless extra_field&.vote_weight_totals
+
+        WEIGHT_LABELS.each_with_object({}) do |(weight, label), result|
+          result[label] = extra_field.vote_weight_totals[weight].to_i
+        end
+      end
+
+      def vote_weights_enabled?
+        proposal.component.settings.respond_to?(:awesome_voting_manifest) &&
+          proposal.component.settings.awesome_voting_manifest.present?
+      end
+    end
+  end
+end
+
+Decidim::Proposals::ProposalSerializer.prepend(
+  Extends::Proposals::ProposalSerializerExtends
+)

--- a/spec/serializers/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/serializers/decidim/proposals/proposal_serializer_spec.rb
@@ -254,21 +254,21 @@ module Decidim
           it "places vote weight columns immediately after votes" do
             keys = serialized.keys
             votes_index = keys.index(:votes)
-            expect(keys[votes_index + 1]).to eq(:votes_green)
-            expect(keys[votes_index + 2]).to eq(:votes_yellow)
-            expect(keys[votes_index + 3]).to eq(:votes_red)
+            expect(keys[votes_index + 1]).to eq(:votes_red_disapproval)
+            expect(keys[votes_index + 2]).to eq(:votes_yellow_neutral)
+            expect(keys[votes_index + 3]).to eq(:votes_green_approval)
           end
 
-          it "serializes votes_green_favorable count" do
-            expect(serialized).to include(votes_green: 1)
+          it "serializes votes_green_approval_favorable count" do
+            expect(serialized).to include(votes_green_approval: 1)
           end
 
-          it "serializes votes_yellow_neutral count" do
-            expect(serialized).to include(votes_yellow: 1)
+          it "serializes votes_yellow_neutral_neutral count" do
+            expect(serialized).to include(votes_yellow_neutral: 1)
           end
 
-          it "serializes votes_red_unfavorable count" do
-            expect(serialized).to include(votes_red: 1)
+          it "serializes votes_red_disapproval_unfavorable count" do
+            expect(serialized).to include(votes_red_disapproval: 1)
           end
 
           context "when proposal has no votes" do
@@ -279,9 +279,9 @@ module Decidim
 
             it "returns zero for all weight columns" do
               expect(serialized).to include(
-                votes_green: 0,
-                votes_yellow: 0,
-                votes_red: 0
+                votes_green_approval: 0,
+                votes_yellow_neutral: 0,
+                votes_red_disapproval: 0
               )
             end
           end
@@ -290,18 +290,18 @@ module Decidim
             before { extra_fields.destroy }
 
             it "does not include vote weight columns" do
-              expect(serialized).not_to have_key(:votes_green)
-              expect(serialized).not_to have_key(:votes_yellow)
-              expect(serialized).not_to have_key(:votes_red)
+              expect(serialized).not_to have_key(:votes_green_approval)
+              expect(serialized).not_to have_key(:votes_yellow_neutral)
+              expect(serialized).not_to have_key(:votes_red_disapproval)
             end
           end
         end
 
         context "when awesome_voting_manifest is not set" do
           it "does not include vote weight columns" do
-            expect(serialized).not_to have_key(:votes_green)
-            expect(serialized).not_to have_key(:votes_yellow)
-            expect(serialized).not_to have_key(:votes_red)
+            expect(serialized).not_to have_key(:votes_green_approval)
+            expect(serialized).not_to have_key(:votes_yellow_neutral)
+            expect(serialized).not_to have_key(:votes_red_disapproval)
           end
         end
 

--- a/spec/serializers/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/serializers/decidim/proposals/proposal_serializer_spec.rb
@@ -1,0 +1,473 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalSerializer do
+      subject do
+        described_class.new(proposal)
+      end
+
+      let!(:proposal) { create(:proposal, :accepted, body:) }
+      let!(:category) { create(:category, participatory_space: component.participatory_space) }
+      let!(:scope) { create(:scope, organization: component.participatory_space.organization) }
+      let(:participatory_process) { component.participatory_space }
+      let(:component) { proposal.component }
+
+      let!(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
+      let(:meetings) { create_list(:meeting, 2, :published, component: meetings_component) }
+
+      let!(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
+      let(:other_proposals) { create_list(:proposal, 2, component: proposals_component) }
+      let(:body) { Decidim::Faker::Localized.localized { ::Faker::Lorem.sentences(number: 3).join("\n") } }
+
+      let(:expected_answer) do
+        answer = proposal.answer
+        Decidim.available_locales.each_with_object({}) do |locale, result|
+          result[locale.to_s] = if answer.is_a?(Hash)
+                                  answer[locale.to_s] || ""
+                                else
+                                  ""
+                                end
+        end
+      end
+
+      before do
+        proposal.update!(category:)
+        proposal.update!(scope:)
+        proposal.link_resources(meetings, "proposals_from_meeting")
+        proposal.link_resources(other_proposals, "copied_from_component")
+      end
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "doesn't serialize author's data" do
+          expect(serialized).not_to include(:author)
+        end
+
+        it "serializes the id" do
+          expect(serialized).to include(id: proposal.id)
+        end
+
+        it "serializes the category" do
+          expect(serialized[:category]).to include(id: category.id)
+          expect(serialized[:category]).to include(name: category.name)
+        end
+
+        it "serializes the scope" do
+          expect(serialized[:scope]).to include(id: scope.id)
+          expect(serialized[:scope]).to include(name: scope.name)
+        end
+
+        it "serializes the title" do
+          expect(serialized).to include(title: proposal.title)
+        end
+
+        it "serializes the body" do
+          expect(serialized).to include(body: proposal.body)
+        end
+
+        it "serializes the address" do
+          expect(serialized).to include(address: proposal.address)
+        end
+
+        it "serializes the latitude" do
+          expect(serialized).to include(latitude: proposal.latitude)
+        end
+
+        it "serializes the longitude" do
+          expect(serialized).to include(longitude: proposal.longitude)
+        end
+
+        it "serializes the amount of votes" do
+          expect(serialized).to include(votes: proposal.proposal_votes_count)
+        end
+
+        it "serializes the amount of comments" do
+          expect(serialized).to include(comments: proposal.comments_count)
+        end
+
+        it "serializes the date of creation" do
+          expect(serialized).to include(published_at: proposal.published_at)
+        end
+
+        it "serializes the url" do
+          expect(serialized[:url]).to include("http", proposal.id.to_s)
+        end
+
+        it "serializes the component" do
+          expect(serialized[:component]).to include(id: proposal.component.id)
+        end
+
+        it "serializes the meetings" do
+          expect(serialized[:meeting_urls].length).to eq(2)
+          expect(serialized[:meeting_urls].first).to match(%r{http.*/meetings})
+        end
+
+        it "serializes the participatory space" do
+          expect(serialized[:participatory_space]).to include(id: participatory_process.id)
+          expect(serialized[:participatory_space][:url]).to include("http", participatory_process.slug)
+        end
+
+        it "serializes the state" do
+          expect(serialized).to include(state: proposal.state)
+        end
+
+        it "serializes the reference" do
+          expect(serialized).to include(reference: proposal.reference)
+        end
+
+        it "serializes the answer" do
+          expect(serialized).to include(answer: expected_answer)
+        end
+
+        it "serializes the date of the answer" do
+          expect(serialized).to include(answered_at: proposal.answered_at)
+        end
+
+        it "serializes withdrawn status" do
+          expect(serialized).to include(withdrawn: proposal.withdrawn?)
+        end
+
+        it "serializes withdrawn date" do
+          expect(serialized).to include(withdrawn_at: proposal.withdrawn_at)
+        end
+
+        it "serializes the amount of attachments" do
+          expect(serialized).to include(attachments: proposal.attachments.count)
+        end
+
+        it "serializes the endorsements" do
+          expect(serialized[:endorsements]).to include(total_count: proposal.endorsements.count)
+          expect(serialized[:endorsements]).to include(user_endorsements: proposal.endorsements.for_listing.map { |identity| identity.normalized_author&.name })
+        end
+
+        it "serializes related proposals" do
+          expect(serialized[:related_proposals].length).to eq(2)
+          expect(serialized[:related_proposals].first).to match(%r{http.*/proposals})
+        end
+
+        it "serializes if proposal is_amend" do
+          expect(serialized).to include(is_amend: proposal.emendation?)
+        end
+
+        it "serializes the original proposal" do
+          expect(serialized[:original_proposal]).to include(title: proposal&.amendable&.title)
+          expect(serialized[:original_proposal][:url]).to be_nil || include("http", proposal.id.to_s)
+        end
+
+        context "with proposal having an answer" do
+          let!(:proposal) { create(:proposal, :with_answer) }
+
+          it "serializes the answer" do
+            expect(serialized).to include(answer: expected_answer)
+          end
+        end
+
+        context "with rich text proposal body" do
+          let(:image) { "<img src=\"logo.png\" #{alt_attribute} width=\"407\">" }
+          let(:alt_attribute) { "alt=\"Logo alt attribute\"" }
+          let(:body_content) do
+            <<~TEXT
+              <h2>This is my "heading 2" title</h2>
+              <p>A "normal" description below Heading 2</p>
+              <p><br></p>
+              <h3>Now this is my "heading 3"</h3>
+              <p><br></p>
+              <ul>
+              <li>This is my first option</li>
+              <li>This is my second option</li>
+              <li>This is my third option</li>
+              </ul>
+              <p><br></p>
+              <p>And below an uploaded image</p>
+              <p>#{image}</p>
+              <p><br></p>
+              <p><code>Here is code block</code></p>
+            TEXT
+          end
+          let(:body) do
+            {
+              "en" => body_content,
+              "machine_translation" => {
+                "es" => body_content,
+                "ca" => body_content
+              }
+            }
+          end
+
+          it "serializes the body without HTML tags" do
+            expected_body = <<~TEXT.chomp
+              ----------------------------
+              This is my "heading 2" title
+              ----------------------------
+
+              A "normal" description below Heading 2
+
+              Now this is my "heading 3"
+              --------------------------
+
+              * This is my first option
+              * This is my second option
+              * This is my third option
+
+              And below an uploaded image
+
+              Logo alt attribute
+
+              Here is code block
+            TEXT
+
+            expect(serialized[:body]["en"]).to eq(expected_body)
+            expect(serialized[:body]["en"]).to include("Logo alt attribute")
+            expect(serialized[:body]["machine_translation"]["es"]).to eq(expected_body)
+            expect(serialized[:body]["machine_translation"]["es"]).to include("Logo alt attribute")
+            expect(serialized[:body]["machine_translation"]["ca"]).to eq(expected_body)
+            expect(serialized[:body]["machine_translation"]["ca"]).to include("Logo alt attribute")
+          end
+
+          context "and image is uploaded without 'alt' attribute" do
+            let(:alt_attribute) { "" }
+
+            it "serializes the body without image" do
+              expect(serialized[:body]["en"]).not_to include("Logo alt attribute")
+              expect(serialized[:body]["machine_translation"]["es"]).not_to include("Logo alt attribute")
+              expect(serialized[:body]["machine_translation"]["ca"]).not_to include("Logo alt attribute")
+            end
+          end
+        end
+
+        context "with voting cards enabled" do
+          let(:component) { create(:proposal_component, settings: { awesome_voting_manifest: :voting_cards }) }
+          let!(:proposal) { create(:proposal, :accepted, component:) }
+          let!(:extra_fields) { create(:awesome_proposal_extra_fields, proposal:) }
+
+          before do
+            [["1", :green], ["2", :yellow], ["3", :red]].each do |weight, _|
+              vote = create(:proposal_vote, proposal:, author: create(:user, organization: proposal.organization))
+              create(:awesome_vote_weight, vote:, weight:)
+            end
+          end
+
+          it "places vote weight columns immediately after votes" do
+            keys = serialized.keys
+            votes_index = keys.index(:votes)
+            expect(keys[votes_index + 1]).to eq(:votes_green)
+            expect(keys[votes_index + 2]).to eq(:votes_yellow)
+            expect(keys[votes_index + 3]).to eq(:votes_red)
+          end
+
+          it "serializes votes_green_favorable count" do
+            expect(serialized).to include(votes_green: 1)
+          end
+
+          it "serializes votes_yellow_neutral count" do
+            expect(serialized).to include(votes_yellow: 1)
+          end
+
+          it "serializes votes_red_unfavorable count" do
+            expect(serialized).to include(votes_red: 1)
+          end
+
+          context "when proposal has no votes" do
+            before do
+              proposal.votes.destroy_all
+              extra_fields.update!(vote_weight_totals: {})
+            end
+
+            it "returns zero for all weight columns" do
+              expect(serialized).to include(
+                votes_green: 0,
+                votes_yellow: 0,
+                votes_red: 0
+              )
+            end
+          end
+
+          context "when proposal has no extra fields record" do
+            before { extra_fields.destroy }
+
+            it "does not include vote weight columns" do
+              expect(serialized).not_to have_key(:votes_green)
+              expect(serialized).not_to have_key(:votes_yellow)
+              expect(serialized).not_to have_key(:votes_red)
+            end
+          end
+        end
+
+        context "when awesome_voting_manifest is not set" do
+          it "does not include vote weight columns" do
+            expect(serialized).not_to have_key(:votes_green)
+            expect(serialized).not_to have_key(:votes_yellow)
+            expect(serialized).not_to have_key(:votes_red)
+          end
+        end
+
+        context "when admin exports proposal" do
+          subject do
+            described_class.new(proposal, public_scope: false)
+          end
+
+          let(:serialized) { subject.serialize }
+
+          it "serializes author" do
+            expect(serialized).to include(:author)
+          end
+
+          context "and there is a phone authorization" do
+            let!(:authorization) do
+              create(
+                :authorization,
+                id: 1,
+                name: "phone_authorization_handler",
+                user: proposal.creator_author,
+                metadata: {
+                  phone_number: "0644444444"
+                }
+              )
+            end
+
+            it "data in author are not empty" do
+              expect(serialized[:author][:name]).not_to be_empty
+              expect(serialized[:author][:nickname]).not_to be_empty
+              expect(serialized[:author][:email]).not_to be_empty
+              expect(serialized[:author][:phone_number]).not_to be_empty
+              expect(serialized[:author][:url]).not_to be_empty
+            end
+          end
+
+          context "when it is an official proposal" do
+            let!(:proposal) { create(:proposal, :official) }
+
+            before do
+              component.participatory_space.organization.update!(name: { en: "My organization" })
+              proposal.reload
+            end
+
+            it "serializes the organization name" do
+              expect(serialized[:author]).to include(name: ["My organization"])
+            end
+
+            it "serializes the link to the organization" do
+              expect(serialized[:author]).to include(url: [root_url])
+            end
+          end
+
+          context "when it is a user" do
+            let!(:proposal) { create(:proposal, :participant_author) }
+            let!(:authorization) do
+              create(
+                :authorization,
+                id: 1,
+                name: "phone_authorization_handler",
+                user: proposal.creator_author,
+                metadata: {
+                  phone_number: "0644444444"
+                }
+              )
+            end
+
+            before do
+              proposal.creator_author.update!(name: "John Doe", nickname: "john_doe")
+              proposal.reload
+            end
+
+            it "serializes the user name" do
+              expect(serialized[:author]).to include(name: ["John Doe"])
+            end
+
+            it "serializes the user nickname" do
+              expect(serialized[:author]).to include(nickname: ["john_doe"])
+            end
+
+            it "serializes the user email" do
+              expect(serialized[:author]).to include(email: [proposal.creator_author.email.to_s])
+            end
+
+            it "serializes the phone number from authorization" do
+              expect(serialized[:author]).to include(phone_number: "0644444444")
+            end
+
+            it "serializes the link to its profile" do
+              expect(serialized[:author]).to include(url: [profile_url(proposal.creator_author.nickname)])
+            end
+          end
+
+          context "when it is multiple users" do
+            let!(:coauthorships) { create_list(:coauthorship, 3, coauthorable: proposal) }
+
+            it "serializes the user names" do
+              expect(serialized[:author]).to include(name: proposal.authors.map(&:name))
+            end
+
+            it "serializes the link to the profiles" do
+              urls = proposal.authors.map { |author| profile_url(author.nickname) }
+              expect(serialized[:author]).to include(url: urls)
+            end
+          end
+
+          context "when it is a meeting" do
+            let!(:proposal) { create(:proposal, :official_meeting) }
+
+            it "serializes the title of the meeting" do
+              title = proposal.authors.map { |author| translated_attribute(author.title) }
+              expect(serialized[:author]).to include(name: title)
+            end
+
+            it "serializes the link to the meeting" do
+              urls = proposal.authors.map { |meeting| meeting_url(meeting) }
+              expect(serialized[:author]).to include(url: urls)
+            end
+          end
+
+          context "when it is a user group" do
+            let!(:proposal) { create(:proposal, :user_group_author) }
+
+            before do
+              proposal.coauthorships.first.user_group.update!(name: "ACME", nickname: "acme")
+              proposal.reload
+            end
+
+            it "serializes author" do
+              expect(serialized).to include(:author)
+            end
+
+            it "serializes the user name of the user group" do
+              expect(serialized[:author]).to include(name: ["ACME"])
+            end
+
+            it "serializes the link to the profile of the user group" do
+              expect(serialized[:author]).to include(url: [profile_url("acme")])
+            end
+
+            it "serializes the nickname of the user group" do
+              expect(serialized[:author]).to include(nickname: ["acme"])
+            end
+
+            it "serializes the email of the user group" do
+              expect(serialized[:author]).to include(email: [proposal.coauthorships.first.user_group.email.to_s])
+            end
+          end
+        end
+      end
+
+      def profile_url(nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:)
+      end
+
+      def meeting_url(meeting)
+        Decidim::EngineRouter.main_proxy(meeting.component).meeting_url(id: meeting.id, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        proposal.organization.host
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description

We had an issue on the exports of proposals, the serializer was not including the distinct votes of the colored cards into the exports, so we couldn't see the granularity of the votes

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to participatory processes
* Create a new proposal component and add the colored cards and the simple vote module on the steps
* Create new proposals 
* Try to vote on some of them with different accounts
* Export your proposals in the back office
* Make sure you see the "votes" properly and each of the "votes_green / votes_yellow / votes_red" properly

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=164348741&issue=OpenSourcePolitics%7Cintern-tasks%7C388

#### Tasks
- [x] Extend serializers
- [x] Add specs