### PR TITLE
fix: avoid overlap of logo and login on mobile portrait

### DIFF
--- a/app/packs/src/decidim/global_adjustments.js
+++ b/app/packs/src/decidim/global_adjustments.js
@@ -42,3 +42,24 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }, { passive: true });
 });
+// on mobile portrait, when user is not signin, change the display of div.main-bar__menu-mobile
+// so that logo and signin link don't overlap
+document.addEventListener("DOMContentLoaded", function () {
+  const signIn = document.querySelector('.main-bar a[href^="/users/sign_in"]')
+  const menuBarMobile = document.querySelector('header .main-bar__menu-mobile');
+  const menuBarMobileLink = document.querySelector('header .main-bar__links-mobile__login')
+
+  if (window.innerWidth <= 600 && signIn && screen.orientation.type === "portrait-primary"){
+    menuBarMobile.style.flexDirection = "column-reverse";
+    if (menuBarMobileLink) menuBarMobileLink.style.marginBottom = "1rem";
+  }
+  screen.orientation.addEventListener("change", () => {
+    if (screen.orientation.type === "landscape-primary"){
+      menuBarMobile.style.flexDirection = "row-reverse";
+      if (menuBarMobileLink) menuBarMobileLink.style.marginBottom = "0rem";
+    }else {
+      menuBarMobile.style.flexDirection = "column-reverse";
+      if (menuBarMobileLink) menuBarMobileLink.style.marginBottom = "1rem";
+    }
+  });
+});


### PR DESCRIPTION
#### :tophat: Description
The aim of this PR is to avoid the overlap of logo and login link when on mobile portrait view.

#### Testing

1. As an admin, add the logo of Loire atlantique (cf logo screenshot) to the organization (settings > appearance)
2. Choose french language
3. Logout and switch for mobile portrait view in devtools. See that the "Se connecter" link and the menu burger are one above the other (screenshot one)
4. Switch for landscape view and see that the "Se connecter" link and the menu burger are on the same level (screenshot two)
5. Login and check in portrait and landscape that avatar and menu burger are on the same level.

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=167238118&issue=OpenSourcePolitics%7Crelease-party-0.31%7C42

#### :camera: Screenshots
**LOGO**
<img width="560" height="160" alt="Logo-LA-participer" src="https://github.com/user-attachments/assets/83dd0f6f-ae89-4816-8334-9e661b718574" />

**ONE**
<img width="726" height="477" alt="Capture d’écran 2026-03-20 à 11 00 07" src="https://github.com/user-attachments/assets/5230aeba-b6bb-4538-9d7c-030550dd1150" />

**TWO**
<img width="849" height="382" alt="Capture d’écran 2026-03-20 à 11 00 17" src="https://github.com/user-attachments/assets/ea2446b7-241d-4963-b9bd-6a1f9f8c0082" />

