### PR TITLE
fix: Surveys separators 0.31

### DIFF
--- a/app/packs/src/decidim/global_adjustments.js
+++ b/app/packs/src/decidim/global_adjustments.js
@@ -42,3 +42,39 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }, { passive: true });
 });
+
+// --- Fixes regarding the surveys --- //
+document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-toggle-toggle-value]");
+    if (!btn) return;
+
+    setTimeout(() => {
+      const target =
+        document.querySelector(".answer-questionnaire") ||
+        document.querySelector(".questionnaire") ||
+        document.querySelector("main");
+
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    }, 50);
+  });
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  const announcements = document.querySelectorAll(".flash[data-announcement]");
+  if (!announcements.length) return;
+
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-toggle-toggle-value]");
+    if (!btn) return;
+
+    const goingForward = btn.dataset.toggleToggleValue.startsWith("step-1");
+    announcements.forEach(a => a.classList.toggle("is-hidden", goingForward));
+  });
+});
+
+// ------ //

--- a/app/packs/src/decidim/global_adjustments.js
+++ b/app/packs/src/decidim/global_adjustments.js
@@ -72,7 +72,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const btn = e.target.closest("button[data-toggle-toggle-value]");
     if (!btn) return;
 
-    const goingForward = btn.dataset.toggleToggleValue.startsWith("step-1");
+    const goingForward = !btn.dataset.toggleToggleValue.startsWith("step-0");
     announcements.forEach(a => a.classList.toggle("is-hidden", goingForward));
   });
 });

--- a/app/packs/stylesheets/decidim/global_adjustments.scss
+++ b/app/packs/stylesheets/decidim/global_adjustments.scss
@@ -1,7 +1,13 @@
 .flash[data-announcement] {
-  &:has(.flash__message p:empty) {
-    display: none;
+  display: none;
+
+  &:has(.flash__message p:not(:empty)) {
+    display: flex;
   }
+}
+
+.flash[data-announcement].is-hidden {
+  display: none !important;
 }
 
 .content-block {


### PR DESCRIPTION
#### :tophat: Description

Fix on surveys, if you have separators it now gets to the top of the page to get to next question without any scrolling, and alerts now appears correctly only on the first part of the survey in 0.29

#### Testing

Example:
* Log in as admin
* Access Backoffice
* Go to participatory processes
* Configure a survey and add multiple questions and separators, make sure each part is long enough to make sure that if you click on "continue" it has to scroll to the top
* Add announcements and make sure they appear only on the first part

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=169448083&issue=OpenSourcePolitics%7Cintern-tasks%7C397

#### Tasks
- [ ] Add js and css 