### PR TITLE
fix: Make sure decidim cookies banner doesn't appear

### DIFF
--- a/app/packs/stylesheets/decidim/global_adjustments.scss
+++ b/app/packs/stylesheets/decidim/global_adjustments.scss
@@ -20,3 +20,10 @@
 .main-bar__links-desktop__item-wrapper div:has(a[aria-label="Activité"]) {
   display: none;
 }
+
+#dc-dialog-wrapper.cookies__container,
+#dc-modal,
+a[data-dialog-open="dc-modal"],
+li:has(a[data-dialog-open="dc-modal"]) {
+  display: none !important;
+}

--- a/spec/system/mobile_header_spec.rb
+++ b/spec/system/mobile_header_spec.rb
@@ -26,7 +26,6 @@ describe "Mobile header" do
       driven_by(:iphone)
       switch_to_host(organization.host)
       visit decidim.root_path
-      click_on(id: "dc-dialog-accept")
     end
 
     it "has a sticky header" do
@@ -79,7 +78,6 @@ describe "Mobile header" do
       switch_to_host(organization.host)
       login_as user, scope: :user
       visit decidim.root_path
-      click_on(id: "dc-dialog-accept")
     end
 
     it "displays an avatar on the header" do


### PR DESCRIPTION
#### :tophat: Description

Make disappear the decidim cookies banner when you arrive on a decidim page for the first time

#### Testing

Example:
* Using private navigation, go to localhost:3000 and make sure there's no banner at the end of the page regarding cookies

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=156006116&issue=OpenSourcePolitics%7Cintern-tasks%7C362