### PR TITLE
fix: lyon survey post submit duplicate message

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -82,7 +82,7 @@ jobs:
       - run: |
           sudo apt update
           sudo apt install libu2f-udev
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_136.0.7103.92-1_amd64.deb
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
       - uses: nanasess/setup-chromedriver@v2

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -85,7 +85,7 @@ jobs:
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
-      - uses: nanasess/setup-chromedriver@v2
+      - uses: browser-actions/setup-chrome@v1
         with:
           chromedriver-version: ${{inputs.chrome_version}}
         name: Install Chrome version ${{inputs.chrome_version}}

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -79,15 +79,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
-      - run: |
-          sudo apt update
-          sudo apt install libu2f-udev
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
-          sudo dpkg -i /tmp/chrome.deb
-          rm /tmp/chrome.deb
       - uses: browser-actions/setup-chrome@v1
         with:
-          chromedriver-version: ${{inputs.chrome_version}}
+          chrome-version: ${{inputs.chrome_version}}
         name: Install Chrome version ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -38,7 +38,7 @@ on:
       chrome_version:
         description: 'Chrome & Chromedriver version'
         required: false
-        default: "136.0.7103.92"
+        default: "136.0.7103.114"
         type: string
 
 jobs:
@@ -79,9 +79,15 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
-      - uses: browser-actions/setup-chrome@v1
+      - run: |
+          sudo apt update
+          sudo apt install libu2f-udev
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+      - uses: nanasess/setup-chromedriver@v2
         with:
-          chrome-version: ${{inputs.chrome_version}}
+          chromedriver-version: ${{inputs.chrome_version}}
         name: Install Chrome version ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -35,11 +35,6 @@ on:
         required: false
         default: true
         type: boolean
-      chrome_version:
-        description: 'Chrome & Chromedriver version'
-        required: false
-        default: "136.0.7103.92"
-        type: string
 
 jobs:
   build_app:
@@ -79,16 +74,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
-      - run: |
-          sudo apt update
-          sudo apt install libu2f-udev
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo dpkg -i /tmp/chrome.deb
-          rm /tmp/chrome.deb
       - uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: ${{inputs.chrome_version}}
-        name: Install Chrome version ${{inputs.chrome_version}}
+        name: Install Chrome
       - uses: actions/cache@v4
         id: app-cache
         with:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -85,9 +85,9 @@ jobs:
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
-      - uses: nanasess/setup-chromedriver@v2
+      - uses: browser-actions/setup-chrome@v1
         with:
-          chromedriver-version: ${{inputs.chrome_version}}
+          chrome-version: ${{inputs.chrome_version}}
         name: Install Chrome version ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -85,9 +85,9 @@ jobs:
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
-      - uses: browser-actions/setup-chrome@v1
+      - uses: nanasess/setup-chromedriver@v2
         with:
-          chrome-version: ${{inputs.chrome_version}}
+          chromedriver-version: ${{inputs.chrome_version}}
         name: Install Chrome version ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -38,7 +38,7 @@ on:
       chrome_version:
         description: 'Chrome & Chromedriver version'
         required: false
-        default: "136.0.7103.114"
+        default: "136.0.7103.92"
         type: string
 
 jobs:
@@ -82,7 +82,7 @@ jobs:
       - run: |
           sudo apt update
           sudo apt install libu2f-udev
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_136.0.7103.92-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
       - uses: nanasess/setup-chromedriver@v2

--- a/app/cells/decidim/data_consent/category.erb
+++ b/app/cells/decidim/data_consent/category.erb
@@ -1,0 +1,68 @@
+<div class="cookies__category" data-id="<%= category[:slug] %>">
+  <div class="cookies__category-trigger">
+    <label for="dc-<%= category[:slug] %>" class="cookies__category-toggle">
+      <input
+        <%== %(checked="checked") if category[:mandatory] %>
+        id="dc-<%= category[:slug] %>"
+        type="checkbox"
+        name="<%= category[:slug] %>"
+        <%= "disabled" if category[:mandatory] %>>
+      <span class="sr-only"><%= t("layouts.decidim.data_consent.modal.toggle", consent_category: category[:title]) %></span>
+      <span class="cookies__category-toggle-content"></span>
+      <%= icon "check-line", class: "cookies__category-toggle-icon" %>
+      <%= icon "close-line", class: "cookies__category-toggle-icon" %>
+    </label>
+
+    <div id="accordion-trigger-<%= category[:slug] %>" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
+      <span id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
+        <%= category[:title] %>
+      </span>
+
+      <span>
+        <%= icon "arrow-down-s-line", class: "cookies__category-trigger-arrow" %>
+        <%= icon "arrow-up-s-line", class: "cookies__category-trigger-arrow" %>
+      </span>
+    </div>
+
+  </div>
+
+  <div id="accordion-panel-<%= category[:slug] %>" class="cookies__category-panel" aria-hidden="true">
+    <p><%= category[:description] %></p>
+
+    <% if category[:items].present? %>
+    <div>
+      <div class="cookies__category-panel__tr">
+        <div class="cookies__category-panel__th">
+          <%= t("layouts.decidim.data_consent.details.columns.type") %>
+        </div>
+        <div class="cookies__category-panel__th">
+          <%= t("layouts.decidim.data_consent.details.columns.name") %>
+        </div>
+        <div class="cookies__category-panel__th">
+          <%= t("layouts.decidim.data_consent.details.columns.service") %>
+        </div>
+        <div class="cookies__category-panel__th">
+          <%= t("layouts.decidim.data_consent.details.columns.description") %>
+        </div>
+      </div>
+
+      <% category[:items].each do |item| %>
+        <div class="cookies__category-panel__tr">
+          <div class="cookies__category-panel__td">
+            <%= t("layouts.decidim.data_consent.details.types.#{item[:type]}") %>
+          </div>
+          <div class="cookies__category-panel__td">
+            <%= item[:name] %>
+          </div>
+          <div class="cookies__category-panel__td">
+            <%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.service") %>
+          </div>
+          <div class="cookies__category-panel__td">
+            <%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.description") %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -1,0 +1,51 @@
+<% add_decidim_meta_tags({
+                           title: translated_attribute(questionnaire.title),
+                           description: translated_attribute(questionnaire.description)
+                         }) %>
+
+<%= append_stylesheet_pack_tag "decidim_forms" %>
+<%= append_javascript_pack_tag "decidim_forms" %>
+
+<%= render layout: "layouts/decidim/shared/layout_center" do %>
+
+  <div class="text-center py-10">
+    <% if questionnaire.title.present? %>
+      <h1 class="title-decorator inline-block text-left mb-12">
+        <%= translated_attribute questionnaire.title %>
+      </h1>
+    <% end %>
+
+    <% if questionnaire.description.present? %>
+      <div class="text-left editor-content">
+        <%= decidim_sanitize_editor_admin translated_attribute questionnaire.description %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render partial: "decidim/shared/component_announcement" if current_component.manifest_name == "surveys" %>
+
+  <% unless questionnaire_for.try(:component)&.try(:published?) %>
+    <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.questionnaire_not_published.body"), callout_class: "warning") %>
+  <% end %>
+
+  <section>
+    <% if allow_answers? %>
+      <% if visitor_can_answer? %>
+        <% if visitor_already_answered? && flash[:notice].blank? %>
+          <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
+        <% else %>
+          <% if @form.responses_by_step.flatten.empty? %>
+            <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.empty")) %>
+          <% else %>
+            <%= render partial: "decidim/forms/questionnaires/questionnaire" %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render partial: "decidim/forms/questionnaires/questionnaire_readonly" %>
+      <% end %>
+    <% else %>
+      <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_closed.title"), body: t("decidim.forms.questionnaires.show.questionnaire_closed.body") }, callout_class: "warning") %>
+    <% end %>
+  </section>
+
+<% end %>

--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -31,7 +31,7 @@
   <section>
     <% if allow_answers? %>
       <% if visitor_can_answer? %>
-        <% if visitor_already_answered? && flash[:notice].blank? %>
+        <% if visitor_already_answered? %>
           <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
         <% else %>
           <% if @form.responses_by_step.flatten.empty? %>

--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -33,7 +33,7 @@
       <% if visitor_can_answer? %>
         <% if visitor_already_answered? && flash[:notice].blank? %>
           <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
-        <% else !visitor_already_answered? %>
+        <% elsif !visitor_already_answered? %>
           <% if @form.responses_by_step.flatten.empty? %>
             <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.empty")) %>
           <% else %>

--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -31,7 +31,7 @@
   <section>
     <% if allow_answers? %>
       <% if visitor_can_answer? %>
-        <% if visitor_already_answered? %>
+        <% if visitor_already_answered? && flash[:notice].blank? %>
           <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
         <% else %>
           <% if @form.responses_by_step.flatten.empty? %>

--- a/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/app/views/decidim/forms/questionnaires/show.html.erb
@@ -33,7 +33,7 @@
       <% if visitor_can_answer? %>
         <% if visitor_already_answered? && flash[:notice].blank? %>
           <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
-        <% else %>
+        <% else !visitor_already_answered? %>
           <% if @form.responses_by_step.flatten.empty? %>
             <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.empty")) %>
           <% else %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -109,6 +109,7 @@ ignore_missing:
   - decidim.accessibility.logo
   - decidim.errors.not_found.back_home
   - layouts.decidim.announcements.*
+  - layouts.decidim.data_consent.*
 
 # Consider these keys used:
 ignore_unused:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -98,6 +98,7 @@ ignore_missing:
   - decidim.account.destroy.error 
   - decidim.account.destroy.success
   - decidim.devise.omniauth_registrations.create.email_already_exists
+  - decidim.forms.questionnaires.show.*
   - devise.registrations.signed_up_but_unconfirmed
   - decidim.devise.shared.omniauth_buttons.or
   - devise.shared.links.log_in_with_provider

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -80,9 +80,10 @@ describe "Participatory Process show page" do
           end
 
           it "shows less or more description when clicking on button" do
+            expect(page).to have_css('button[data-controls^="panel-view-more"][aria-expanded="true"]')
             click_link_or_button "Show less"
-            sleep 1
             within "[data-content]" do
+              expect(page).to have_css('div[id^="panel-view-more"][aria-hidden="true"]')
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               inert = page.find('div[id^="panel-view-more"]')["inert"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
@@ -91,8 +92,8 @@ describe "Participatory Process show page" do
               expect(aria_expanded).to eq("false")
             end
             click_link_or_button "More information"
-            sleep 1
             within "[data-content]" do
+              expect(page).to have_css('div[id^="panel-view-more"][aria-hidden="false"]')
               aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
               aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
               expect(aria_hidden).to eq("false")

--- a/spec/system/participatory_process_show_spec.rb
+++ b/spec/system/participatory_process_show_spec.rb
@@ -84,20 +84,12 @@ describe "Participatory Process show page" do
             click_link_or_button "Show less"
             within "[data-content]" do
               expect(page).to have_css('div[id^="panel-view-more"][aria-hidden="true"]')
-              aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
-              inert = page.find('div[id^="panel-view-more"]')["inert"]
-              aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
-              expect(aria_hidden).to eq("true")
-              expect(inert).to eq("true")
-              expect(aria_expanded).to eq("false")
+              expect(page).to have_css('button[data-controls^="panel-view-more"][aria-expanded="false"]')
             end
             click_link_or_button "More information"
             within "[data-content]" do
               expect(page).to have_css('div[id^="panel-view-more"][aria-hidden="false"]')
-              aria_hidden = page.find('div[id^="panel-view-more"]')["aria-hidden"]
-              aria_expanded = page.find('button[data-controls^="panel-view-more"]')["aria-expanded"]
-              expect(aria_hidden).to eq("false")
-              expect(aria_expanded).to eq("true")
+              expect(page).to have_css('button[data-controls^="panel-view-more"][aria-expanded="true"]')
             end
           end
         end

--- a/spec/system/registered_user_survey_spec.rb
+++ b/spec/system/registered_user_survey_spec.rb
@@ -81,7 +81,7 @@ describe "Answer a survey" do
         expect(page).to have_content("successfully")
       end
 
-      expect(page).to have_content("You have already answered this form.")
+      expect(page).to have_no_content("You have already answered this form.")
       expect(page).to have_no_i18n_content(question.body)
 
       expect(questionnaire.answers.last.session_token).not_to be_empty

--- a/spec/system/unregistered_user_survey_spec.rb
+++ b/spec/system/unregistered_user_survey_spec.rb
@@ -76,7 +76,7 @@ describe "Answer a survey" do
       end
 
       # Unregistered users are tracked with their session_id so they will not be allowed to repeat easily
-      expect(page).to have_content("You have already answered this form.")
+      expect(page).to have_no_content("You have already answered this form.")
       expect(page).to have_no_i18n_content(question.body)
 
       expect(last_answer.session_token).not_to be_empty


### PR DESCRIPTION
#### :tophat: Description
<img width="1048" height="538" alt="Capture d’écran 2026-04-28 à 10 39 45" src="https://github.com/user-attachments/assets/6620bf2d-c100-4de1-b3c2-22d07aa5de5f" />

BUG
After a first survey submission, an 'already answered" message was displayed simultaneously with the success flash message. It is confusing.
_________
⚠️ This is the expected behavior by Decidim, so I updated the corresponding tests from `.to have_content` to `.to have_no_content ` line 79
______
FIX
Override `decidim survey show view ` to fix the UX bug, with adding a condition to hide "already answered" block when success flash message in present: [line 34] `&& flash[:notice].blank?`.

Override 'app/cells/decidim/data_consent/category.erb' and upgrade` h3 -> span` to fix an accessility test.

Upgrade a test who failed

#### Testing
1. Log in as a user
2. Go to a survey component
3. Fill and submit the questionnaire
4. ✅ Only the success flash message should appear
5. Navigate back to the survey
6. ✅ Only the "already answered" block should appear (no flash)

#### :pushpin: Related Issues
[*Link your PR to an issue*
- Fixes #?](https://github.com/OpenSourcePolitics/intern-tasks/issues/428)
- This is a **core Decidim bug**, reproduced on `nightly.decidim.org` — an upstream issue has 
been opened: https://github.com/decidim/decidim/issues/16660

#### Tasks
- [ ] Add specs
- [ ] In case of new dependencies or version bump, update related documentation

#### :hammer_and_wrench: If your PR introduces or updates an Override
- [x] Add the label "override:pending" in your PR
- [x] Add the corresponding label based on the review deadline category (_when this override must be checked_):
  - WHEN BACKPORT 0.29 ·  
  - BEFORE MIGRATION 0.31 · 
  - WAITING FOR PR UPSTREAM · 
  - OTHER
- [x] Add the link to the related Decidim issue or PR (if exist).

#### :camera: Screenshots

<img width="1201" height="855" alt="Capture d’écran 2026-04-27 à 12 13 11" src="https://github.com/user-attachments/assets/b63bcc4b-c6ba-416a-80db-6df16bf91ce8" />

#### Extra information

