### PR TITLE
Fix: content block error

### DIFF
--- a/config/initializers/participatory_processes_registry_manager_override.rb
+++ b/config/initializers/participatory_processes_registry_manager_override.rb
@@ -139,13 +139,6 @@ module Decidim
             content_block.default!
           end
 
-          Decidim.content_blocks.register(:participatory_process_homepage, :metrics) do |content_block|
-            content_block.cell = "decidim/participatory_processes/content_blocks/metrics"
-            content_block.public_name_key = "decidim.content_blocks.participatory_space_metrics.name"
-
-            content_block.default!
-          end
-
           Decidim.content_blocks.register(:participatory_process_homepage, :related_processes) do |content_block|
             content_block.cell = "decidim/participatory_processes/content_blocks/related_processes"
             content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/highlighted_processes_settings_form"


### PR DESCRIPTION
#### :tophat: Description
This PR removes from an override the metrics content block added in participatory processes, that causes a 500 error.

#### Testing

1. As an admin, go to a process > landing page
2. See that you can access the page

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=175291793&issue=OpenSourcePolitics%7Cintern-tasks%7C407