### PR TITLE
Fix(a11y): role menu/presentation on user menu

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,7 @@ module DecidimApp
       require "extends/permissions/initiatives/permissions_extends"
       # presenters
       require "extends/presenters/decidim/forms/admin/questionnaire_answer_presenter_extends"
+      require "extends/presenters/decidim/menu_item_presenter_extends"
       # serializers
       require "extends/serializers/decidim/proposals/proposal_serializer_extends"
     end

--- a/lib/extends/presenters/decidim/menu_item_presenter_extends.rb
+++ b/lib/extends/presenters/decidim/menu_item_presenter_extends.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MenuItemPresenterExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def render
+      content_tag :li, role: :presentation, class: link_wrapper_classes do
+        output = if url == "#"
+                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled", role: :menuitem)]
+                 else
+                   [link_to(composed_label, url, link_options.merge(role: :menuitem))]
+                 end
+        output.push(@view.send(:simple_menu, **@menu_item.submenu).render) if @menu_item.submenu
+
+        safe_join(output)
+      end
+    end
+  end
+end
+
+Decidim::MenuItemPresenter.class_eval do
+  include(MenuItemPresenterExtends)
+end


### PR DESCRIPTION
Partial backport of https://github.com/decidim/decidim/pull/16878

Fix an accessibility test failure for 
```
The element “a” with the attribute “href” must not appear as a descendant of an element with the attribute “role=menuitem”.
```
in the profile user menu. 

Notes : they're might be other places to fix since searching the decidim 0.29 code base for `li` elements with `role="menuitem"` returns several occurrences with link included inside them