### PR TITLE
fix: sign in display on mobile view

### DIFF
--- a/app/packs/src/decidim/global_adjustments.js
+++ b/app/packs/src/decidim/global_adjustments.js
@@ -71,11 +71,21 @@ document.addEventListener("DOMContentLoaded", function () {
 document.addEventListener("DOMContentLoaded", function () {
   const signIn = document.querySelector('.main-bar a[href^="/users/sign_in"]')
   const menuBarMobile = document.querySelector('header .main-bar__menu-mobile');
-  const menuBarMobileLink = document.querySelector('header .main-bar__links-mobile__login')
+  const menuBarMobileLink = document.querySelector('header .main-bar__links-mobile__login');
+  const button = document.querySelector('#main-dropdown-summary-mobile');
 
   if (window.innerWidth <= 600 && signIn && screen.orientation.type === "portrait-primary"){
     menuBarMobile.style.flexDirection = "column-reverse";
     if (menuBarMobileLink) menuBarMobileLink.style.marginBottom = "1rem";
+
+    // hide or show signin when the dropdown-menu is clicked
+    button.addEventListener('click', () => {
+      if (menuBarMobile.style.flexDirection == "column-reverse") {
+        menuBarMobile.style.flexDirection = "row-reverse";
+      } else {
+        menuBarMobile.style.flexDirection = "column-reverse";
+      }
+    })
   }
   screen.orientation.addEventListener("change", () => {
     if (screen.orientation.type === "landscape-primary"){


### PR DESCRIPTION
#### :tophat: Description
This PR updates javascript to fix the bad masking of sign_in link after clicking on menu button on mobile portrait view.

#### Testing

1. As a non logged_in user, open your devtools and go to mobile portrait view (cf screenshot)
2. Click on the menu btn and see that the sign_in link is well hidden (cf screenshot)

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=192174853&issue=OpenSourcePolitics%7Cintern-tasks%7C447


#### :camera: Screenshots
<img width="354" height="503" alt="Capture d’écran 2026-05-27 à 14 20 43" src="https://github.com/user-attachments/assets/a91b4eda-cb12-4a1d-b55f-95c7fd69e444" />

<img width="340" height="410" alt="Capture d’écran 2026-05-27 à 14 20 50" src="https://github.com/user-attachments/assets/856cb83e-1788-4290-8da9-7ba7609da8f0" />


