### PR TITLE
fix: SSO & Extra User Fields

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -59,3 +59,6 @@ GEOCODER_UNITS=km                    # Units for geocoder results (e.g., km or m
 # DECIDIM_AI_BASIC_AUTH="<USER>:<PASSWORD>" Required for the AI Request Handler
 # DECIDIM_AI_REPORTING_USER_EMAIL="<EMAIL>"
 # DECIDIM_AI_SECRET="<SECRET_KEY>" # Not required for the AI Request Handler
+
+#= Enforce EUF completion after login
+DECIDIM_FORCE_EUF_COMPLETION=true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :check_euf_completion, if: :current_user
 end

--- a/app/overrides/decidim/shared/filters/_dropdown_label/unescape_check_box_label.html.erb.deface
+++ b/app/overrides/decidim/shared/filters/_dropdown_label/unescape_check_box_label.html.erb.deface
@@ -1,1 +1,1 @@
-<!-- replace "erb[loud]:contains('filter_text_for(leaf.label')" --><%= filter_text_for(CGI.unescapeHTML(leaf.label), id: "dropdown-title-#{data_checkboxes_tree_id}") %>
+<!-- replace "erb[loud]:contains('filter_text_for(leaf.label')" --><%= filter_text_for(CGI.unescapeHTML(leaf.label.to_s), id: "dropdown-title-#{data_checkboxes_tree_id}") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module DecidimApp
       require "extends/forms/decidim/account_form_extends"
       require "extends/forms/decidim/editor_image_form_extends"
       # controllers
+      require "extends/controllers/application_controller_extends"
+      require "extends/controllers/decidim/devise/invitations_controller_extends"
       require "extends/controllers/decidim/admin/scopes_controller_extends"
       require "extends/controllers/decidim/scopes_controller_extends"
       require "extends/controllers/decidim/comments/comments_controller_extends"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,10 @@ en:
           <p>
             You can't edit this information here.
           </p>
+      update:
+        error: There was a problem updating your account.
+        success: Your account was successfully updated.
+        success_with_email_confirmation: Your account was successfully updated. You will receive an email to confirm your new email address.
     admin:
       actions:
         add: Add
@@ -117,6 +121,9 @@ en:
           email_outro: You received this notification because you are the author of the proposal. You can unfollow it by visiting the proposal page (" %{resource_title} ") and clicking on " Unfollow ".
           email_subject: Your proposal has been published!
           notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is now live.
+    extra_user_fields:
+      force_euf_completion:
+        alert: Please complete your profile before continuing. Required fields must be filled in.
     forms:
       questionnaire_answer_presenter:
         download_attachment: Download attachment

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,6 +31,10 @@ fr:
           <p>
             Vous ne pouvez pas modifier ces informations ici.
           </p>
+      update:
+        error: Une erreur s'est produite lors de la mise à jour de votre compte.
+        success: Votre compte a été mis à jour avec succès.
+        success_with_email_confirmation: Votre compte a été mis à jour avec succès. Vous recevrez un email pour confirmer votre nouvelle adresse.
     admin:
       actions:
         add: Ajouter
@@ -125,6 +129,9 @@ fr:
           email_outro: Vous recevez cette notification car vous êtes l’auteur de la proposition. Vous pouvez vous désabonner en visitant la page de la proposition (« %{resource_title} ») et en cliquant sur « Ne plus suivre ».
           email_subject: Votre proposition a été publiée !
           notification_title: Votre proposition <a href="%{resource_path}">%{resource_title}</a> est maintenant en ligne.
+    extra_user_fields:
+      force_euf_completion:
+        alert: Veuillez compléter votre profil avant de continuer. Les champs obligatoires doivent être renseignés.
     forms:
       questionnaire_answer_presenter:
         download_attachment: Télécharger la pièce jointe

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -133,6 +133,9 @@ default: &default
     <<: *decidim_default
     participatory_processes:
       sort_by_date: <%= ENV.fetch("SORT_PROCESSES_BY_DATE", "false") == "true" %>
+    extra_user_fields:
+      force_euf_completion: <%= ENV["DECIDIM_FORCE_EUF_COMPLETION"] %>
+
   sidekiq:
     concurrency: <%= Decidim::Env.new('SIDEKIQ_CONCURRENCY', '5').to_i %>
     max_retries: <%= Decidim::Env.new('SIDEKIQ_MAX_RETRIES', '5').to_i %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -134,8 +134,7 @@ default: &default
     participatory_processes:
       sort_by_date: <%= ENV.fetch("SORT_PROCESSES_BY_DATE", "false") == "true" %>
     extra_user_fields:
-      force_euf_completion: <%= ENV["DECIDIM_FORCE_EUF_COMPLETION"] %>
-
+      force_euf_completion: <%= ENV["DECIDIM_FORCE_EUF_COMPLETION"] == "true" %>
   sidekiq:
     concurrency: <%= Decidim::Env.new('SIDEKIQ_CONCURRENCY', '5').to_i %>
     max_retries: <%= Decidim::Env.new('SIDEKIQ_MAX_RETRIES', '5').to_i %>

--- a/lib/extends/commands/decidim/create_omniauth_registration_extends.rb
+++ b/lib/extends/commands/decidim/create_omniauth_registration_extends.rb
@@ -13,6 +13,9 @@ module CreateOmniauthRegistrationExtends
 
         return broadcast(:ok, @user)
       end
+
+      prefill_euf_fields_from_existing_user
+
       return broadcast(:invalid) if form.invalid?
 
       transaction do
@@ -32,6 +35,24 @@ module CreateOmniauthRegistrationExtends
   def manage_user_confirmation
     # send welcome notification and email
     @user.after_confirmation if verified_email
+  end
+
+  private
+
+  def prefill_euf_fields_from_existing_user
+    existing_user = Decidim::User.find_by(
+      email: form.email,
+      organization: form.current_organization
+    )
+    return unless existing_user
+
+    existing_data = existing_user.extended_data.presence || {}
+    %w(phone_number country postal_code date_of_birth gender location underage).each do |field|
+      next unless form.respond_to?(:"#{field}=")
+      next if existing_data[field].blank?
+
+      form.public_send(:"#{field}=", existing_data[field])
+    end
   end
 end
 

--- a/lib/extends/controllers/application_controller_extends.rb
+++ b/lib/extends/controllers/application_controller_extends.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ApplicationControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_euf_completion, if: :current_user
+
+    private
+
+    def check_euf_completion
+      return unless euf_completion_enforced?
+      return if euf_whitelisted_path?
+
+      missing_field = first_missing_euf_field(current_user)
+      return unless missing_field
+
+      stored = safe_euf_redirect_path? ? request.fullpath : stored_location_for(current_user)
+      session[:euf_redirect_url] = stored if stored.present?
+      flash[:alert] = t("decidim.extra_user_fields.force_euf_completion.alert")
+      redirect_to "#{decidim.account_path}#user_#{missing_field}"
+    end
+
+    def euf_completion_enforced?
+      Rails.application.secrets.dig(:decidim, :extra_user_fields, :force_euf_completion)
+    end
+
+    def euf_whitelisted_path?
+      whitelisted_paths = ["/account", "/users/sign_out", "/rails/active_storage", "/decidim-packs"]
+      whitelisted_paths.any? { |path| request.path.start_with?(path) }
+    end
+
+    def safe_euf_redirect_path?
+      path = request.fullpath
+      return false if path.include?("invitation_token")
+      return false if path.include?("users/auth")
+      return false if path.start_with?("/users/")
+
+      true
+    end
+
+    def first_missing_euf_field(user)
+      return if user.admin?
+      return unless current_organization.extra_user_fields_enabled?
+
+      [:country, :postal_code, :date_of_birth, :gender, :phone_number, :location, :underage].find do |field|
+        current_organization.activated_extra_field?(field) &&
+          user.extended_data[field.to_s].blank?
+      end
+    end
+  end
+end
+
+ApplicationController.class_eval do
+  include(ApplicationControllerExtends)
+end

--- a/lib/extends/controllers/application_controller_extends.rb
+++ b/lib/extends/controllers/application_controller_extends.rb
@@ -15,7 +15,12 @@ module ApplicationControllerExtends
       missing_field = first_missing_euf_field(current_user)
       return unless missing_field
 
-      stored = safe_euf_redirect_path? ? request.fullpath : stored_location_for(current_user)
+      existing = session["user_return_to"]
+      stored = if existing.present?
+                 existing
+               elsif safe_euf_redirect_path?
+                 request.fullpath
+               end
       session[:euf_redirect_url] = stored if stored.present?
       flash[:alert] = t("decidim.extra_user_fields.force_euf_completion.alert")
       redirect_to "#{decidim.account_path}#user_#{missing_field}"

--- a/lib/extends/controllers/decidim/account_controller_extends.rb
+++ b/lib/extends/controllers/decidim/account_controller_extends.rb
@@ -2,6 +2,33 @@
 
 module Decidim
   module AccountControllerExtends
+    def update
+      enforce_permission_to(:update, :user, current_user:)
+
+      @account = form(Decidim::AccountForm).from_params(account_params)
+
+      Decidim::UpdateAccount.call(@account) do
+        on(:ok) do |email_is_unconfirmed|
+          flash[:notice] = if email_is_unconfirmed
+                             t("account.update.success_with_email_confirmation", scope: "decidim")
+                           else
+                             t("account.update.success", scope: "decidim")
+                           end
+
+          bypass_sign_in(current_user)
+
+          redirect_url = session.delete(:euf_redirect_url) || decidim.account_path
+          redirect_to redirect_url
+        end
+
+        on(:invalid) do |password|
+          fetch_entered_password(password)
+          flash[:alert] = t("account.update.error", scope: "decidim")
+          render action: :show
+        end
+      end
+    end
+
     def destroy
       enforce_permission_to(:delete, :user, current_user:)
       @form = form(Decidim::DeleteAccountForm).from_params(params)
@@ -48,6 +75,8 @@ module Decidim
     def account_params
       params[:user][:name] = current_user.name if disable_profile_field?(:name)
       params[:user][:email] = current_user.email if disable_profile_field?(:email)
+      params[:user][:nickname] ||= current_user.nickname
+      params[:user][:tos_agreement] = "1"
       params[:user].to_unsafe_h
     end
 

--- a/lib/extends/controllers/decidim/account_controller_extends.rb
+++ b/lib/extends/controllers/decidim/account_controller_extends.rb
@@ -17,7 +17,9 @@ module Decidim
 
           bypass_sign_in(current_user)
 
-          redirect_url = session.delete(:euf_redirect_url) || decidim.account_path
+          redirect_url = session.delete(:euf_redirect_url) ||
+                         stored_location_for(current_user) ||
+                         decidim.account_path
           redirect_to redirect_url
         end
 
@@ -43,6 +45,23 @@ module Decidim
     end
 
     private
+
+    def private_space_path_for(user)
+      private_user = Decidim::ParticipatorySpacePrivateUser
+                     .where(user:)
+                     .order(created_at: :desc)
+                     .first
+
+      return if private_user&.privatable_to.blank?
+
+      space = private_user.privatable_to
+      case space
+      when Decidim::Assembly
+        decidim_assemblies.assembly_path(space.slug)
+      when Decidim::ParticipatoryProcess
+        decidim_participatory_processes.participatory_process_path(space.slug)
+      end
+    end
 
     def handle_successful_destruction
       sign_out(current_user)

--- a/lib/extends/controllers/decidim/devise/invitations_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/invitations_controller_extends.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ApplicationInvitationsControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def after_accept_path_for(resource)
+      private_user = Decidim::ParticipatorySpacePrivateUser
+                     .where(user: resource)
+                     .order(created_at: :desc)
+                     .first
+
+      if private_user&.privatable_to.present?
+        space = private_user.privatable_to
+        destination = case space
+                      when Decidim::Assembly
+                        decidim_assemblies.assembly_path(space.slug)
+                      when Decidim::ParticipatoryProcess
+                        decidim_participatory_processes.participatory_process_path(space.slug)
+                      end
+        session[:euf_redirect_url] = destination if destination.present?
+      end
+
+      invite_redirect_path || after_sign_in_path_for(resource)
+    end
+  end
+end
+
+Decidim::Devise::InvitationsController.class_eval do
+  include(ApplicationInvitationsControllerExtends)
+end

--- a/lib/extends/controllers/decidim/devise/invitations_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/invitations_controller_extends.rb
@@ -18,7 +18,7 @@ module ApplicationInvitationsControllerExtends
                       when Decidim::ParticipatoryProcess
                         decidim_participatory_processes.participatory_process_path(space.slug)
                       end
-        session[:euf_redirect_url] = destination if destination.present?
+        store_location_for(resource, destination) if destination.present?
       end
 
       invite_redirect_path || after_sign_in_path_for(resource)

--- a/lib/extends/controllers/decidim/devise/omniauth_registrations_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/omniauth_registrations_controller_extends.rb
@@ -39,8 +39,7 @@ module OmniauthRegistrationsControllerExtends
 
     def sign_in_and_redirect(resource_or_scope, *args)
       strategy = request.env["omniauth.strategy"]
-      provider = strategy.name
-      session["omniauth.provider"] = provider
+      session["omniauth.provider"] = strategy.name if strategy
       super
     end
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Decidim::AccountController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization, extra_user_fields: { "enabled" => true }) }
+    let(:valid_params) do
+      {
+        user: {
+          name: user.name,
+          nickname: user.nickname,
+          email: user.email,
+          password: "",
+          old_password: "",
+          personal_url: "",
+          about: "",
+          locale: "fr",
+          tos_agreement: "1"
+        }
+      }
+    end
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+      sign_in user
+    end
+
+    def stub_update_account(event, *args)
+      allow(Decidim::UpdateAccount).to receive(:call) do |_form, &block|
+        callbacks = {}
+        allow(controller).to receive(:on) { |ev, &cb| callbacks[ev] = cb }
+        controller.instance_exec(&block)
+        callbacks[event]&.call(*args)
+      end
+    end
+
+    describe "PUT update" do
+      context "when UpdateAccount succeeds" do
+        before { stub_update_account(:ok, false) }
+
+        context "and euf_redirect_url is stored in session" do
+          before { session[:euf_redirect_url] = "/assemblies/some-assembly" }
+
+          it "redirects to the stored euf_redirect_url" do
+            put :update, params: valid_params
+            expect(response).to redirect_to("/assemblies/some-assembly")
+          end
+
+          it "clears euf_redirect_url from session" do
+            put :update, params: valid_params
+            expect(session[:euf_redirect_url]).to be_nil
+          end
+
+          it "shows the success flash" do
+            put :update, params: valid_params
+            expect(flash[:notice]).to be_present
+          end
+        end
+
+        context "and euf_redirect_url is a participatory process path" do
+          before { session[:euf_redirect_url] = "/processes/some-process" }
+
+          it "redirects to the stored process path" do
+            put :update, params: valid_params
+            expect(response).to redirect_to("/processes/some-process")
+          end
+        end
+
+        context "and no euf_redirect_url is stored in session" do
+          it "redirects to account path" do
+            put :update, params: valid_params
+            expect(response).to redirect_to(account_path)
+          end
+        end
+      end
+
+      context "when UpdateAccount fails" do
+        before do
+          stub_update_account(:invalid, false)
+          session[:euf_redirect_url] = "/assemblies/some-assembly"
+        end
+
+        it "renders the show template" do
+          put :update, params: valid_params
+          expect(response).to render_template(:show)
+        end
+
+        it "keeps euf_redirect_url in session so the user can retry" do
+          put :update, params: valid_params
+          expect(session[:euf_redirect_url]).to eq("/assemblies/some-assembly")
+        end
+
+        it "shows the error flash" do
+          put :update, params: valid_params
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -30,74 +30,97 @@ module Decidim
       sign_in user
     end
 
-    def stub_update_account(event, *args)
+    def stub_update_account_ok
       allow(Decidim::UpdateAccount).to receive(:call) do |_form, &block|
         callbacks = {}
         allow(controller).to receive(:on) { |ev, &cb| callbacks[ev] = cb }
         controller.instance_exec(&block)
-        callbacks[event]&.call(*args)
+        callbacks[:ok]&.call(false)
       end
     end
 
-    describe "PUT update" do
-      context "when UpdateAccount succeeds" do
-        before { stub_update_account(:ok, false) }
+    describe "POST update redirection after EUF completion" do
+      before { stub_update_account_ok }
 
-        context "and euf_redirect_url is stored in session" do
-          before { session[:euf_redirect_url] = "/assemblies/some-assembly" }
+      context "when session[:euf_redirect_url] is set (normal navigation interception)" do
+        context "and points to an assembly" do
+          before { session[:euf_redirect_url] = "/assemblies/my-assembly" }
 
-          it "redirects to the stored euf_redirect_url" do
+          it "redirects to the assembly" do
             put :update, params: valid_params
-            expect(response).to redirect_to("/assemblies/some-assembly")
+            expect(response).to redirect_to("/assemblies/my-assembly")
           end
 
           it "clears euf_redirect_url from session" do
             put :update, params: valid_params
             expect(session[:euf_redirect_url]).to be_nil
           end
-
-          it "shows the success flash" do
-            put :update, params: valid_params
-            expect(flash[:notice]).to be_present
-          end
         end
 
-        context "and euf_redirect_url is a participatory process path" do
-          before { session[:euf_redirect_url] = "/processes/some-process" }
+        context "and points to a participatory process" do
+          before { session[:euf_redirect_url] = "/processes/my-process" }
 
-          it "redirects to the stored process path" do
+          it "redirects to the process" do
             put :update, params: valid_params
-            expect(response).to redirect_to("/processes/some-process")
+            expect(response).to redirect_to("/processes/my-process")
           end
-        end
 
-        context "and no euf_redirect_url is stored in session" do
-          it "redirects to account path" do
+          it "clears euf_redirect_url from session" do
             put :update, params: valid_params
-            expect(response).to redirect_to(account_path)
+            expect(session[:euf_redirect_url]).to be_nil
           end
         end
       end
 
-      context "when UpdateAccount fails" do
+      context "when stored_location_for is set (invitation flow)" do
+        context "and points to an assembly" do
+          before do
+            allow(controller).to receive(:stored_location_for).and_return("/assemblies/private-assembly")
+          end
+
+          it "redirects to the assembly" do
+            put :update, params: valid_params
+            expect(response).to redirect_to("/assemblies/private-assembly")
+          end
+        end
+
+        context "and points to a participatory process" do
+          before do
+            allow(controller).to receive(:stored_location_for).and_return("/processes/private-process")
+          end
+
+          it "redirects to the process" do
+            put :update, params: valid_params
+            expect(response).to redirect_to("/processes/private-process")
+          end
+        end
+      end
+
+      context "when both session[:euf_redirect_url] and stored_location_for are set" do
         before do
-          stub_update_account(:invalid, false)
-          session[:euf_redirect_url] = "/assemblies/some-assembly"
+          session[:euf_redirect_url] = "/assemblies/from-session"
+          allow(controller).to receive(:stored_location_for).and_return("/assemblies/from-devise")
         end
 
-        it "renders the show template" do
+        it "prioritizes session[:euf_redirect_url]" do
           put :update, params: valid_params
-          expect(response).to render_template(:show)
+          expect(response).to redirect_to("/assemblies/from-session")
         end
+      end
 
-        it "keeps euf_redirect_url in session so the user can retry" do
+      context "when neither session[:euf_redirect_url] nor stored_location_for are set" do
+        it "redirects to account path" do
           put :update, params: valid_params
-          expect(session[:euf_redirect_url]).to eq("/assemblies/some-assembly")
+          expect(response).to redirect_to(account_path)
         end
+      end
 
-        it "shows the error flash" do
+      context "when stored_location_for returns nil" do
+        before { allow(controller).to receive(:stored_location_for).and_return(nil) }
+
+        it "redirects to account path" do
           put :update, params: valid_params
-          expect(flash[:alert]).to be_present
+          expect(response).to redirect_to(account_path)
         end
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ApplicationController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization, extra_user_fields: { "enabled" => true }) }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+      sign_in user
+      allow(controller).to receive(:current_organization).and_return(organization)
+    end
+
+    describe "#euf_completion_enforced?" do
+      it "returns true when the secret is enabled" do
+        allow(Rails.application.secrets).to receive(:dig)
+          .with(:decidim, :extra_user_fields, :force_euf_completion)
+          .and_return(true)
+        expect(controller.send(:euf_completion_enforced?)).to be(true)
+      end
+
+      it "returns false when the secret is disabled" do
+        allow(Rails.application.secrets).to receive(:dig)
+          .with(:decidim, :extra_user_fields, :force_euf_completion)
+          .and_return(false)
+        expect(controller.send(:euf_completion_enforced?)).to be(false)
+      end
+
+      it "returns nil when the secret is not set" do
+        allow(Rails.application.secrets).to receive(:dig)
+          .with(:decidim, :extra_user_fields, :force_euf_completion)
+          .and_return(nil)
+        expect(controller.send(:euf_completion_enforced?)).to be_nil
+      end
+    end
+
+    describe "#euf_whitelisted_path?" do
+      {
+        "/account" => true,
+        "/users/sign_out" => true,
+        "/rails/active_storage/blobs/xxx" => true,
+        "/decidim-packs/main.js" => true,
+        "/assemblies/my-assembly" => false,
+        "/processes/my-process" => false,
+        "/initiatives" => false,
+        "/" => false
+      }.each do |path, expected|
+        it "returns #{expected} for #{path}" do
+          allow(request).to receive(:path).and_return(path)
+          expect(controller.send(:euf_whitelisted_path?)).to be(expected)
+        end
+      end
+    end
+
+    describe "#safe_euf_redirect_path?" do
+      it "returns true for a normal assembly path" do
+        allow(request).to receive(:fullpath).and_return("/assemblies/my-assembly")
+        expect(controller.send(:safe_euf_redirect_path?)).to be(true)
+      end
+
+      it "returns true for a process path" do
+        allow(request).to receive(:fullpath).and_return("/processes/my-process")
+        expect(controller.send(:safe_euf_redirect_path?)).to be(true)
+      end
+
+      it "returns false for paths containing invitation_token" do
+        allow(request).to receive(:fullpath).and_return("/users/invitation/accept?invitation_token=abc123")
+        expect(controller.send(:safe_euf_redirect_path?)).to be(false)
+      end
+
+      it "returns false for omniauth paths" do
+        allow(request).to receive(:fullpath).and_return("/users/auth/openid_connect/callback")
+        expect(controller.send(:safe_euf_redirect_path?)).to be(false)
+      end
+
+      it "returns false for paths starting with /users/" do
+        allow(request).to receive(:fullpath).and_return("/users/sign_in")
+        expect(controller.send(:safe_euf_redirect_path?)).to be(false)
+      end
+    end
+
+    describe "#first_missing_euf_field" do
+      context "when the user is an admin" do
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+        it "returns nil" do
+          expect(controller.send(:first_missing_euf_field, user)).to be_nil
+        end
+      end
+
+      context "when extra_user_fields is not enabled on the organization" do
+        let(:organization) { create(:organization, extra_user_fields: { "enabled" => false }) }
+
+        it "returns nil" do
+          expect(controller.send(:first_missing_euf_field, user)).to be_nil
+        end
+      end
+
+      context "when all fields are filled" do
+        before do
+          allow(organization).to receive(:activated_extra_field?).and_return(true)
+          user.update!(extended_data: {
+                         "phone_number" => "+33612345678",
+                         "country" => "FR",
+                         "postal_code" => "75001",
+                         "date_of_birth" => "1990-01-01",
+                         "gender" => "female",
+                         "location" => "Paris",
+                         "underage" => false
+                       })
+        end
+
+        it "returns nil" do
+          expect(controller.send(:first_missing_euf_field, user)).to be_nil
+        end
+      end
+
+      context "when phone_number is activated and missing" do
+        before do
+          allow(organization).to receive(:extra_user_fields_enabled?).and_return(true)
+          allow(organization).to receive(:activated_extra_field?).and_return(false)
+          allow(organization).to receive(:activated_extra_field?).with(:phone_number).and_return(true)
+          user.update!(extended_data: { "phone_number" => nil })
+        end
+
+        it "returns :phone_number" do
+          expect(controller.send(:first_missing_euf_field, user)).to eq(:phone_number)
+        end
+      end
+
+      context "when country is activated and missing" do
+        before do
+          allow(organization).to receive(:extra_user_fields_enabled?).and_return(true)
+          allow(organization).to receive(:activated_extra_field?).and_return(false)
+          allow(organization).to receive(:activated_extra_field?).with(:country).and_return(true)
+          user.update!(extended_data: { "country" => "" })
+        end
+
+        it "returns :country" do
+          expect(controller.send(:first_missing_euf_field, user)).to eq(:country)
+        end
+      end
+
+      context "when country and phone_number are activated but only phone_number is missing" do
+        before do
+          allow(organization).to receive(:extra_user_fields_enabled?).and_return(true)
+          allow(organization).to receive(:activated_extra_field?).and_return(false)
+          allow(organization).to receive(:activated_extra_field?).with(:country).and_return(true)
+          allow(organization).to receive(:activated_extra_field?).with(:phone_number).and_return(true)
+          user.update!(extended_data: { "country" => "FR", "phone_number" => nil })
+        end
+
+        it "returns :phone_number" do
+          expect(controller.send(:first_missing_euf_field, user)).to eq(:phone_number)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -19,19 +19,6 @@ module Decidim
     describe "#after_accept_path_for" do
       subject { controller.after_accept_path_for(user) }
 
-      context "when the user has no private space membership" do
-        it "does not store euf_redirect_url in session" do
-          subject
-          expect(session[:euf_redirect_url]).to be_nil
-        end
-
-        it "delegates to after_sign_in_path_for" do
-          allow(controller).to receive(:after_sign_in_path_for).with(user).and_return("/account")
-          expect(subject).to eq("/account")
-          subject
-        end
-      end
-
       context "when the user is a member of a private assembly" do
         let(:assembly) { create(:assembly, :private, organization:) }
 
@@ -39,15 +26,15 @@ module Decidim
           create(:participatory_space_private_user, user:, privatable_to: assembly)
         end
 
-        it "stores the assembly path in euf_redirect_url" do
+        it "stores the assembly path via store_location_for" do
+          expect(controller).to receive(:store_location_for)
+            .with(user, "/assemblies/#{assembly.slug}")
           subject
-          expect(session[:euf_redirect_url]).to eq("/assemblies/#{assembly.slug}")
         end
 
-        it "delegates to after_sign_in_path_for" do
-          allow(controller).to receive(:after_sign_in_path_for).with(user).and_return("/account")
-          expect(subject).to eq("/account")
+        it "does not store in session[:euf_redirect_url]" do
           subject
+          expect(session[:euf_redirect_url]).to be_nil
         end
       end
 
@@ -58,9 +45,22 @@ module Decidim
           create(:participatory_space_private_user, user:, privatable_to: participatory_process)
         end
 
-        it "stores the participatory process path in euf_redirect_url" do
+        it "stores the process path via store_location_for" do
+          expect(controller).to receive(:store_location_for)
+            .with(user, "/processes/#{participatory_process.slug}")
           subject
-          expect(session[:euf_redirect_url]).to eq("/processes/#{participatory_process.slug}")
+        end
+
+        it "does not store in session[:euf_redirect_url]" do
+          subject
+          expect(session[:euf_redirect_url]).to be_nil
+        end
+      end
+
+      context "when the user has no private space membership" do
+        it "does not call store_location_for" do
+          expect(controller).not_to receive(:store_location_for)
+          subject
         end
 
         it "delegates to after_sign_in_path_for" do
@@ -82,8 +82,9 @@ module Decidim
         end
 
         it "stores the most recent membership's space path" do
+          expect(controller).to receive(:store_location_for)
+            .with(user, "/assemblies/#{assembly_new.slug}")
           subject
-          expect(session[:euf_redirect_url]).to eq("/assemblies/#{assembly_new.slug}")
         end
       end
 
@@ -94,7 +95,7 @@ module Decidim
           )
         end
 
-        it "returns the invite_redirect path without delegating to after_sign_in_path_for" do
+        it "returns the invite_redirect path" do
           expect(controller).not_to receive(:after_sign_in_path_for)
           expect(subject).to eq("/some/path")
         end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Decidim::Devise::InvitationsController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+      sign_in user
+      allow(controller).to receive(:after_sign_in_path_for).and_return("/account")
+    end
+
+    describe "#after_accept_path_for" do
+      subject { controller.after_accept_path_for(user) }
+
+      context "when the user has no private space membership" do
+        it "does not store euf_redirect_url in session" do
+          subject
+          expect(session[:euf_redirect_url]).to be_nil
+        end
+
+        it "delegates to after_sign_in_path_for" do
+          allow(controller).to receive(:after_sign_in_path_for).with(user).and_return("/account")
+          expect(subject).to eq("/account")
+          subject
+        end
+      end
+
+      context "when the user is a member of a private assembly" do
+        let(:assembly) { create(:assembly, :private, organization:) }
+
+        before do
+          create(:participatory_space_private_user, user:, privatable_to: assembly)
+        end
+
+        it "stores the assembly path in euf_redirect_url" do
+          subject
+          expect(session[:euf_redirect_url]).to eq("/assemblies/#{assembly.slug}")
+        end
+
+        it "delegates to after_sign_in_path_for" do
+          allow(controller).to receive(:after_sign_in_path_for).with(user).and_return("/account")
+          expect(subject).to eq("/account")
+          subject
+        end
+      end
+
+      context "when the user is a member of a private participatory process" do
+        let(:participatory_process) { create(:participatory_process, :private, organization:) }
+
+        before do
+          create(:participatory_space_private_user, user:, privatable_to: participatory_process)
+        end
+
+        it "stores the participatory process path in euf_redirect_url" do
+          subject
+          expect(session[:euf_redirect_url]).to eq("/processes/#{participatory_process.slug}")
+        end
+
+        it "delegates to after_sign_in_path_for" do
+          allow(controller).to receive(:after_sign_in_path_for).with(user).and_return("/account")
+          expect(subject).to eq("/account")
+          subject
+        end
+      end
+
+      context "when the user has multiple private space memberships" do
+        let(:assembly_old) { create(:assembly, :private, organization:) }
+        let(:assembly_new) { create(:assembly, :private, organization:) }
+
+        before do
+          create(:participatory_space_private_user, user:, privatable_to: assembly_old,
+                                                    created_at: 2.days.ago)
+          create(:participatory_space_private_user, user:, privatable_to: assembly_new,
+                                                    created_at: 1.day.ago)
+        end
+
+        it "stores the most recent membership's space path" do
+          subject
+          expect(session[:euf_redirect_url]).to eq("/assemblies/#{assembly_new.slug}")
+        end
+      end
+
+      context "when invite_redirect param is present" do
+        before do
+          allow(controller).to receive(:params).and_return(
+            ActionController::Parameters.new(invite_redirect: "/some/path")
+          )
+        end
+
+        it "returns the invite_redirect path without delegating to after_sign_in_path_for" do
+          expect(controller).not_to receive(:after_sign_in_path_for)
+          expect(subject).to eq("/some/path")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/euf_completion_spec.rb
+++ b/spec/system/euf_completion_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "EUF Force Completion" do
+  let(:organization) do
+    create(:organization, extra_user_fields: {
+             "enabled" => true,
+             "phone_number" => { "enabled" => true, "required" => true }
+           })
+  end
+  let(:password) { "dqCFgjfDbC7dPbrv" }
+  let(:user) { create(:user, :confirmed, password:, organization:, extended_data: {}) }
+  let!(:assembly) { create(:assembly, :published, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    allow(Rails.application.secrets).to receive(:dig).and_call_original
+    allow(Rails.application.secrets).to receive(:dig)
+      .with(:decidim, :extra_user_fields, :force_euf_completion)
+      .and_return(true)
+  end
+
+  context "when FORCE_EUF_COMPLETION is enabled and phone_number is missing" do
+    before { login_as user, scope: :user }
+
+    it "intercepts navigation and redirects to account" do
+      visit decidim_assemblies.assemblies_path
+      expect(page).to have_current_path(%r{/account})
+      expect(page).to have_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+    end
+
+    it "does not intercept /account itself" do
+      visit decidim.account_path
+      expect(page).to have_current_path(decidim.account_path, ignore_query: true)
+      expect(page).to have_css("form.edit_user")
+    end
+
+    it "does not intercept /users/sign_out" do
+      visit decidim.destroy_user_session_path
+      expect(page).to have_no_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+    end
+
+    context "when completing the profile from a normal navigation interception" do
+      it "redirects back to the original destination after saving" do
+        visit decidim_assemblies.assemblies_path
+        expect(page).to have_current_path(%r{/account})
+
+        within "form.edit_user" do
+          fill_in "Phone Number", with: "+33612345678", match: :first
+          find("*[type=submit]").click
+        end
+
+        within_flash_messages do
+          expect(page).to have_content("successfully")
+        end
+
+        expect(page).to have_current_path(decidim_assemblies.assemblies_path, ignore_query: true)
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:user) { create(:user, :confirmed, :admin, password:, organization:, extended_data: {}) }
+
+      it "does not intercept navigation" do
+        visit decidim_assemblies.assemblies_path
+        expect(page).to have_current_path(decidim_assemblies.assemblies_path, ignore_query: true)
+        expect(page).to have_no_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+      end
+    end
+  end
+
+  context "when FORCE_EUF_COMPLETION is disabled" do
+    before do
+      allow(Rails.application.secrets).to receive(:dig)
+        .with(:decidim, :extra_user_fields, :force_euf_completion)
+        .and_return(false)
+      login_as user, scope: :user
+    end
+
+    it "does not intercept navigation" do
+      visit decidim_assemblies.assemblies_path
+      expect(page).to have_current_path(decidim_assemblies.assemblies_path, ignore_query: true)
+      expect(page).to have_no_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+    end
+  end
+
+  context "when phone_number is already filled" do
+    let(:user) do
+      create(:user, :confirmed, password:, organization:,
+                                extended_data: { "phone_number" => "+33612345678" })
+    end
+
+    before { login_as user, scope: :user }
+
+    it "does not intercept navigation" do
+      visit decidim_assemblies.assemblies_path
+      expect(page).to have_current_path(decidim_assemblies.assemblies_path, ignore_query: true)
+      expect(page).to have_no_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+    end
+  end
+
+  context "when user is invited to a private assembly" do
+    let(:private_assembly) { create(:assembly, :published, :private, organization:) }
+    let(:invited_user) do
+      Decidim::User.invite!(
+        { email: "invited@example.com", name: "Invited User", organization: },
+        nil,
+        { extended_data: {} }
+      )
+    end
+
+    before do
+      create(:participatory_space_private_user, user: invited_user, privatable_to: private_assembly)
+    end
+
+    it "redirects to the assembly after completing the profile" do
+      visit decidim.accept_user_invitation_path(
+        invitation_token: invited_user.raw_invitation_token
+      )
+
+      within "#invitation_edit_user" do
+        fill_in "user[nickname]", with: "invited_user"
+        fill_in "user[password]", with: password, match: :first
+        check "user[tos_agreement]"
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_current_path(%r{/account})
+      expect(page).to have_content(I18n.t("decidim.extra_user_fields.force_euf_completion.alert"))
+
+      within "form.edit_user" do
+        fill_in "Phone Number", with: "+33612345678", match: :first
+        find("*[type=submit]").click
+      end
+
+      within_flash_messages do
+        expect(page).to have_content("successfully")
+      end
+
+      expect(page).to have_current_path(
+        decidim_assemblies.assembly_path(private_assembly.slug),
+        ignore_query: true
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description

Adds **Extra User Fields Force Completion with SSO**: when `DECIDIM_FORCE_EUF_COMPLETION=true`, users with missing extra user fields are intercepted on any page and redirected to `/account#user_<field>` until they fill in the required information. After completion, they are redirected to their original destination.

Also covers:
- Private space invitation flow: after accepting an invitation and completing their profile, users are redirected to the relevant assembly/process instead of `/account`
- Fix: when a user created via invitation connects via SSO for the first time, their existing `extended_data` is pre-filled into the omniauth registration form before validation, if all required fields are already present, the registration step is skipped entirely and the user is signed in directly

#### Testing

* Set `DECIDIM_FORCE_EUF_COMPLETION=true`, activate `phone_number` field on the organisation
* Log in as a user with no `phone_number` -> navigating to `/assemblies` redirects to `/account#user_phone_number` with an alert flash
* Fill in the phone number and save -> redirected back to `/assemblies`
* Log in as admin -> no redirection, normal navigation
* Invite a new user to a private assembly via email -> after accepting the invitation and filling in the phone number -> redirected to the assembly page
* With the same user, disconnect and reconnect via SSO for the first time -> if `phone_number` was already filled, the user is signed in directly without seeing the omniauth registration form


#### Tasks

- [x] Add specs
- [x] `ApplicationControllerExtends` - `check_euf_completion` before_action intercepting users with missing EUF fields on any non-whitelisted path
- [x] `AccountControllerExtends` - override `update` to redirect to stored destination after successful profile completion
- [x] `InvitationsControllerExtends` - override `after_accept_path_for` to store the private space path in session before redirecting to `/account`
- [x] `CreateOmniauthRegistrationExtends` - pre-fill EUF fields from existing user's `extended_data` before form validation; if all required fields are already present, the omniauth registration step is skipped and the user is signed in directly
- [x]  OmniauthRegistrationsControllerExtends - nil guard on strategy in sign_in_and_redirect
- [x] `config/secrets.yml` — `FORCE_EUF_COMPLETION` env var support
- [x] i18n `fr`/`en` — alert message for EUF completion

#### Extra information

The EUF interception is fully opt-in via `FORCE_EUF_COMPLETION` env var (defaults to `false`). Without it, no behaviour change on any existing flow.