### PR TITLE
fix: add missing locales

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -206,3 +206,5 @@ ignore_unused:
   - decidim.initiatives.form.edit_documents
   - layouts.decidim.initiative_creation_header.*
   - decidim.initiatives.signatures.workflows.legacy_signature_handler.*
+  - activemodel.attributes.sms_code.*
+  - decidim.budgets.creation.text

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,9 @@ en:
         document_number: Unique number
       participatory_process:
         copy_landing_page_blocks: Copy landing page blocks
+      sms_code:
+        phone_country: Country code
+        phone_number: Phone number
   activerecord:
     models:
       decidim:
@@ -251,6 +254,8 @@ en:
         models:
           project:
             name: Project
+      creation:
+        text: They were added to this budget
     budgets_importer:
       actions:
         import: Import projects to budget

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -16,6 +16,9 @@ fr:
         document_number: Numéro unique
       participatory_process:
         copy_landing_page_blocks: Copier les blocs de la page d'accueil
+      sms_code:
+        phone_country: Pays
+        phone_number: Numéro de téléphone
   activerecord:
     models:
       decidim:
@@ -259,6 +262,8 @@ fr:
         models:
           project:
             name: Projet
+      creation:
+        text: Ce projet a été ajouté à ce budget
     budgets_importer:
       actions:
         import: Importer des projets


### PR DESCRIPTION
#### :tophat: Description
Addition of two missing locales : 
- First one is related to phone_number & country code
- Second one is related to budgets creation text when a proposal is linked to a project

#### Testing

**Locale 1 - Phone country & Phone number (Ephemeral Authorization Handler)**

* Log in as admin
* Access Backoffice > Settings > Permissions
* Enable ephemeral verification on a budget component and link it to an existing authorization method
* Log out
* Access the budget component as an unregistered visitor
* Click on a restricted action (vote)
* Check that the verification form displays "Pays" and "Numéro de téléphone" instead of "Phone country" and "Phone number"

**Locale 2 - Budget project creation text**

* Log in as admin
* Access Backoffice > Budgets
* Create or access an existing budget project linked to a proposal
* Log out (or stay logged in)
* Access the project public page
* Click on the "Historique" tab
* Check that the creation entry displays "Ce projet a été ajouté à ce budget" instead of `translation missing: fr.decidim.budgets.creation.text`

#### :pushpin: Related Issues

- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?filterQuery=assignee%3AAyakorK&pane=issue&itemId=201560911&issue=OpenSourcePolitics%7Cintern-tasks%7C456
