### PR TITLE
Fix: add missing translations for initiatives

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -113,6 +113,7 @@ ignore_missing:
   - decidim.budgets.projects.budget_summary.vote
   - decidim.budgets.projects.budget_summary.cancel_order
   - decidim.budgets.projects.budget_confirm.are_you_sure
+  - decidim.initiatives.initiatives.pending_initiatives.*
 
 
 # Consider these keys used:
@@ -206,3 +207,5 @@ ignore_unused:
   - decidim.initiatives.form.edit_documents
   - layouts.decidim.initiative_creation_header.*
   - decidim.initiatives.signatures.workflows.legacy_signature_handler.*
+  # initiatives
+  - decidim.initiatives.initiatives.pending_initiatives.*

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -316,6 +316,8 @@ de:
       initiatives:
         index_header:
           new_initiative: Neue Initiative
+        pending_initiatives:
+          description: Diese Initiativen sind noch nicht öffentlich. Bitte prüfen Sie sie und reichen Sie sie zur technischen Validierung ein, damit sie veröffentlicht werden können.
     meetings:
       actions:
         invalid_destroy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -522,6 +522,10 @@ fr:
         edit_attachments: Modifier les pièces jointes
         edit_image: Modifier l'Image
         image_legend: "(Facultatif) Ajouter une image"
+      initiatives:
+        pending_initiatives:
+          description: Ces initiatives ne sont pas encore publiques. Veuillez les examiner et les soumettre pour validation technique afin qu'elles puissent être rendues publiques.
+          title: Brouillons et initiatives en attente
       signatures:
         workflows:
           legacy_signature_handler:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -248,6 +248,10 @@ nl:
           highlighted_initiatives:
             active_initiatives: Active initiatives
             see_all_initiatives: See all initiatives
+      initiatives:
+        pending_initiatives:
+          description: Deze initiatieven zijn nog niet openbaar. Bekijk ze en dien ze in voor technische validatie, zodat ze openbaar kunnen worden gemaakt.
+          title: Concepten en lopende initiatieven
       unavailable_scope: Unavailable scope
     meetings:
       application_helper:


### PR DESCRIPTION
#### :tophat: Description
This PR adds missing translations for initiatives.

#### Testing
As a logged in french user, create a new initiative and send it to validation.
See that translations for title & description are well applied (cf screenshot) 

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=203738282&issue=OpenSourcePolitics%7Cintern-tasks%7C458


#### :camera: Screenshots
<img width="1230" height="591" alt="Capture d’écran 2026-06-29 à 13 52 50" src="https://github.com/user-attachments/assets/9de38213-d4c5-45be-87c7-24fc69c369b8" />
