### PR TITLE
fix: Display correctly an error when trying to update with invalid image

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module DecidimApp
       require "extends/commands/decidim/participatory_processes/admin/copy_participatory_process_extends"
       require "extends/commands/decidim/create_omniauth_registration_extends"
       require "extends/commands/decidim/forms/admin/update_questionnaire_extends"
+      require "extends/commands/decidim/admin/content_blocks/update_content_block_extends"
       # forms
       require "extends/forms/decidim/assemblies/admin/assembly_copy_form_extends"
       require "extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends"
@@ -31,6 +32,7 @@ module DecidimApp
       require "extends/forms/decidim/omniauth_registration_form_extends"
       require "extends/forms/decidim/account_form_extends"
       require "extends/forms/decidim/editor_image_form_extends"
+      require "extends/forms/decidim/admin/content_block_form_extends"
       # controllers
       require "extends/controllers/decidim/admin/scopes_controller_extends"
       require "extends/controllers/decidim/scopes_controller_extends"
@@ -43,6 +45,8 @@ module DecidimApp
       require "extends/controllers/decidim/budgets/projects_controller_extends"
       require "extends/controllers/decidim/proposals/admin/proposal_states_controller_extends"
       require "extends/controllers/decidim/proposals/proposals_controller_extends"
+      require "extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends"
+      require "extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends"
       # helpers
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       require "extends/helpers/decidim/omniauth_helper_extends"
@@ -57,6 +61,7 @@ module DecidimApp
       require "extends/models/decidim/accountability/result_extends"
       require "extends/models/decidim/proposals/proposal_state_extends"
       require "extends/models/decidim/searchable_author_extends"
+      require "extends/models/decidim/content_block_attachment_extends"
       # permissions
       require "extends/permissions/initiatives/permissions_extends"
       # presenters

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,9 @@ en:
       attachments:
         form:
           send_notification_to_followers: Send a notification to all the people following the consultation who have agreed to receive email notifications
+      content_blocks:
+        update:
+          error: There was an error updating the content block
       models:
         assembly:
           fields:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -42,6 +42,9 @@ fr:
       attachments:
         form:
           send_notification_to_followers: Envoyer une notification à toutes les personnes qui suivent la concertation ayant accepté de recevoir des notifications par mail
+      content_blocks:
+        update:
+          error: Une erreur est survenue lors de la mise à jour du bloc de contenu.
       models:
         assembly:
           fields:

--- a/lib/extends/commands/decidim/admin/content_blocks/update_content_block_extends.rb
+++ b/lib/extends/commands/decidim/admin/content_blocks/update_content_block_extends.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module UpdateContentBlockExtends
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def update_content_block_images
+      params = form.respond_to?(:image_params) ? form.image_params : (form.attributes["images"] || {})
+      content_block.manifest.images.each do |image_config|
+        image_name = image_config[:name]
+        val = params[image_name] || params[image_name.to_s]
+        if val
+          content_block.images_container.send("#{image_name}=", val)
+        elsif params[:"remove_#{image_name}"] == "1" || params["remove_#{image_name}"] == "1"
+          content_block.images_container.send("#{image_name}=", nil)
+        end
+      end
+    end
+  end
+end
+
+Decidim::Admin::ContentBlocks::UpdateContentBlock.include(UpdateContentBlockExtends)

--- a/lib/extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends.rb
+++ b/lib/extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module AssemblyLandingPageContentBlocksControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def update
+      enforce_permission_to_update_resource
+
+      @form = form(Decidim::Admin::ContentBlockForm).from_params(params)
+
+      Decidim::Admin::ContentBlocks::UpdateContentBlock.call(@form, content_block, content_block_scope) do
+        on(:ok) do
+          redirect_to edit_resource_landing_page_path
+        end
+        on(:invalid) do
+          flash.now[:error] = content_block.errors.full_messages.join(", ").presence || t("decidim.admin.content_blocks.update.error", default: "Erreur lors de la mise à jour")
+          render "decidim/admin/shared/landing_page_content_blocks/edit"
+        end
+      end
+    end
+  end
+end
+
+Decidim::Assemblies::Admin::AssemblyLandingPageContentBlocksController.include(AssemblyLandingPageContentBlocksControllerExtends)

--- a/lib/extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends.rb
+++ b/lib/extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ParticipatoryProcessLandingPageContentBlocksControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def update
+      enforce_permission_to_update_resource
+
+      @form = form(Decidim::Admin::ContentBlockForm).from_params(params)
+
+      Decidim::Admin::ContentBlocks::UpdateContentBlock.call(@form, content_block, content_block_scope) do
+        on(:ok) do
+          redirect_to edit_resource_landing_page_path
+        end
+        on(:invalid) do
+          flash.now[:error] = content_block.errors.full_messages.join(", ").presence || t("decidim.admin.content_blocks.update.error", default: "Erreur lors de la mise à jour")
+          render "decidim/admin/shared/landing_page_content_blocks/edit"
+        end
+      end
+    end
+  end
+end
+
+Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessLandingPageContentBlocksController.include(ParticipatoryProcessLandingPageContentBlocksControllerExtends)

--- a/lib/extends/forms/decidim/admin/content_block_form_extends.rb
+++ b/lib/extends/forms/decidim/admin/content_block_form_extends.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ContentBlockFormExtends
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :images, Hash
+  end
+
+  def map_model(model)
+    @images_container = model.images_container
+    self.images = {}
+  end
+
+  def images=(value)
+    if value.is_a?(Hash)
+      super(value.transform_keys(&:to_sym))
+    else
+      @images_container = value
+      super({})
+    end
+  end
+
+  def images
+    @images_container ||= begin
+      cb_id = id.presence
+      if cb_id
+        scope = context.try(:current_participatory_space)
+        cb = scope ? Decidim::ContentBlock.find_by(id: cb_id, scoped_resource_id: scope.id) : Decidim::ContentBlock.find_by(id: cb_id)
+        cb&.images_container
+      end
+    end
+  end
+
+  def image_params
+    attributes["images"] || {}
+  end
+end
+
+Decidim::Admin::ContentBlockForm.include(ContentBlockFormExtends)

--- a/lib/extends/models/decidim/content_block_attachment_extends.rb
+++ b/lib/extends/models/decidim/content_block_attachment_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContentBlockAttachmentExtends
+  def uploader
+    return if content_block.blank?
+
+    config = content_block.manifest.images.find do |image_config|
+      image_config[:name].to_s == name.to_s
+    end
+
+    config = content_block.manifest.images.first if config.blank? && name.blank?
+
+    return if config.blank?
+
+    config[:uploader].constantize
+  end
+end
+
+Decidim::ContentBlockAttachment.prepend(ContentBlockAttachmentExtends)

--- a/spec/commands/decidim/admin/content_blocks/update_content_block_extends_spec.rb
+++ b/spec/commands/decidim/admin/content_blocks/update_content_block_extends_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    module ContentBlocks
+      describe UpdateContentBlock do
+        let(:organization) { create(:organization) }
+        let(:assembly) { create(:assembly, organization:) }
+        let(:scope) { assembly }
+        let(:content_block) do
+          create(:content_block,
+                 manifest_name: "hero",
+                 scope_name: "assembly_homepage",
+                 scoped_resource_id: assembly.id,
+                 organization:)
+        end
+
+        let(:form) do
+          Decidim::Admin::ContentBlockForm.from_params(
+            "id" => content_block.id,
+            "settings" => { "button_text_fr" => "Test" },
+            "images" => {}
+          ).with_context(current_organization: organization)
+        end
+
+        context "when the form has no image params" do
+          it "does not raise and broadcasts :ok" do
+            result = nil
+
+            expect do
+              described_class.call(form, content_block, scope) do
+                on(:ok) { result = :ok }
+                on(:invalid) { result = :invalid }
+              end
+            end.not_to raise_error
+
+            expect(result).to eq(:ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/admin/content_block_form_extends_spec.rb
+++ b/spec/forms/decidim/admin/content_block_form_extends_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ContentBlockForm do
+      subject do
+        described_class.from_params(attributes).with_context(
+          current_organization: organization
+        )
+      end
+
+      let(:organization) { create(:organization) }
+      let(:assembly) { create(:assembly, organization:) }
+      let(:content_block) do
+        create(:content_block,
+               manifest_name: "hero",
+               scope_name: "assembly_homepage",
+               scoped_resource_id: assembly.id,
+               organization:)
+      end
+
+      let(:attributes) do
+        {
+          "id" => content_block.id,
+          "settings" => { "button_text_fr" => "Test" },
+          "images" => { "background_image" => "some-signed-id" }
+        }
+      end
+
+      describe "#images" do
+        it "returns an images_container, never the raw submitted hash" do
+          expect(subject.images).not_to be_a(Hash)
+        end
+      end
+
+      describe "#image_params" do
+        it "returns the raw submitted params for the command to consume" do
+          expect(subject.image_params).to be_a(Hash)
+          expect(subject.image_params[:background_image]).to eq("some-signed-id")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/decidim/content_block_attachment_extends_spec.rb
+++ b/spec/models/decidim/content_block_attachment_extends_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ContentBlockAttachment do
+    let(:organization) { create(:organization) }
+    let(:assembly) { create(:assembly, organization:) }
+    let(:content_block) do
+      create(:content_block,
+             manifest_name: "hero",
+             scope_name: "assembly_homepage",
+             scoped_resource_id: assembly.id,
+             organization:)
+    end
+
+    describe "#uploader" do
+      context "when the attachment is persisted with a name matching the manifest" do
+        subject { content_block.attachments.find_or_initialize_by(name: "background_image") }
+
+        it "returns the configured uploader" do
+          expect(subject.uploader).to eq(Decidim::BackgroundImageUploader)
+        end
+      end
+
+      context "when the attachment is built without a name" do
+        subject { content_block.attachments.build }
+
+        it "does not return nil" do
+          expect(subject.uploader).not_to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/decidim/assemblies/admin/landing_page_content_blocks_spec.rb
+++ b/spec/requests/decidim/assemblies/admin/landing_page_content_blocks_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Assembly landing page content blocks update" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:assembly) { create(:assembly, organization:) }
+  let!(:content_block) do
+    create(:content_block,
+           manifest_name: "hero",
+           scope_name: "assembly_homepage",
+           scoped_resource_id: assembly.id,
+           organization:)
+  end
+
+  before do
+    login_as user, scope: :user
+    host! organization.host
+  end
+
+  def signed_id_for(file_path, content_type)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(file_path),
+      filename: File.basename(file_path),
+      content_type:
+    )
+    blob.signed_id
+  end
+
+  context "when uploading an oversized image" do
+    it "does not crash and shows the validation error on re-render" do
+      signed_id = signed_id_for(Decidim::Dev.asset("5000x5000.png"), "image/png")
+
+      patch decidim_admin_assemblies.assembly_landing_page_content_block_path(assembly, content_block),
+            params: {
+              content_block: {
+                settings: { button_text_fr: "Test" },
+                images: { background_image: signed_id }
+              }
+            }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("We're sorry, but something went wrong")
+      expect(response.body).to include("Images container")
+      expect(content_block.reload.images_container.background_image).not_to be_attached
+    end
+  end
+
+  context "when uploading a valid image" do
+    it "saves successfully" do
+      signed_id = signed_id_for(Decidim::Dev.asset("city.jpeg"), "image/jpeg")
+
+      patch decidim_admin_assemblies.assembly_landing_page_content_block_path(assembly, content_block),
+            params: {
+              content_block: {
+                settings: { button_text_fr: "Test" },
+                images: { background_image: signed_id }
+              }
+            }
+
+      expect(response).to redirect_to(decidim_admin_assemblies.edit_assembly_landing_page_path(assembly))
+      expect(content_block.reload.images_container.background_image).to be_attached
+    end
+  end
+end

--- a/spec/requests/decidim/participatory_processes/admin/landing_page_content_blocks_spec.rb
+++ b/spec/requests/decidim/participatory_processes/admin/landing_page_content_blocks_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Participatory process landing page content blocks update" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let!(:content_block) do
+    create(:content_block,
+           manifest_name: "hero",
+           scope_name: "participatory_process_homepage",
+           scoped_resource_id: participatory_process.id,
+           organization:)
+  end
+
+  before do
+    login_as user, scope: :user
+    host! organization.host
+  end
+
+  def signed_id_for(file_path, content_type)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(file_path),
+      filename: File.basename(file_path),
+      content_type:
+    )
+    blob.signed_id
+  end
+
+  context "when uploading an oversized image" do
+    it "does not crash and shows the validation error on re-render" do
+      signed_id = signed_id_for(Decidim::Dev.asset("5000x5000.png"), "image/png")
+
+      patch decidim_admin_participatory_processes.participatory_process_landing_page_content_block_path(participatory_process, content_block),
+            params: {
+              content_block: {
+                settings: { button_text_fr: "Test" },
+                images: { background_image: signed_id }
+              }
+            }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("We're sorry, but something went wrong")
+      expect(response.body).to include("Images container")
+      expect(content_block.reload.images_container.background_image).not_to be_attached
+    end
+  end
+
+  context "when uploading a valid image" do
+    it "saves successfully" do
+      signed_id = signed_id_for(Decidim::Dev.asset("city.jpeg"), "image/jpeg")
+
+      patch decidim_admin_participatory_processes.participatory_process_landing_page_content_block_path(participatory_process, content_block),
+            params: {
+              content_block: {
+                settings: { button_text_fr: "Test" },
+                images: { background_image: signed_id }
+              }
+            }
+
+      expect(response).to redirect_to(decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(participatory_process))
+      expect(content_block.reload.images_container.background_image).to be_attached
+    end
+  end
+end

--- a/spec/system/decidim/assemblies/admin/admin_manages_landing_page_content_blocks_spec.rb
+++ b/spec/system/decidim/assemblies/admin/admin_manages_landing_page_content_blocks_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages assembly landing page content blocks" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:assembly) { create(:assembly, organization:) }
+  let!(:content_block) do
+    create(:content_block,
+           manifest_name: "hero",
+           scope_name: "assembly_homepage",
+           scoped_resource_id: assembly.id,
+           organization:)
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_assemblies.edit_assembly_landing_page_content_block_path(assembly, content_block)
+  end
+
+  context "when uploading an oversized background image" do
+    it "shows a validation error instead of crashing" do
+      dynamically_attach_file(:content_block_images_background_image, Decidim::Dev.asset("5000x5000.png"))
+
+      within ".edit_content_block" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_no_content("We're sorry, but something went wrong")
+      expect(page).to have_content("Images container is invalid")
+    end
+  end
+
+  context "when uploading a valid background image" do
+    it "saves the content block and redirects to the landing page" do
+      dynamically_attach_file(:content_block_images_background_image, Decidim::Dev.asset("city.jpeg"))
+
+      within ".edit_content_block" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_no_content("Images container is invalid")
+      expect(page).to have_current_path(decidim_admin_assemblies.edit_assembly_landing_page_path(assembly))
+      expect(content_block.reload.images_container.background_image).to be_attached
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description

Fixes a 500 error (`undefined method 'validators_on' for NilClass:Class`) that occurred when an admin uploaded an oversized image to a landing page content block (hero) on an assembly or a participatory process. Instead of showing a validation error, the application crashed.

The root cause was layered across three issues:

1. `ContentBlockAttachment#uploader` could return `nil` when the attachment had no resolved `name`, which made `validates_upload` blow up while rebuilding `images_container` (`undefined method 'validators_on' for NilClass:Class`).
2. Once that was patched, a second crash surfaced: after a failed validation (ROLLBACK), the form re-render relied on `form.object.images`, which returned a raw params `Hash` instead of the `images_container` expected by the form builder. This caused the same kind of crash on a different class (`Hash` has no `validators_on`).
3. Once both crashes were fixed, the form re-rendered correctly but silently. The admin had no way of knowing the upload had failed, since the controller's `on(:invalid)` callback never set a flash message.

The fix touches four areas:
- `ContentBlockAttachment#uploader` now falls back to the manifest's first uploader instead of returning `nil`.
- `ContentBlockForm` now cleanly separates `images` (always returns the `images_container`, used by the form builder) from `image_params` (the raw submitted signed IDs, used by the command).
- `UpdateContentBlock` now reads from `form.image_params` instead of `form.images`.
- Both the assembly and participatory process landing page content blocks controllers now set a flash error message when the update is invalid, so the admin actually sees feedback instead of a silently re-rendered form.

#### Testing

* Log in as admin
* Go to an Assembly (or Participatory Process) > Landing page > Hero image and CTA
* Try uploading a background image with dimensions larger than 3840x3840px
* Submit the form
* See a validation error message instead of a 500 page
* Try uploading a valid image (e.g. under the size/dimension limits)
* See it save successfully and redirect back to the landing page

#### Tasks

- [x] Add specs covering the bug at unit (`ContentBlockAttachment#uploader`, `ContentBlockForm`), command (`UpdateContentBlock`), request (full HTTP flow for assemblies and participatory processes), and system level (full UI upload flow)
- [x] Patch `ContentBlockAttachment#uploader` to never return `nil`
- [x] Separate `ContentBlockForm#images` (images_container) from `#image_params` (raw signed IDs)
- [x] Update `UpdateContentBlock` command to consume `image_params`
- [x] Add user-facing flash error on invalid update for assemblies and participatory processes landing page content blocks
- [x] Verify no regression on existing specs (copy assembly/process, attachments, comments forms)