### PR TITLE
 fix: Fix proposal order issue on "recent"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,7 @@ module DecidimApp
       require "extends/controllers/decidim/proposals/proposals_controller_extends"
       require "extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends"
       require "extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends"
+      require "extends/controllers/decidim/proposals/proposals_controller_reorder_extends"
       # helpers
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       require "extends/helpers/decidim/omniauth_helper_extends"

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
@@ -1,61 +1,55 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module Decidim
   module Proposals
     module ProposalsControllerExtends
-      extend ActiveSupport::Concern
+      def index
+        if component_settings.participatory_texts_enabled?
+          @proposals = Decidim::Proposals::Proposal
+                       .where(component: current_component)
+                       .published
+                       .not_hidden
+                       .only_amendables
+                       .includes(:category, :scope, :attachments, :coauthorships)
+                       .order(position: :asc)
+          render "decidim/proposals/proposals/participatory_texts/participatory_text"
+        else
+          @proposals = search.result
+          @proposals = reorder(@proposals)
+          ids = @proposals.ids
+          @proposals = Decidim::Proposals::Proposal.where(id: ids)
+                                                   .order(Arel.sql("array_position(ARRAY[#{ids.join(",")}]::bigint[], decidim_proposals_proposals.id)"))
+                                                   .page(params[:page])
+                                                   .per(per_page)
+          @proposals = @proposals.includes(:component, :coauthorships, :attachments)
 
-      included do
-        def index
-          if component_settings.participatory_texts_enabled?
-            @proposals = Decidim::Proposals::Proposal
-                         .where(component: current_component)
-                         .published
-                         .not_hidden
-                         .only_amendables
-                         .includes(:category, :scope, :attachments, :coauthorships)
-                         .order(position: :asc)
-            render "decidim/proposals/proposals/participatory_texts/participatory_text"
-          else
-            @proposals = search.result
-            @proposals = reorder(@proposals)
-            ids = @proposals.ids
-            @proposals = Decidim::Proposals::Proposal.where(id: ids)
-                                                     .order(Arel.sql("position(decidim_proposals_proposals.id::text in '#{ids.join(",")}')"))
-                                                     .page(params[:page])
-                                                     .per(per_page)
-            @proposals = @proposals.includes(:component, :coauthorships, :attachments)
-
-            @voted_proposals = if current_user
-                                 ProposalVote.where(
-                                   author: current_user,
-                                   proposal: @proposals.pluck(:id)
-                                 ).pluck(:decidim_proposal_id)
-                               else
-                                 []
-                               end
-          end
+          @voted_proposals = if current_user
+                               ProposalVote.where(
+                                 author: current_user,
+                                 proposal: @proposals.pluck(:id)
+                               ).pluck(:decidim_proposal_id)
+                             else
+                               []
+                             end
         end
+      end
 
-        private
+      private
 
-        def default_filter_params
-          {
-            activity: "all",
-            related_to: "",
-            search_text_cont: "",
-            type: "all",
-            with_any_category: nil,
-            with_any_origin: nil,
-            with_any_scope: nil,
-            with_any_state: default_states
-          }
-        end
+      def default_filter_params
+        {
+          activity: "all",
+          related_to: "",
+          search_text_cont: "",
+          type: "all",
+          with_any_category: nil,
+          with_any_origin: nil,
+          with_any_scope: nil,
+          with_any_state: default_states
+        }
       end
     end
   end
 end
 
-Decidim::Proposals::ProposalsController.include(Decidim::Proposals::ProposalsControllerExtends)
+Decidim::Proposals::ProposalsController.prepend(Decidim::Proposals::ProposalsControllerExtends)

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_reorder_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_reorder_extends.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module ProposalsControllerReorderTiebreaker
+      private
+
+      def reorder(proposals)
+        super.order(id: :desc)
+      end
+    end
+  end
+end
+
+Decidim::Proposals::ProposalsController.prepend(
+  Decidim::Proposals::ProposalsControllerReorderTiebreaker
+)

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -31,7 +31,7 @@ module Decidim
             get :index
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:index)
-            expect(assigns(:proposals).order_values).to eq(["position(decidim_proposals_proposals.id::text in '')"])
+            expect(assigns(:proposals).order_values).to eq(["array_position(ARRAY[]::bigint[], decidim_proposals_proposals.id)"])
           end
 
           it "sets two different collections" do


### PR DESCRIPTION
#### :tophat: Description

Fixes unstable/incorrect sort order on the public proposals index (`?order=recent`, `az`, `za`, etc.), which caused old proposals to sometimes appear ahead of much more recent ones.

Two separate bugs, both fixed:

1. The final re-ordering step in `proposals_controller_extends.rb` used `position(id::text in '...')` to preserve sort order after pagination. Since that's a plain substring match, a short ID (e.g. `133`) that's a substring of a longer, more recent ID (e.g. `2133`) gets sorted next to it, regardless of actual date. Replaced with `array_position(...)`, which matches IDs exactly instead of as text.
2. None of the sort options (`recent`, `most_voted`, `az`, etc.) had a tie-breaker. When several proposals tie on the sorted column (same `published_at` from an import, several proposals with 0 votes, etc.), Postgres falls back to physical row order, which isn't stable. Added `.order(id: :desc)` as a tie-breaker via a `prepend`ed `reorder`.

Also found along the way: our `ProposalsControllerExtends` override was being silently overwritten on every request by `decidim_awesome`'s `MemoizeExtraFields` concern. Switched it from `include` to `prepend` to fix that.

#### Testing

In `rails console`, on a Proposals component:

```ruby
component = Decidim::Component.find(YOUR_COMPONENT_ID)

ActiveRecord::Base.connection.execute("SELECT setval('decidim_proposals_proposals_id_seq', 89)")
short_old = Decidim::Proposals::Proposal.new(component: component, title: { "en" => "AAA short old id" }, body: { "en" => "test" })
short_old.save!(validate: false)
short_old.update_columns(created_at: "2021-01-01".to_time, published_at: "2021-01-01".to_time)

ActiveRecord::Base.connection.execute("SELECT setval('decidim_proposals_proposals_id_seq', 899)")
long_recent = Decidim::Proposals::Proposal.new(component: component, title: { "en" => "ZZZ long recent id" }, body: { "en" => "test" })
long_recent.save!(validate: false)
long_recent.update_columns(created_at: Time.current, published_at: Time.current)

import_time = 3.years.ago
5.times do |i|
  p = Decidim::Proposals::Proposal.new(component: component, title: { "en" => "Tied import #{i}" }, body: { "en" => "test" })
  p.save!(validate: false)
  p.update_columns(created_at: import_time, published_at: import_time)
end
```

Expected, on `/proposals?order=recent`:
* Sort is chronological: "ZZZ long recent id" on top, "AAA short old id" near the bottom with the other 2021-dated content.
* Reloading the page repeatedly keeps the "Tied import" proposals in the same order every time.

Also check `/proposals?order=az` for tied/duplicate titles — order should stay stable across reloads.

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=211340855&issue=OpenSourcePolitics%7Cintern-tasks%7C466

#### Tasks
- [x] Fix proposals controller extends
- [x] Add new extends that adds a tie-breaker to the `reorder` method for all sort options