### PR TITLE
fix: Add missing locales on SK date picker

### DIFF
--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,0 +1,16 @@
+---
+sk:
+  date:
+    buttons:
+      close: "Zavrieť"
+      select: "Vybrať"
+    formats:
+      order: d-m-y
+      separator: "."
+      help:
+        date_format: 'Formát: dd.mm.rrrr'
+  time:
+    clock_format: 24
+    formats:
+      help:
+        time_format: 'Formát: hh:mm'


### PR DESCRIPTION
#### :tophat: Description

On the Banska platform (`sk` locale), the admin datepicker displayed `undefined` in several places (help text, aria-labels, calendar close button), and in some cases blocked event creation/editing entirely (validation stuck on date fields).

The datepicker JS component (`generate_datepicker.js` / `form_date_picker.js`) fetches its translations via `getDictionary()` on the `date.formats`, `time`, and `date.buttons` keys. These keys were missing from `sk.yml`, so the JS received `undefined` instead of a string and rendered it as-is in the DOM.

#### Testing
* Log in as admin on an organization with the `sk` locale active
* Create or edit an event or assembly (any form with a date field)
* Check that the help text under the datepicker shows readable text (no more `undefined`)
* Open the calendar, check that the close button shows text instead of `undefined`
* Pick a date and confirm it saves with the correct format (day/month not swapped)

Note: local reproduction is possible but kind of hard, since many other `sk.yml` keys are missing beyond the datepicker ones, there's no clean way to isolate just `sk` for testing. Testing was done by adding temporary locales that were deleted afterwards

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=214146921&issue=OpenSourcePolitics%7Cintern-tasks%7C469

#### Tasks
- [x] Add missing locales