### PR TITLE
Release v3.10.3

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,7 @@ module DecidimApp
       require "extends/controllers/decidim/proposals/proposals_controller_extends"
       require "extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends"
       require "extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends"
+      require "extends/controllers/decidim/proposals/proposals_controller_reorder_extends"
       # helpers
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       require "extends/helpers/decidim/omniauth_helper_extends"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,5 +1,10 @@
 ---
 sk:
+  decidim:
+    assemblies:
+      assemblies:
+        show:
+          title: "O tejto iniciatíve"
   date:
     buttons:
       close: "Zavrieť"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,0 +1,16 @@
+---
+sk:
+  date:
+    buttons:
+      close: "Zavrieť"
+      select: "Vybrať"
+    formats:
+      order: d-m-y
+      separator: "."
+      help:
+        date_format: 'Formát: dd.mm.rrrr'
+  time:
+    clock_format: 24
+    formats:
+      help:
+        time_format: 'Formát: hh:mm'

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_extends.rb
@@ -1,61 +1,55 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module Decidim
   module Proposals
     module ProposalsControllerExtends
-      extend ActiveSupport::Concern
+      def index
+        if component_settings.participatory_texts_enabled?
+          @proposals = Decidim::Proposals::Proposal
+                       .where(component: current_component)
+                       .published
+                       .not_hidden
+                       .only_amendables
+                       .includes(:category, :scope, :attachments, :coauthorships)
+                       .order(position: :asc)
+          render "decidim/proposals/proposals/participatory_texts/participatory_text"
+        else
+          @proposals = search.result
+          @proposals = reorder(@proposals)
+          ids = @proposals.ids
+          @proposals = Decidim::Proposals::Proposal.where(id: ids)
+                                                   .order(Arel.sql("array_position(ARRAY[#{ids.join(",")}]::bigint[], decidim_proposals_proposals.id)"))
+                                                   .page(params[:page])
+                                                   .per(per_page)
+          @proposals = @proposals.includes(:component, :coauthorships, :attachments)
 
-      included do
-        def index
-          if component_settings.participatory_texts_enabled?
-            @proposals = Decidim::Proposals::Proposal
-                         .where(component: current_component)
-                         .published
-                         .not_hidden
-                         .only_amendables
-                         .includes(:category, :scope, :attachments, :coauthorships)
-                         .order(position: :asc)
-            render "decidim/proposals/proposals/participatory_texts/participatory_text"
-          else
-            @proposals = search.result
-            @proposals = reorder(@proposals)
-            ids = @proposals.ids
-            @proposals = Decidim::Proposals::Proposal.where(id: ids)
-                                                     .order(Arel.sql("position(decidim_proposals_proposals.id::text in '#{ids.join(",")}')"))
-                                                     .page(params[:page])
-                                                     .per(per_page)
-            @proposals = @proposals.includes(:component, :coauthorships, :attachments)
-
-            @voted_proposals = if current_user
-                                 ProposalVote.where(
-                                   author: current_user,
-                                   proposal: @proposals.pluck(:id)
-                                 ).pluck(:decidim_proposal_id)
-                               else
-                                 []
-                               end
-          end
+          @voted_proposals = if current_user
+                               ProposalVote.where(
+                                 author: current_user,
+                                 proposal: @proposals.pluck(:id)
+                               ).pluck(:decidim_proposal_id)
+                             else
+                               []
+                             end
         end
+      end
 
-        private
+      private
 
-        def default_filter_params
-          {
-            activity: "all",
-            related_to: "",
-            search_text_cont: "",
-            type: "all",
-            with_any_category: nil,
-            with_any_origin: nil,
-            with_any_scope: nil,
-            with_any_state: default_states
-          }
-        end
+      def default_filter_params
+        {
+          activity: "all",
+          related_to: "",
+          search_text_cont: "",
+          type: "all",
+          with_any_category: nil,
+          with_any_origin: nil,
+          with_any_scope: nil,
+          with_any_state: default_states
+        }
       end
     end
   end
 end
 
-Decidim::Proposals::ProposalsController.include(Decidim::Proposals::ProposalsControllerExtends)
+Decidim::Proposals::ProposalsController.prepend(Decidim::Proposals::ProposalsControllerExtends)

--- a/lib/extends/controllers/decidim/proposals/proposals_controller_reorder_extends.rb
+++ b/lib/extends/controllers/decidim/proposals/proposals_controller_reorder_extends.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module ProposalsControllerReorderTiebreaker
+      private
+
+      def reorder(proposals)
+        super.order(id: :desc)
+      end
+    end
+  end
+end
+
+Decidim::Proposals::ProposalsController.prepend(
+  Decidim::Proposals::ProposalsControllerReorderTiebreaker
+)

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -31,7 +31,7 @@ module Decidim
             get :index
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:index)
-            expect(assigns(:proposals).order_values).to eq(["position(decidim_proposals_proposals.id::text in '')"])
+            expect(assigns(:proposals).order_values).to eq(["array_position(ARRAY[]::bigint[], decidim_proposals_proposals.id)"])
           end
 
           it "sets two different collections" do


### PR DESCRIPTION
This pull request introduces improvements to proposal ordering logic, adds Slovak locale translations, and refines the way controller extensions are included in the codebase. The main focus is on enhancing the ordering of proposals and making the code more maintainable and extensible.

**Proposal ordering improvements:**

* Introduced a new extension module `ProposalsControllerReorderTiebreaker` in `proposals_controller_reorder_extends.rb` to ensure proposals with the same ordering are consistently sorted by descending `id` as a tiebreaker. This module is prepended to the controller for higher priority. [[1]](diffhunk://#diff-33bf4aedef7242b6acc0ac8a7791e621de751554d57f7580359164d58052b73eR1-R17) [[2]](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9R52)
* Changed the SQL ordering logic in `proposals_controller_extends.rb` from using `position(... in ...)` to `array_position`, which is more efficient and compatible with PostgreSQL for ordering proposals by a specific list of IDs.
* Updated the RSpec test in `proposals_controller_spec.rb` to match the new ordering logic using `array_position`.

**Codebase maintainability:**

* Changed the way controller extensions are applied: switched from `include` to `prepend` for `ProposalsControllerExtends`, ensuring that custom logic takes precedence over the original methods.

**Localization:**

* Added Slovak (`sk`) translations for assemblies and date/time formats in `sk.yml`, improving internationalization support.