### PR TITLE
feat: Add SK locales from Crowdin

### DIFF
--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,21 +1,4540 @@
 ---
 sk:
-  decidim:
-    assemblies:
-      assemblies:
-        show:
-          title: "O tejto iniciatíve"
+  activemodel:
+    attributes:
+      assembly:
+        announcement: Oznámenie
+        document: Dokument
+        import_attachments: Importovať prílohy
+        import_categories: Importovať kategórie
+        import_components: Importovať komponenty
+        twitter: X
+        weight: Pozícia v poradí
+      assembly_member:
+        non_user_avatar: Avatar
+        user_id: Používateľ alebo skupina
+        weight: Pozícia v poradí
+      attachment:
+        documents: Dokumenty
+        image: Obrázok
+        photos: Fotografie
+        title: Názov prílohy alebo obrázka
+        weight: Pozícia v poradí
+      attachment_collection:
+        weight: Pozícia v poradí
+      authorization:
+        verification_attachment: Príloha overenia
+      budget:
+        description: Popis
+        title: Názov
+        total_budget: Celkový rozpočet
+        weight: Pozícia v poradí
+      category:
+        weight: Pozícia v poradí
+      close_meeting:
+        audio_url: URL adresa zvuku
+        video_url: URL adresa videa
+      collaborative_draft:
+        scope_id: Rozsah
+      common:
+        created_at: Vytvorené
+      component:
+        weight: Pozícia v poradí
+      conference:
+        available_slots: Dostupné miesta
+        end_date: Dátum ukončenia
+        location: Miesto
+        main_logo: Hlavné logo
+        objectives: Ciele
+        registration_terms: Podmienky registrácie
+        registrations_enabled: Registrácie povolené
+        sign_date: Dátum podpisu
+        signature: Podpis
+        signature_name: Meno podpisujúceho
+        start_date: Dátum začiatku
+        weight: Pozícia v poradí
+      conference_media_link:
+        date: Dátum
+        link: Odkaz
+        title: Názov
+        weight: Pozícia v poradí
+      conference_partner:
+        link: Odkaz
+        logo: Logo
+        name: Názov
+        partner_type: Typ partnera
+        weight: Pozícia v poradí
+      conference_registration_invite:
+        email: E-mail
+        name: Meno
+        registration_type_id: Typ registrácie
+        user_id: Používateľ
+      conference_registration_type:
+        description: Popis
+        price: Cena
+        title: Názov
+        weight: Pozícia v poradí
+      conference_speaker:
+        affiliation: Afilácia
+        avatar: Avatar
+        conference_meeting_ids: Súvisiace stretnutia
+        personal_url: Osobná URL adresa
+        position: Pozícia
+        short_bio: Krátky životopis
+        twitter_handle: X handle
+        user_id: Používateľ
+      confirmation:
+        verification_code: Overovací kód
+      content_block_attachment:
+        background_image: Obrázok na pozadí
+        main_image: Hlavný obrázok
+      conversation:
+        body: Obsah
+      debate:
+        closed_at: Uzavreté o
+        conclusions: Závery
+      dummy:
+        image: Obrázok
+      dummy_attribute: Fiktívny atribút
+      dummy_resource:
+        decidim_scope_id: Oblasť
+      editor_image:
+        file: Súbor
+      external_domain:
+        value: Hodnota
+      help_section:
+        content: Obsah
+      import:
+        file: Súbor
+      import_participatory_text:
+        document: Dokument
+      initiative:
+        answer: Odpoveď
+        answer_url: URL odpovede
+        area_id: Oblasť
+        decidim_scope_id: Rozsah
+        offline_votes_for_scope: Osobné podpisy pre %{scope_name}
+        type_id: Typ
+      initiatives_settings:
+        initiatives_order: Poradie
+      initiatives_type:
+        area_enabled: Povoliť autorom vybrať oblasť pre ich iniciatívu
+        attachments_enabled: Povoliť prílohy
+        child_scope_threshold_enabled: Povoliť podpisy pre podradené rozsahy
+        comments_enabled: Povoliť komentáre
+        custom_signature_end_date_enabled: Povoliť autorom vybrať koniec obdobia zberu podpisov
+        only_global_scope_enabled: Povoliť len vytváranie iniciatív s globálnym rozsahom
+        signature_type: Typ podpisu
+      initiatives_type_scope:
+        decidim_scopes_id: Rozsahy
+        supports_required: Požadovaná podpora
+      meeting:
+        customize_registration_email: Prispôsobiť registračný e-mail
+        end_time: Čas ukončenia
+        id: ID
+        iframe_access_level: Úroveň prístupu Iframe
+        iframe_embed_type: Typ vloženia Iframe
+        iframe_embed_type_html: Iba niekoľko služieb umožňuje „Vložiť na stránku stretnutia“ alebo „Otvoriť na stránke živého podujatia“. Upozorňujeme, že pri možnosti „Vložiť na stránku stretnutia“ na mobilných zariadeniach, keďže obrazovka zdedí iné rozmery, to bude v skutočnosti fungovať ako „Otvoriť na stránke živého podujatia“.
+        online_meeting_url: URL adresa online stretnutia
+        organizer_gid: Vytvoriť ako
+        registration_email_custom_content: Vlastný obsah registračného e-mailu
+        registration_type: Typ registrácie
+        registration_url: URL adresa registrácie
+        reserved_slots: Vyhradené miesta pre toto stretnutie
+        start_time: Čas začiatku
+        type_of_meeting: Typ
+      meeting_agenda:
+        title: Názov
+        visible: Viditeľné
+      meeting_agenda_items:
+        description: Popis
+        duration: Trvanie
+        title: Názov
+      meeting_registration_invite:
+        email: E-mail
+        name: Meno
+      message:
+        body: Text
+      mobile_phone:
+        mobile_phone_number: Číslo mobilného telefónu
+      newsletter:
+        send_to_all_users: Odoslať všetkým účastníkom
+        send_to_followers: Odoslať sledujúcim
+        send_to_participants: Odoslať účastníkom
+      oauth_application:
+        name: Názov aplikácie OAuth
+        organization_name: Organizácia
+      organization:
+        admin_terms_of_service_body: Telo podmienok používania pre administrátorov
+        available_authorizations: Dostupné autorizácie
+        enable_machine_translations: Povoliť strojové preklady
+        force_authentication: Vynútiť overenie
+        force_users_to_authenticate_before_access_organization: Vynútiť overenie používateľov pred prístupom k organizácii
+        from: E-mailová adresa odosielateľa
+        from_email: E-mailová adresa
+        from_label: Štítok
+        highlight_alternative_color: Zvýraznenie, alternatívne
+        highlight_color: Zvýraznenie
+        host: Hostiteľ
+        machine_translation_display_priority: Priorita zobrazenia strojového prekladu
+        machine_translation_display_priority_original: Najprv pôvodný text
+        machine_translation_display_priority_translation: Najprv preložený text
+        organization_admin_email: E-mail administrátora organizácie
+        organization_admin_name: Meno administrátora organizácie
+        organization_locales: Jazyky organizácie
+        secondary_hosts: Sekundárni hostitelia
+        tertiary_color: Terciárna
+        twitter_handler: X účet
+        users_registration_mode: Režim registrácie používateľov
+      organization_file_uploads:
+        allowed_content_types:
+          admin: MIME typy pre administrátora
+          default: Predvolené MIME typy
+        allowed_file_extensions:
+          admin: Prípony súborov pre administrátora
+          default: Predvolené prípony súborov
+          image: Prípony obrázkových súborov
+        maximum_file_size:
+          avatar: Veľkosť súboru avatara
+          default: Predvolená veľkosť súboru
+      participatory_process:
+        document: Dokument
+        import_attachments: Importovať prílohy
+        import_categories: Importovať kategórie
+        import_components: Importovať komponenty
+        import_steps: Importovať kroky
+        weight: Pozícia v poradí
+      participatory_process_group:
+        developer_group: Iniciátorská skupina
+        group_url: Webová stránka
+        local_area: Oblasť organizácie
+        meta_scope: Metadáta rozsahu
+        participatory_scope: O čom sa rozhoduje
+        participatory_structure: Ako sa rozhoduje
+        target: Kto sa zúčastňuje
+        title: Názov
+      partner:
+        logo: Logo
+      post:
+        body: Obsah
+        decidim_author_id: Autor
+        published_at: Čas publikovania
+        title: Názov
+      project:
+        budget_amount: Výška rozpočtu
+        proposals: Návrhy
+        selected: Vybrané na realizáciu
+      proposal:
+        decidim_proposals_proposal_state_id: Stav
+        latitude: Zemepisná šírka
+        longitude: Zemepisná dĺžka
+        scope_id: Rozsah
+      proposal_state:
+        announcement_title: Nadpis odpovede
+        bg_color: Farba pozadia
+        colors:
+          blue: Modrá
+          gray: Sivá
+          green: Zelená
+          orange: Oranžová
+          pink: Ružová
+          purple: Fialová
+          red: Červená
+          yellow: Žltá
+        text_color: Farba textu
+      proposals_copy:
+        copy_proposals: Rozumiem, že sa týmto importujú všetky návrhy z vybraného komponentu do aktuálneho a že túto akciu nie je možné vrátiť späť.
+      proposals_file_import:
+        file: Súbor
+      proposals_import:
+        keep_answers: Ponechať stavy a odpovede
+        scope_id: Oblasť
+      questionnaire:
+        title: Názov
+      questionnaire_question:
+        max_characters: Limit znakov (ponechajte 0, ak bez limitu)
+      result:
+        subresults: Čiastkové výsledky
+      settings:
+        scope_id: Oblasť
+      static_page:
+        allow_public_access: Povoliť prístup bez overenia
+        topic_id: Téma
+        weight: Pozícia v poradí
+      static_page_topic:
+        name: Názov témy
+        weight: Pozícia v poradí
+      template:
+        description: Popis
+        name: Názov
+      user:
+        avatar: Avatar
+        encrypted_password: Heslo
+        locale: Jazyk
+        old_password: Aktuálne heslo
+        tos_agreement: Súhlas s podmienkami používania
+      validate_registration_code:
+        code: Kód
+    errors:
+      models:
+        assembly:
+          attributes:
+            document:
+              allowed_file_content_types: 'Neplatný typ dokumentu. Povolené sú len súbory s nasledujúcimi príponami: %{types}.'
+        census_data:
+          attributes:
+            file:
+              malformed: Chybný súbor importu, pozorne si prečítajte pokyny a uistite sa, že súbor je kódovaný v UTF-8.
+        conference_registration_invite:
+          attributes:
+            email:
+              already_invited: Tento e-mail už bol pozvaný.
+        initiative:
+          attributes:
+            attachment:
+              file: Súbor je neplatný
+              needs_to_be_reattached: Je potrebné znova pripojiť
+              title: Názov by nemal byť prázdny
+        meeting:
+          attributes:
+            iframe_embed_type:
+              not_embeddable: Túto URL adresu nie je možné vložiť na stránku stretnutia alebo živého podujatia.
+            online_meeting_url:
+              url_format: Musí to byť platná URL adresa
+        meeting_agenda:
+          attributes:
+            base:
+              too_many_minutes: Trvanie položiek presahuje trvanie stretnutia o %{count} minút.
+              too_many_minutes_child: Trvanie podpoložiek presahuje trvanie nadradenej položky programu „%{parent_title}“ o %{count} minút.
+        meeting_registration_invite:
+          attributes:
+            email:
+              already_invited: Tento e-mailový účet už bol pozvaný.
+        newsletter:
+          attributes:
+            base:
+              at_least_one_space: Vyberte aspoň jeden participatívny priestor.
+        organization:
+          attributes:
+            password:
+              secret_key: Aby ste mohli uložiť toto pole, musíte definovať premennú prostredia SECRET_KEY_BASE
+        participatory_process:
+          attributes:
+            document:
+              allowed_file_content_types: 'Neplatný typ dokumentu. Povolené sú len súbory s nasledujúcimi príponami: %{types}'
+        participatory_text:
+          attributes:
+            document:
+              allowed_file_content_types: 'Neplatný typ dokumentu. Povolené sú iba súbory s nasledujúcimi príponami: %{types}'
+        proposals_merge:
+          attributes:
+            base:
+              not_official: Nie sú oficiálne
+              voted: Získali hlasy alebo lajky
+        proposals_split:
+          attributes:
+            base:
+              not_official: Nie sú oficiálne
+              voted: Získali hlasy alebo lajky
+        questionnaire:
+          request_invalid: Pri spracovaní požiadavky sa vyskytol problém. Skúste to znova.
+        user:
+          attributes:
+            nickname:
+              format: Prezývka musí byť malými písmenami a nesmie obsahovať medzery
+        user_group_csv_verification:
+          attributes:
+            file:
+              malformed: Nesprávne naformátovaný súbor na import, pozorne si prečítajte pokyny a uistite sa, že súbor je kódovaný v UTF-8.
+      new_import:
+        attributes:
+          file:
+            invalid_file: Bol poskytnutý neplatný súbor, skontrolujte, či je súbor správne naformátovaný.
+            invalid_mime_type: Neplatný typ MIME.
+    models:
+      decidim/comments/comment_upvoted_event: Komentár bol kladne ohodnotený
+      decidim/debates/close_debate_event: Debata bola uzavretá
+      decidim/debates/creation_enabled_event: Vytváranie debát povolené
+      decidim/gamification/level_up_event: Dosiahli ste vyššiu úroveň
+      decidim/invited_to_group_event: Pozvaný/á do skupiny
+      decidim/promoted_to_admin_event: Povýšený/á na správcu skupiny
+      decidim/resource_hidden_event: Zdroj bol skrytý
+      decidim/welcome_notification_event: Uvítacia správa
+  activerecord:
+    attributes:
+      decidim/action_log:
+        created_at: Čas
+        with_participatory_space: Participatívny priestor
+    models:
+      decidim/budgets/budget:
+        one: Rozpočet
+        other: Rozpočty
+      decidim/initiative:
+        one: Iniciatíva
+        other: Iniciatívy
+      decidim/proposals/proposal_vote:
+        one: Hlas
+        other: Hlasov
   date:
     buttons:
-      close: "Zavrieť"
-      select: "Vybrať"
+      close: Zavrieť
+      select: Vybrať
     formats:
-      order: d-m-y
-      separator: "."
+      decidim_short_dashed: '%d-%m-%Y'
       help:
         date_format: 'Formát: dd.mm.rrrr'
+      order: d-m-y
+      separator: .
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: asi 1 hodina
+        other: asi %{count} hodín
+      about_x_months:
+        one: asi 1 mesiac
+        other: asi %{count} mesiacov
+      half_a_minute: pol minúty
+      less_than_x_minutes:
+        one: menej ako minúta
+        other: menej ako %{count} minút
+      less_than_x_seconds:
+        one: menej ako 1 sekunda
+        other: menej ako %{count} sekúnd
+      short:
+        about_x_days: '%{count}d'
+        about_x_hours: '%{count}h'
+        about_x_minutes: '%{count}m'
+        about_x_months: '%{count} mes.'
+        about_x_years: '%{count}r'
+        almost_x_years: '%{count}r'
+        half_a_minute: 1m
+        less_than_x_minutes: '%{count}m'
+        less_than_x_seconds: '%{count}s'
+        over_x_years: '%{count}r'
+        x_days: '%{count}d'
+        x_hours: '%{count}h'
+        x_minutes: '%{count}m'
+        x_months: '%{count} mes.'
+        x_seconds: '%{count}s'
+        x_years: '%{count}r'
+      x_days:
+        one: 1 deň
+        other: '%{count} dní'
+      x_hours:
+        one: 1 hodina
+        other: '%{count} hodín'
+      x_minutes:
+        one: 1 minúta
+        other: '%{count} minút'
+      x_months:
+        one: 1 mesiac
+        other: '%{count} mesiacov'
+      x_seconds:
+        one: 1 sekunda
+        other: '%{count} sekúnd'
+    widget:
+      label:
+        date: Vyberte dátum pre %{label}
+        time: Vyberte čas pre %{label}
+      picker:
+        date_button: Otvoriť výber kalendára pre %{label}
+        time_button: Otvoriť výber času pre %{label}
+  decidim:
+    accessibility:
+      external_link: Externý odkaz
+      front_page_link: Prejsť na úvodnú stránku
+      opens_in_new_tab: Otvorí sa v novej karte
+    account:
+      blocked: Tento účet bol zablokovaný z dôvodu porušenia podmienok používania
+      delete:
+        alert: Túto akciu nie je možné vrátiť späť. Ak odstránite svoj účet, nebudete sa môcť prihlásiť pomocou svojich prihlasovacích údajov. Odstránenie vášho účtu bude mať za následok anonymizáciu vašich príspevkov. Stále si budete môcť vytvoriť nový účet, ale tieto príspevky s ním nebudú spojené.
+        leaving_authorizations_behind: Niektoré údaje viazané na vašu autorizáciu sa z bezpečnostných dôvodov uložia. Ak si vytvoríte iný účet a znova sa autorizujete, tieto údaje sa obnovia do vášho nového účtu.
+      download_your_data_export:
+        notice: Sťahovanie vašich údajov momentálne prebieha. Po jeho dokončení dostanete e-mail.
+      email_change:
+        body1: Na adresu %{unconfirmed_email} sme poslali e-mail na overenie vašej novej e-mailovej adresy.
+        body2: Potrebujete, aby sme vám overovací e-mail poslali znova? %{resend_link} alebo %{cancel_link}.
+        cancel: zrušiť
+        cancel_error: Zmenu e-mailu sa nepodarilo zrušiť.
+        cancel_successfully: Zmena e-mailu bola úspešne zrušená.
+        resend_error: Nepodarilo sa znova odoslať potvrdzovací e-mail.
+        resend_successfully: Potvrdzovací e-mail bol úspešne znova odoslaný na %{unconfirmed_email}.
+        send_again: Odoslať znova
+        title: Overenie zmeny e-mailu
+      show:
+        available_locales_helper: Vyberte jazyk, ktorý chcete používať na prehliadanie a prijímanie upozornení na platforme.
+      update:
+        success_with_email_confirmation: Váš účet bol úspešne aktualizovaný. Dostanete e-mail na potvrdenie vašej novej e-mailovej adresy.
+    accountability:
+      actions:
+        import: Importovať výsledky z iného komponentu
+        import_csv: Importovať výsledky zo súboru CSV
+        new_result: Nový výsledok
+        new_status: Nový stav
+      admin:
+        exports:
+          result_comments: Komentáre
+        import_results:
+          new:
+            download_export: Stiahnuť export vo formáte CSV
+            info: "<p>Odporúčame vám postupovať podľa týchto krokov:</p>\n<ol>\n<li><a href='%{link_new_status}' target='_blank'>Vytvorte stavy pre výsledky</a>, ktoré chcete pridať</li>\n<li><a href='%{link_new_result}' target='_blank'>Vytvorte aspoň jeden výsledok manuálne</a> prostredníctvom tohto panela správcu pred použitím importu, aby ste lepšie porozumeli formátu a tomu, čo budete musieť vyplniť.</li>\n<li>%{link_export_csv}</li>\n<li>Vykonajte zmeny lokálne. Môžete zmeniť iba nasledujúce stĺpce CSV (ostatné budú ignorované):</li>\n  <ul>\n  <li><b>taxonomies/ids:</b> ID pre taxonómie (ak je ich viac, oddeľte ich čiarkou)</li>\n  <li><b>parent/id:</b> ID nadradeného prvku (pre súvisiace výsledky). Voliteľné</li>\n  <li><b>title/en:</b> Názov v anglickom jazyku. Bude to závisieť od konfigurácie jazyka vašej platformy.</li>\n  <li><b>description/en:</b> Popis v anglickom jazyku. Bude to závisieť od konfigurácie jazyka vašej platformy.</li>\n  <li><b>start_date:</b> dátum začiatku realizácie\
+              \ výsledku (formát RRRR-MM-DD)</li>\n  <li><b>end_date:</b> dátum ukončenia realizácie výsledku (formát RRRR-MM-DD)</li>\n  <li><b>status/id:</b> ID stavu pre tento výsledok</li>\n  <li><b>progress:</b> Percento (od 0 do 100) realizácie</li>\n  <li><b>proposals_ids:</b> interné ID súvisiacich návrhov (oddelené čiarkou). Automaticky sa skonvertuje na <span class='attribute-name'>proposal_url</span></li>\n  </ul>\n</li>\n</ol>\n"
+            title: Importovať výsledky zo súboru CSV
+        imports:
+          create:
+            invalid: Pri importovaní výsledkov sa vyskytol problém.
+            success: Súbor sa začal importovať. V priebehu niekoľkých minút dostanete e-mail s výsledkom importu.
+        results:
+          create:
+            invalid: Pri vytváraní tohto výsledku sa vyskytol problém.
+            success: Výsledok bol úspešne vytvorený.
+          update:
+            invalid: Pri aktualizácii tohto výsledku sa vyskytol problém.
+            success: Výsledok bol úspešne aktualizovaný.
+        statuses:
+          create:
+            invalid: Pri vytváraní tohto stavu sa vyskytol problém.
+            success: Stav bol úspešne vytvorený.
+          destroy:
+            success: Stav bol úspešne odstránený.
+          update:
+            invalid: Pri aktualizácii tohto stavu sa vyskytol problém.
+            success: Stav bol úspešne aktualizovaný.
+      admin_log:
+        status:
+          create: '%{user_name} vytvoril/a stav %{resource_name}'
+          delete: '%{user_name} odstránil/a stav %{resource_name}'
+          update: '%{user_name} aktualizoval/a stav %{resource_name}'
+      import_mailer:
+        import:
+          errors_present: Pri importovaní výsledkov sa vyskytol problém.
+      import_projects_mailer:
+        import:
+          added_projects:
+            one: Jeden výsledok bol importovaný z projektov.
+            other: Z projektov bolo importovaných %{count} výsledkov.
+          subject: Úspešný import projektov
+          success: Projekty boli úspešne importované do výsledkov v komponente %{component_name}. Výsledky si môžete prezrieť v administračnom rozhraní.
+      last_activity:
+        new_result: 'Nový výsledok:'
+      models:
+        result:
+          fields:
+            created_at: Vytvorené
+      results:
+        no_results: Nie sú tu žiadne projekty
+    activity:
+      time_ago: pred %{time}
+    admin:
+      actions:
+        attachment:
+          new: Nová príloha
+        attachment_collection:
+          new: Nový priečinok príloh
+        export: Exportovať
+        import: Importovať
+        import_assembly: Importovať
+        moderate: Spravovať moderovanie
+        new_assembly_user_role: Nový administrátor zhromaždenia
+        new_conference: Nová konferencia
+        new_conference_user_role: Nový správca konferencie
+        new_initiative_type_scope: Nový rozsah typu iniciatívy
+        new_media_link: Nový mediálny odkaz
+        new_partner: Nový partner
+        new_registration_type: Nový typ registrácie
+        new_speaker: Nový rečník
+        newsletter:
+          new: Nový newsletter
+        see_process: Zobraziť proces
+        send_me_a_test_email: Pošlite mi testovací e-mail
+        share: Zdieľať
+        user:
+          new: Nový administrátor
+      admin_terms_of_service:
+        accept:
+          error: Pri prijímaní podmienok používania pre administrátorov sa vyskytol problém.
+          success: Skvelé! Prijali ste podmienky používania pre administrátorov.
+        actions:
+          accept: Súhlasím s podmienkami
+          are_you_sure: Naozaj chcete odmietnuť podmienky používania pre administrátorov?
+          refuse: Odmietnuť podmienky pre administrátorov
+          title: Súhlasiť s podmienkami používania
+        required_review:
+          alert: 'Povinné: Prečítajte si naše podmienky používania pre administrátorov'
+          callout: Nájdite si chvíľu na prečítanie podmienok používania pre administrátorov. V opačnom prípade nebudete môcť spravovať platformu.
+          cta: Prečítať si ich teraz.
+      area_types:
+        destroy:
+          success: Typ oblasti bol úspešne odstránený.
+        update:
+          success: Typ oblasti bol úspešne aktualizovaný.
+      areas:
+        destroy:
+          has_spaces: Táto oblasť má závislé priestory. Pred jej odstránením sa uistite, že na ňu neodkazuje žiadny participatívny priestor.
+          success: Oblasť bola úspešne odstránená.
+        update:
+          success: Oblasť bola úspešne aktualizovaná.
+      assemblies:
+        index:
+          unpublished: Nepublikované
+      assembly_imports:
+        create:
+          error: Vyskytol sa problém pri importovaní tohto zhromaždenia.
+          success: Zhromaždenie bolo úspešne importované.
+        new:
+          import: Importovať
+          select: Vyberte údaje, ktoré chcete importovať
+      assembly_publications:
+        create:
+          error: Vyskytol sa problém pri publikovaní tohto zhromaždenia.
+          success: Zhromaždenie bolo úspešne publikované.
+        destroy:
+          error: Vyskytol sa problém pri zrušení publikovania tohto zhromaždenia.
+          success: Publikovanie zhromaždenia bolo úspešne zrušené.
+      assembly_user_roles:
+        create:
+          error: Vyskytol sa problém pri pridávaní administrátora pre toto zhromaždenie.
+          success: Administrátor bol úspešne pridaný do tohto zhromaždenia.
+        destroy:
+          success: Administrátor bol úspešne odstránený z tohto zhromaždenia.
+        edit:
+          update: Aktualizovať
+        new:
+          create: Vytvoriť
+        update:
+          error: Pri aktualizácii administrátora pre toto zhromaždenie sa vyskytol problém.
+          success: Administrátor pre toto zhromaždenie bol úspešne aktualizovaný.
+      attachments_privacy_warning:
+        message: Pri práci s prílohami v súkromnom priestore buďte opatrní. Ktorýkoľvek účastník by mohol tento dokument zdieľať s ostatnými.
+      autocomplete:
+        search_prompt: Pre vyhľadávanie zadajte aspoň tri znaky.
+      block_user:
+        new:
+          action: Zablokovať účet a odoslať odôvodnenie
+          already_reported_html: Pokračovaním v tejto akcii skryjete aj všetok obsah účastníka.
+          description: Zablokovaním používateľa sa jeho účet stane nepoužiteľným. Vo svojom odôvodnení môžete uviesť akékoľvek pokyny o spôsoboch, ktorými by ste zvážili odblokovanie používateľa.
+          justification: Odôvodnenie
+          title: Zablokovať používateľa %{name}
+      components:
+        create:
+          success_landing_page: Komponent bol úspešne vytvorený. Pre tento komponent môžete pridať blok obsahu na domovskej stránke priestoru. Prejdite na <a href="%{landing_page_path}">Vstupnú stránku</a> a nakonfigurujte ho.
+      conference_speakers:
+        publish:
+          invalid: Vyskytol sa problém pri publikovaní tohto rečníka.
+          success: Rečník konferencie bol úspešne publikovaný.
+        unpublish:
+          invalid: Vyskytol sa problém pri zrušení publikovania tohto rečníka.
+          success: Publikovanie rečníka konferencie bolo úspešne zrušené.
+      conferences:
+        index:
+          unpublished: Nepublikované
+      conflicts:
+        attempts: Pokusy
+        'false': Nie
+        index:
+          text: Vyhľadávať podľa e-mailu, mena alebo prezývky aktuálneho používateľa
+        managed_user_name: Spravovaný používateľ
+        solved: Vyriešené
+        transfer:
+          email: E-mail
+          error: Pri prenose aktuálneho účastníka na spravovaného účastníka sa vyskytol problém.
+          name: Meno
+          reason: Dôvod
+          success: Aktuálny prenos bol úspešne dokončený.
+          title: Prenos
+        'true': Áno
+        user_name: Používateľ
+      content_blocks:
+        create:
+          error: Pri vytváraní bloku obsahu sa vyskytol problém.
+          success: Blok obsahu bol úspešne vytvorený.
+        destroy:
+          error: Pri pokuse o odstránenie tohto bloku obsahu sa vyskytol problém.
+          success: Blok obsahu bol úspešne odstránený.
+        edit:
+          active_content_blocks: Aktívne bloky obsahu
+          add: Pridať blok obsahu
+          destroy_confirmation: Naozaj chcete odstrániť tento blok obsahu?
+          inactive_content_blocks: Neaktívne bloky obsahu
+          title: Obsah stránky
+          update: Aktualizovať
+      dashboard:
+        pending_moderations:
+          announcement:
+            one: Čaká %{count} moderácia
+            other: Čaká %{count} moderácií
+          goto_moderation: Prejsť na globálne moderácie
+          title: Čakajúce moderácie
+        show:
+          dropdown: Rozbaľovacie menu
+      domain_allowlist:
+        form:
+          domain_too_short: Doména je príliš krátka
+        update:
+          error: Nepodarilo sa aktualizovať zoznam povolených externých domén.
+          success: Zoznam povolených externých domén bol úspešne aktualizovaný.
+      exports:
+        formats:
+          CSV: CSV
+          Excel: Excel
+          FormPDF: PDF
+          JSON: JSON
+        notice: Váš export momentálne prebieha. Po jeho dokončení dostanete e-mail.
+      filters:
+        accepted_at_not_null:
+          label: Prijaté
+          values:
+            'false': Neprijaté
+            'true': Prijaté
+        ceased_date_not_null:
+          label: Ukončené
+          values:
+            'false': Neukončené
+            'true': Ukončené
+        decidim_participatory_process_group_id_eq:
+          label: Podľa skupiny procesov
+        initiatives:
+          decidim_area_id_eq:
+            label: Oblasť
+          state_eq:
+            label: Stav
+            values:
+              accepted: Dostatok podpisov
+              created: Koncept
+              discarded: Vyradené
+              rejected: Nedostatok podpisov
+              validating: Technické overenie
+          type_id_eq:
+            label: Typ
+        invitation_accepted_at_present:
+          label: Pozvánka prijatá
+          values:
+            'false': Nie
+            'true': Áno
+        last_sign_in_at_present:
+          label: Niekedy prihlásený
+          values:
+            'false': Nie
+            'true': Áno
+        meetings:
+          closed_at_present:
+            label: Stav
+            values:
+              'false': Otvorené
+              'true': Zatvorené
+          is_upcoming_true:
+            label: Dátum
+            values:
+              'false': Minulé
+              'true': Nadchádzajúce
+          with_any_origin:
+            label: Pôvod
+            values:
+              official: Oficiálne
+              participants: Účastník
+          with_any_type:
+            label: Typ stretnutia
+            values:
+              hybrid: Hybridné
+              in_person: Prezenčné
+              online: Online
+        moderated_users:
+          reports_reason_eq:
+            label: Dôvod nahlásenia
+            values:
+              does_not_belong: Nepatrí sem
+              offensive: Urážlivé
+              spam: Spam
+        moderations:
+          reportable_type_string_eq:
+            label: Typ
+        projects:
+          selected_at_null:
+            label: Vybrané
+            values:
+              'false': Vybrané na realizáciu
+              'true': Nevybrané na realizáciu
+        proposals:
+          is_emendation_true:
+            label: Typ
+            values:
+              'false': Návrhy
+              'true': Pozmeňujúce návrhy
+          proposal_state_id_eq:
+            label: Stav
+          state_eq:
+            label: Stav
+            values:
+              accepted: Prijaté
+              evaluating: Hodnotí sa
+              not_answered: Nezodpovedané
+              published: Zverejnené
+              rejected: Zamietnuté
+              validating: Technické overenie
+              withdrawn: Stiahnuté
+          with_any_state:
+            label: Zodpovedané
+            values:
+              state_not_published: Nezodpovedané
+              state_published: Zodpovedané
+        rejected_at_not_null:
+          label: Zamietnuté
+          values:
+            'false': Nezamietnuté
+            'true': Zamietnuté
+        remove_all: Odstrániť všetko
+        results:
+          status_id_eq:
+            label: Stav
+        search_placeholder:
+          full_name_or_user_name_or_user_nickname_cont: Hľadať podľa mena alebo prezývky
+          report_count_eq: Počet nahlásení sa rovná
+          reported_id_string_or_reported_content_cont: Hľadať %{collection} podľa ID nahlásenia alebo obsahu
+          user_name_or_user_email_cont: Hľadať podľa mena alebo e-mailu
+          user_name_or_user_nickname_or_user_email_cont: Hľadať %{collection} podľa e-mailu, mena alebo prezývky
+        sent_at_not_null:
+          label: Odoslané
+          values:
+            'false': Neodoslané
+            'true': Odoslané
+        state_eq:
+          label: Stav
+          values:
+            all: Všetky
+            pending: Čakajúce
+            rejected: Zamietnuté
+            verified: Overené
+      forms:
+        file_help:
+          import:
+            explanation: 'Pokyny pre súbor:'
+            message_1: Podporované sú súbory CSV, JSON a Excel (.xlsx)
+            message_2: Pre súbory CSV musí byť oddeľovačom stĺpcov bodkočiarka (";")
+      help_sections:
+        error: Pri aktualizácii sekcií pomocníka sa vyskytol problém.
+        success: Sekcie pomocníka boli úspešne aktualizované.
+      imports:
+        and: a
+        data_errors:
+          duplicate_headers:
+            detail: Skontrolujte, či súbor obsahuje požadované stĺpce alebo hlavičky iba raz.
+            message:
+              one: Duplicitný stĺpec %{columns}.
+              other: Duplicitné stĺpce %{columns}.
+          invalid_indexes:
+            lines:
+              detail: Skontrolujte, či sú tieto riadky správne naformátované a obsahujú platné záznamy.
+              message:
+                one: V importovanom súbore sa našla chyba na riadku %{indexes}.
+                other: V importovanom súbore sa našli chyby na riadkoch %{indexes}.
+            records:
+              detail: Skontrolujte, či sú tieto záznamy správne naformátované a obsahujú platné záznamy.
+              message:
+                one: V importovanom súbore sa našla chyba pre záznamy s poradovými číslami %{indexes}.
+                other: V importovanom súbore sa našli chyby pre záznamy s poradovými číslami %{indexes}.
+          missing_headers:
+            detail: Skontrolujte, či súbor obsahuje požadované stĺpce.
+            message:
+              one: Chýbajúci stĺpec %{columns}.
+              other: Chýbajúce stĺpce %{columns}.
+        error: Počas importu sa vyskytol problém.
+        example_error: Pri vytváraní príkladu pre daný typ sa vyskytol problém.
+        new:
+          accepted_mime_types:
+            csv: CSV
+            json: JSON
+            xlsx: Excel (.xlsx)
+          actions:
+            back: Späť
+          download_example: Stiahnuť príklad
+          download_example_format: Príklad ako %{name}
+          file_legend: Pridajte súbor na import, ktorý sa spracuje.
+          import: Importovať
+        notice: '%{count} %{resource_name} úspešne importovaných.'
+      initiatives_settings:
+        update:
+          error: Pri aktualizácii nastavení iniciatív sa vyskytol problém.
+          success: Nastavenia iniciatív boli úspešne aktualizované.
+      logs:
+        filters:
+          participatory_space: Nájsť participatívny priestor
+          text: Hľadať podľa e-mailu, mena alebo prezývky používateľa
+          user: Používateľ
+        logs_list:
+          no_logs_yet: Zatiaľ tu nie sú žiadne záznamy.
+          no_matching_logs: S poskytnutými filtrami vyhľadávania neexistujú žiadne záznamy. Skúste ich zmeniť a skúste to znova.
+      media_links:
+        create:
+          success: Mediálny odkaz bol úspešne vytvorený.
+        destroy:
+          success: Mediálny odkaz bol úspešne odstránený.
+        update:
+          success: Mediálny odkaz bol úspešne aktualizovaný.
+      menu:
+        assemblies: Zhromaždenia
+        assemblies_submenu:
+          assembly_admins: Administrátori zhromaždenia
+          attachment_collections: Priečinky
+          attachment_files: Súbory
+          attachments: Prílohy
+          components: Komponenty
+          info: O tomto zhromaždení
+          landing_page: Rozloženie vstupnej stránky
+          moderations: Moderovanie
+          see_assembly: Zobraziť zhromaždenie
+        attachments: Prílohy
+        authorization_revocation:
+          destroy:
+            confirm: Zrušenie autorizácií pred dátumom nie je možné vrátiť späť. Naozaj chcete pokračovať?
+            confirm_all: Zrušenie všetkých autorizácií nie je možné vrátiť späť. Naozaj chcete pokračovať?
+          destroy_nok: Pri rušení autorizácií sa vyskytol problém.
+          no_data: Žiadni overení účastníci.
+          title: Zrušenie autorizácií
+        authorization_workflows: Autorizácie
+        committee_members: Členovia výboru
+        components: Komponenty
+        conferences_submenu:
+          diploma: Certifikát o účasti
+          media_links: Mediálne odkazy
+          registration_types: Typy registrácií
+          see_conference: Zobraziť konferenciu
+          user_registrations: Registrácie používateľov
+        content: Nahlásený obsah
+        external_domain_allowlist: Povolené externé domény
+        initiative_type_scopes: Rozsahy typov iniciatív
+        initiatives_menu:
+          see_initiative: Zobraziť iniciatívu
+        initiatives_settings: Nastavenia
+        moderation: Globálne moderovanie
+        moderations: Moderovanie
+        participatory_process_groups_submenu:
+          landing_page: Rozloženie vstupnej stránky
+        participatory_processes_submenu:
+          landing_page: Rozloženie vstupnej stránky
+        reported_users: Nahlásení účastníci
+        see_site: Zobraziť stránku
+        static_page_topics: Témy
+        templates: Šablóny
+      models:
+        assembly:
+          fields:
+            actions: Akcie
+            created_at: Vytvorené
+            promoted: Zvýraznené
+            published: Publikované
+            title: Názov
+          name: Zhromaždenie
+        assembly_member:
+          name: Člen
+          positions:
+            other: Iné
+            president: Predseda
+            secretary: Tajomník
+            vice_president: Podpredseda
+        assembly_user_role:
+          fields:
+            email: E-mail
+            name: Meno
+            role: Rola
+          name: Administrátor zhromaždenia
+          roles:
+            admin: Administrátor
+            collaborator: Spolupracovník
+            moderator: Moderátor
+        initiatives:
+          fields:
+            published_at: Publikované
+        media_link:
+          name: Mediálny odkaz
+        participatory_process:
+          fields:
+            actions: Akcie
+        participatory_process_group:
+          fields:
+            title: Názov
+        registration_type:
+          fields:
+            weight: Pozícia v poradí
+        share_token:
+          fields:
+            expires_at: Platnosť vyprší
+            times_used: Počet použití
+            token: Prístupový odkaz
+        user:
+          fields:
+            last_sign_in_at: Dátum posledného prihlásenia
+      moderated_users:
+        index:
+          actions:
+            block: Zablokovať používateľa
+            title: Akcie
+            unblock: Odblokovať používateľa
+            unreport: Zrušiť nahlásenie
+          name: Meno
+          nickname: Prezývka
+          reason: Dôvod
+          reports: Počet nahlásení
+          title: Nahlásení účastníci
+        report:
+          reasons:
+            does_not_belong: Nepatrí sem
+            offensive: Urážlivé
+            spam: Spam
+        tabs:
+          blocked: Zablokovaní
+          unblocked: Nezablokovaní
+      moderations:
+        index:
+          title: Nahlásený obsah
+        report:
+          reasons:
+            hidden_during_block: Skryté počas blokovania používateľa
+            parent_hidden: Nadradený obsah bol skrytý
+        reports:
+          index:
+            author: Autor(i)
+            callout_html: Obsah sa zobrazí na paneli moderovania, keď ho používateľ (môže to byť ktokoľvek s registrovaným účtom) nahlási kliknutím na vlajku %{icon} vedľa položky.
+            content_original_language: Pôvodný jazyk obsahu
+            participatory_space: Participatívny priestor
+            reported_content: Nahlásený obsah
+            see_current: Zobraziť aktuálne
+            see_original: Zobraziť originál
+            title: Správy o moderovaní
+          show:
+            report_details: Podrobnosti o dôvode
+            report_language: Jazyk nahlásenia
+            report_reason: Dôvod
+            title: Podrobnosti nahlásenia
+      new_import:
+        accepted_mime_types:
+          csv: CSV
+          json: JSON
+          xlsx: XLSX
+      newsletters:
+        create:
+          success: Newsletter bol úspešne vytvorený. Pred odoslaním ho prosím skontrolujte.
+        send:
+          no_recipients: Pre tento výber nie sú žiadni príjemcovia.
+        send_to_user:
+          sent_successfully: Newsletter bol úspešne odoslaný na %{email}
+        show:
+          send_me_a_test_email: Pošlite mi testovací e-mail
+      officializations:
+        block:
+          error: Pri blokovaní účastníka sa vyskytol problém.
+          success: Účastník bol úspešne zablokovaný.
+        create:
+          success: Účastník bol úspešne oficionalizovaný.
+        destroy:
+          success: Oficionalizácia účastníka bola úspešne zrušená.
+        index:
+          block: Zablokovať
+          reports: Nahlásenia
+          unblock: Odblokovať
+        show_email_modal:
+          description: Ak potrebujete kontaktovať účastníka priamo, môžete kliknúť na tlačidlo Zobraziť a uvidíte jeho e-mailovú adresu. Táto akcia bude zaznamenaná.
+          title: Zobraziť e-mailovú adresu účastníka
+        unblock:
+          error: Pri odblokovaní účastníka sa vyskytol problém.
+          success: Účastník bol úspešne odblokovaný.
+      organization:
+        form:
+          twitter: X
+          url: URL
+      organization_external_domain_allowlist:
+        edit:
+          update: Aktualizovať
+        external_domain:
+          down: Dole
+          external_domain: Externá doména
+          remove: Odstrániť
+          up: Hore
+        form:
+          add: Pridať do zoznamu povolených
+      participatory_process_steps:
+        destroy:
+          error:
+            active_step: Aktívnu fázu nie je možné odstrániť.
+            last_step: Poslednú fázu procesu nie je možné odstrániť.
+      participatory_processes:
+        index:
+          unpublished: Nezverejnené
+      password_change:
+        alert: Ak chcete pokračovať, musíte si zmeniť heslo.
+        notification: Administrátori si musia zmeniť heslo každých %{days} dní.
+      reminders:
+        create:
+          error: Pri vytváraní pripomienok sa vyskytol problém.
+          success:
+            one: '%{count} používateľ dostane pripomienku.'
+            other: '%{count} používateľov dostane pripomienku.'
+        new:
+          submit: Odoslať
+      scopes:
+        destroy:
+          success: Rozsah bol úspešne odstránený.
+      share_tokens:
+        actions:
+          confirm_destroy: Naozaj chcete odstrániť tento prístup?
+          destroy: Odstrániť
+        destroy:
+          error: Pri odstraňovaní prístupového odkazu sa vyskytol problém.
+          success: Prístupový odkaz bol úspešne odstránený.
+      shared:
+        adjacent_navigation:
+          next: Nasledujúci
+          next_title: Nasledujúca položka
+          previous: Predchádzajúci
+          previous_title: Predchádzajúca položka
+      static_page_topics:
+        destroy:
+          success: Téma bola úspešne odstránená.
+      static_pages:
+        edit:
+          changed_notably_help: Ak je začiarknuté, účastníci budú upozornení, aby prijali nové podmienky používania.
+          last_notable_change: 'Posledná významná zmena: %{tos_version_formatted}'
+        form:
+          slug_help_html: 'Použite tu čiastočné cesty, nie úplné adresy URL. Akceptuje písmená, čísla, pomlčky a lomky a musí začínať písmenom. Príklad: %{url}'
+        topic:
+          empty: V tejto téme nie sú žiadne stránky.
+        update:
+          success: Stránka bola úspešne aktualizovaná.
+      templates:
+        actions:
+          new_template: Nová šablóna
+        apply:
+          error: Pri aplikovaní tejto šablóny sa vyskytol problém.
+          success: Šablóna bola úspešne aplikovaná.
+        copy:
+          error: Pri kopírovaní tejto šablóny sa vyskytol problém.
+          success: Šablóna bola úspešne skopírovaná.
+        create:
+          error: Pri vytváraní tejto šablóny sa vyskytol problém.
+          success: Šablóna bola úspešne vytvorená.
+        destroy:
+          success: Šablóna bola úspešne odstránená.
+        empty: Zatiaľ tu nie sú žiadne šablóny.
+        fetch:
+          error: Túto šablónu sa nepodarilo nájsť. Obnovte stránku.
+        missing_resource: (chýbajúci zdroj)
+        update:
+          error: Pri aktualizácii tejto šablóny sa vyskytol problém.
+          success: Šablóna bola úspešne aktualizovaná.
+      titles:
+        menu: Menu
+        panel: Admin
+        template_types:
+          questionnaires: Šablóny dotazníkov
+        templates: Šablóny
+      users:
+        new:
+          title: Pozvať nového administrátora
+      users_statistics:
+        users_count:
+          no_users_count_statistics_yet: Zatiaľ nie sú k dispozícii žiadne štatistiky počtu účastníkov.
+    admin_log:
+      area_type:
+        create: '%{user_name} vytvoril/a typ oblasti %{resource_name}'
+        delete: '%{user_name} odstránil/a typ oblasti %{resource_name}'
+        update: '%{user_name} aktualizoval/a typ oblasti %{resource_name}'
+      assembly:
+        create: '%{user_name} vytvoril/a zhromaždenie %{resource_name}'
+        duplicate: '%{user_name} duplikoval/a zhromaždenie %{resource_name}'
+        export: '%{user_name} exportoval/a zhromaždenie %{resource_name}'
+        import: '%{user_name} importoval/a zhromaždenie %{resource_name}'
+        publish: '%{user_name} publikoval/a zhromaždenie %{resource_name}'
+        unpublish: '%{user_name} zrušil/a publikovanie zhromaždenia %{resource_name}'
+        update: '%{user_name} aktualizoval/a zhromaždenie %{resource_name}'
+      assembly_member:
+        create: '%{user_name} vytvoril/a člena %{resource_name} v zhromaždení %{space_name}'
+        delete: '%{user_name} odstránil/a člena %{resource_name} zo zhromaždenia %{space_name}'
+        update: '%{user_name} aktualizoval/a člena %{resource_name} v zhromaždení %{space_name}'
+      assembly_setting:
+        update: '%{user_name} aktualizoval/a nastavenia zhromaždení'
+      assembly_type:
+        delete: '%{user_name} odstránil/a typ zhromaždenia %{resource_name}'
+      assembly_user_role:
+        create: '%{user_name} pozval/a %{resource_name} do zhromaždenia %{space_name}'
+        delete: '%{user_name} odstránil/a účastníka %{resource_name} zo zhromaždenia %{space_name}'
+        update: '%{user_name} zmenil/a rolu používateľa %{resource_name} v zhromaždení %{space_name}'
+      attachment:
+        create: '%{user_name} vytvoril/a prílohu %{resource_name}'
+        delete: '%{user_name} odstránil/a prílohu %{resource_name}'
+        update: '%{user_name} aktualizoval/a prílohu %{resource_name}'
+      attachment_collection:
+        create: '%{user_name} vytvoril/a zbierku príloh %{resource_name}'
+        delete: '%{user_name} odstránil/a zbierku príloh %{resource_name}'
+        update: '%{user_name} aktualizoval/a zbierku príloh %{resource_name}'
+      category:
+        create: '%{user_name} pridal/a kategóriu %{resource_name} do priestoru %{space_name}'
+        delete: '%{user_name} odstránil/a kategóriu %{resource_name} z priestoru %{space_name}'
+        update: '%{user_name} aktualizoval/a kategóriu %{resource_name} v priestore %{space_name}'
+      component:
+        export_component: '%{user_name} exportoval/a %{resource_name} %{component_name} v %{space_name} ako %{format_name}'
+        update_permissions_with_space: '%{user_name} aktualizoval/a oprávnenia pre %{resource_name} v %{space_name}'
+      conferences:
+        partner:
+          create: '%{user_name} vytvoril/a partnera %{resource_name} v konferencii %{space_name}'
+          delete: '%{user_name} odstránil/a partnera %{resource_name} z konferencie %{space_name}'
+          update: '%{user_name} aktualizoval/a partnera %{resource_name} v konferencii %{space_name}'
+        registration_type:
+          delete: '%{user_name} odstránil/a typ registrácie %{resource_name} z konferencie %{space_name}'
+      contextual_help_section:
+        update: '%{user_name} aktualizoval/a sekciu pomocníka %{resource_name}'
+      helpers:
+        answers: odpovede
+        comments: komentáre
+        projects: projekty
+        results: výsledky
+      impersonation_log:
+        manage: '%{user_name} spravoval/a %{resource_name} z dôvodu: %{reason}'
+      organization:
+        update_external_domain: '%{user_name} aktualizoval/a externé domény organizácie'
+        update_id_documents_config: '%{user_name} aktualizoval konfiguráciu autorizácie dokladov totožnosti'
+      participatory_process:
+        duplicate: '%{user_name} duplikoval/a participatívny proces %{resource_name}'
+        export: '%{user_name} exportoval/a participatívny proces %{resource_name}'
+        import: '%{user_name} importoval/a participatívny proces %{resource_name}'
+      participatory_process_group:
+        unpublish: '%{user_name} zrušil/a zverejnenie skupiny participatívnych procesov %{resource_name}'
+      scope_type:
+        create: '%{user_name} vytvoril/a typ rozsahu %{resource_name}'
+        delete: '%{user_name} odstránil/a typ rozsahu %{resource_name}'
+        update: '%{user_name} aktualizoval/a typ rozsahu %{resource_name}'
+      user:
+        block: '%{user_name} zablokoval/a používateľa %{resource_name}'
+        grant_id_documents_offline_verification: '%{user_name} overil %{resource_name} pomocou offline autorizácie dokladov totožnosti'
+        promote: '%{user_name} povýšil/a %{resource_name}'
+        transfer: '%{user_name} previedol/a účastníka %{resource_name}'
+        unblock: '%{user_name} odblokoval/a používateľa %{resource_name}'
+      user_group:
+        block: '%{user_name} zablokoval/a skupinu používateľov %{resource_name}'
+        unblock: '%{user_name} odblokoval/a skupinu používateľov %{resource_name}'
+      user_moderation:
+        unreport: '%{user_name} zrušil/a nahlásenie %{resource_type} - %{unreported_user_name}'
+    admin_terms_of_service:
+      default_body: <h2>PODMIENKY POUŽÍVANIA PRE ADMINISTRÁTOROV</h2><p>Veríme, že ste dostali obvyklé poučenie od miestneho systémového administrátora. Zvyčajne sa to zhrnie do týchto troch vecí:</p><ol><li>Rešpektujte súkromie ostatných.</li><li>Premýšľajte predtým, než kliknete.</li><li>S veľkou mocou prichádza veľká zodpovednosť.</li></ol>
+    alert:
+      dismiss: Zrušiť upozornenie
+    amendments:
+      amendable:
+        promote_help_text: Tento pozmeňujúci návrh môžete povýšiť a zverejniť ho ako nezávislý %{model_name}.
+      amendments:
+        title:
+          one: '%{count} pozmeňujúci návrh'
+          other: '%{count} pozmeňujúcich návrhov'
+      name: Pozmeňujúci návrh
+      promoted:
+        error: Pri zverejňovaní pozmeňujúceho návrhu ako nového návrhu sa vyskytol problém.
+        success: Pozmeňujúci návrh bol úspešne zverejnený ako nový návrh.
+      rejected:
+        error: Pri zamietaní tohto pozmeňujúceho návrhu sa vyskytol problém, skúste to znova neskôr.
+        success: Pozmeňujúci návrh bol úspešne zamietnutý.
+      withdraw:
+        error: Pri sťahovaní pozmeňujúceho návrhu sa vyskytol problém.
+        success: Pozmeňujúci návrh bol úspešne stiahnutý.
+    application:
+      document:
+        visit_link: Navštíviť odkaz
+      documents:
+        component_documents:
+          dummy: Dokumenty fiktívneho komponentu
+          meetings: Dokumenty stretnutí
+        documents: Dokumenty
+      photo:
+        alt: Obrázok média
+        title: Obrázok
+      photos:
+        photos: Obrázky
+    assemblies:
+      admin:
+        assemblies:
+          form:
+            duration: Trvanie
+            duration_help: Ak je trvanie tohto zhromaždenia obmedzené, vyberte dátum ukončenia. V opačnom prípade sa bude zobrazovať ako neurčité.
+            images: Obrázky
+            included_at_help: Vyberte dátum, kedy bolo toto zhromaždenie pridané na platformu. Nemusí to byť nevyhnutne rovnaký dátum ako dátum vytvorenia.
+            metadata: Metadáta
+            other: Iné
+            select_a_created_by: Vyberte tvorcu
+            select_parent_assembly: Vyberte nadradené zhromaždenie
+            slug_help_html: 'URL slugy sa používajú na generovanie URL adries, ktoré odkazujú na toto zhromaždenie. Akceptujú sa iba písmená, čísla a pomlčky a musia začínať písmenom. Príklad: %{url}'
+            social_handlers: Sociálne siete
+            title: Všeobecné informácie
+            visibility: Viditeľnosť
+        assembly_imports:
+          form:
+            slug_help_html: 'URL slugy sa používajú na generovanie URL adries, ktoré odkazujú na toto zhromaždenie. Akceptujú sa iba písmená, čísla a pomlčky a musia začínať písmenom. Príklad: %{url}'
+        assembly_members:
+          form:
+            explanation: 'Pokyny pre obrázok:'
+            image_guide: Najlepšie obrázok na výšku, ktorý neobsahuje žiadny text.
+            non_user_avatar_help: Pred zverejnením osôb ako členov by ste mali získať ich súhlas.
+        content_blocks:
+          highlighted_assemblies:
+            max_results: Maximálny počet prvkov na zobrazenie
+        new_import:
+          accepted_types:
+            json: JSON
+      assemblies:
+        description:
+          area_name: Oblasť
+          closing_date: Dátum ukončenia
+          created_by: Vytvoril/a
+          creation_date: Dátum vytvorenia
+          data: Údaje zhromaždenia
+          developer_group: Skupina propagátorov
+          duration: Trvanie
+          included_at: Zahrnuté dňa
+          indefinite_duration: Na neurčito
+          local_area: Oblasť organizácie
+          meta_scope: Rozsah
+          participatory_scope: O čom sa rozhoduje
+          participatory_structure: Ako sa rozhoduje
+          target: Kto sa zúčastňuje
+          title: O tomto zhromaždení
+        filters:
+          names:
+            all: Všetky
+          type: Typ
+        show:
+          title: O tejto iniciatíve
+      content_blocks:
+        children_assemblies:
+          name: Zhromaždenia
+        dates_metadata:
+          name: Metadáta dátumov
+        extra_data:
+          name: Typ a trvanie
+        highlighted_assemblies:
+          name: Zvýraznené zhromaždenia
+        related_assemblies:
+          name: Súvisiace zhromaždenia
+      created_by:
+        city_council: Mestské zastupiteľstvo
+        others: Ostatné
+        public: Verejnosť
+      filter:
+        all: Všetky typy
+        commission: Komisia
+        consultative_advisory: Konzultačné/Poradné
+        executive: Výkonné
+        government: Vláda
+        help: 'Zobraziť:'
+        others: Ostatné
+        participatory: Participatívne
+        working_group: Pracovná skupina
+      index:
+        title: Zhromaždenia
+      last_activity:
+        new_assembly: 'Nové zhromaždenie:'
+      pages:
+        home:
+          highlighted_assemblies:
+            active_spaces: Aktívne zhromaždenia
+            see_all_spaces: Zobraziť všetky zhromaždenia
+      show:
+        duration: Trvanie
+        social_networks_title: Navštívte zhromaždenie na
+    author:
+      avatar: 'Avatar: %{name}'
+      official_author: Oficiálny
+    authorization_handlers:
+      admin:
+        another_dummy_authorization_handler:
+          help:
+            - Príklad obsluhy autorizácie, aby vývojári pochopili, ako funguje jednoduché overenie.
+            - Je určený pre vývojárov, aby pochopili, ako implementovať vlastný systém overovania.
+            - Získajte overenie zadaním čísla pasu začínajúceho na „A“.
+        csv_census:
+          help:
+            - Administrátori nahrajú súbor CSV s e-mailmi prijatých účastníkov.
+            - Overiť sa môžu iba účastníci s e-mailom v tomto súbore CSV.
+        default:
+          help:
+            - Pomocník pre obsluhu autorizácie nie je definovaný.
+            - Vývojár musí definovať pomocníka v prekladovom (i18n) kľúči "%{authorization_handler}"
+        dummy_authorization_handler:
+          help:
+            - Príklad obsluhy autorizácie, aby vývojári pochopili, ako funguje jednoduché overenie.
+            - Je určený pre vývojárov, aby pochopili, ako implementovať vlastný systém overovania.
+            - Nechajte sa overiť zadaním čísla dokladu končiaceho na "X".
+        sms:
+          help:
+            - Účastníci požiadajú o zaslanie overovacieho kódu na ich telefón.
+            - Na overenie musia zadať kód.
+            - Ak kód nedostanú, môžu oň požiadať znova.
+      another_dummy_authorization_handler:
+        explanation: Overte sa zadaním čísla pasu, ktoré sa začína na „A“.
+      csv_census:
+        explanation: Nechajte sa overiť pomocou registra organizácie.
+      dummy_authorization_handler:
+        explanation: Overte sa zadaním čísla dokladu, ktoré sa končí na „X“.
+        fields:
+          allowed_postal_codes: Povolené poštové smerovacie čísla (oddelené čiarkami)
+      errors:
+        duplicate_authorization: Účastník s rovnakými údajmi je už autorizovaný. Administrátor vás bude kontaktovať pre overenie vašich údajov.
+      id_documents:
+        explanation: Nahrajte svoje doklady totožnosti, aby sme mohli overiť vašu totožnosť.
+      postal_letter:
+        explanation: Pošleme vám list s kódom, ktorý budete musieť zadať, aby sme mohli overiť vašu adresu.
+    authorization_modals:
+      content:
+        incomplete:
+          explanation: 'Hoci ste momentálne autorizovaný pomocou „%{authorization}“, musíte sa znova autorizovať, pretože nám chýbajú nasledujúce údaje:'
+        ok:
+          title: Počas prezerania tejto stránky ste boli autorizovaný. Ak chcete vykonať túto akciu, obnovte stránku.
+        pending:
+          explanation: Ak chcete vykonať túto akciu, musíte byť autorizovaný pomocou „%{authorization}“, ale vaša autorizácia stále prebieha.
+          resume: Skontrolujte priebeh vašej autorizácie „%{authorization}“.
+        unauthorized:
+          explanation: Prepáčte, túto akciu nemôžete vykonať, pretože niektoré z vašich autorizačných údajov sa nezhodujú.
+          invalid_field: Hodnota %{value} pre pole %{field} nie je platná.
+        unconfirmed:
+          confirmation_instructions: 'Ak ste nedostali pokyny na potvrdenie, môžete o ne požiadať znova:'
+    block_user_mailer:
+      notify:
+        body_1: Váš účet bol zablokovaný.
+        body_2: 'Dôvod: %{justification}'
+        greetings: S pozdravom,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+        hello: Dobrý deň,
+        subject: Váš účet bol zablokovaný organizáciou %{organization_name}
+    blogs:
+      actions:
+        author_id: Vytvoriť príspevok ako
+      admin:
+        posts:
+          create:
+            invalid: Pri vytváraní tohto príspevku sa vyskytol problém.
+            success: Príspevok bol úspešne vytvorený.
+          destroy:
+            success: Príspevok bol úspešne odstránený.
+          edit:
+            title: Upraviť príspevok
+          index:
+            not_published_yet: Zatiaľ nepublikované.
+          update:
+            success: Príspevok bol úspešne uložený.
+      admin_log:
+        post:
+          create: '%{user_name} vytvoril/a blogový príspevok %{resource_name} v priestore %{space_name}'
+          delete: '%{user_name} odstránil/a blogový príspevok %{resource_name} z priestoru %{space_name}'
+          update: '%{user_name} aktualizoval/a blogový príspevok %{resource_name} v priestore %{space_name}'
+      content_blocks:
+        highlighted_posts:
+          last_published: Naposledy publikované
+          name: Príspevky
+          see_all: Zobraziť všetky príspevky
+      last_activity:
+        new_post: 'Nový príspevok:'
+      models:
+        post:
+          fields:
+            official_blog_post: Oficiálny príspevok
+            published_at: Čas publikovania
+            title: Názov
+      posts:
+        index:
+          count:
+            one: '%{count} príspevok'
+            other: '%{count} príspevkov'
+          empty: Zatiaľ tu nie sú žiadne príspevky.
+    budgets:
+      actions:
+        edit_projects: Pridať projekty
+        new_budget: Nový rozpočet
+        new_project: Nový projekt
+        send_voting_reminders: Poslať pripomienky k hlasovaniu
+      admin:
+        budgets:
+          create:
+            invalid: Pri vytváraní tohto rozpočtu sa vyskytol problém.
+            success: Rozpočet bol úspešne vytvorený.
+          edit:
+            title: Upraviť rozpočet
+            update: Aktualizovať rozpočet
+          index:
+            finished_orders: Dokončené hlasovania
+            pending_orders: Čakajúce hlasovania
+            title: Rozpočty
+            users_with_finished_orders: Používatelia s dokončenými hlasovaniami
+            users_with_pending_orders: Používatelia s čakajúcimi hlasovaniami
+          new:
+            create: Vytvoriť rozpočet
+            title: Nový rozpočet
+          update:
+            invalid: Pri aktualizácii tohto rozpočtu sa vyskytol problém.
+            success: Rozpočet bol úspešne aktualizovaný.
+        exports:
+          projects: Projekty
+        projects:
+          create:
+            invalid: Pri vytváraní tohto projektu sa vyskytol problém.
+            success: Projekt bol úspešne vytvorený.
+          index:
+            actions: Akcie
+            cancel: Zrušiť
+            change_budget: Zmeniť rozpočet
+            change_selected: Zmeniť stav výberu
+            deselect_implementation: Zrušiť výber na realizáciu
+            select_for_implementation: Vybrať na realizáciu
+            selected: Vybrané
+            selected_options:
+              'no': Nie
+              'yes': Áno
+            update: Aktualizovať
+            update_budget_button: Aktualizovať rozpočet projektu
+          update:
+            invalid: Pri aktualizácii tohto projektu sa vyskytol problém.
+            success: Projekt bol úspešne aktualizovaný.
+          update_budget:
+            invalid: 'Tieto projekty už sú v rovnakom rozpočte alebo ich rozpočty presahujú maximálnu povolenú hodnotu: %{errored}.'
+            select_a_project: Vyberte projekt.
+            success: 'Projekty boli úspešne aktualizované do rozpočtu %{subject_name}: %{successful}.'
+          update_selected:
+            invalid:
+              selected: 'Tieto projekty už boli vybrané na realizáciu: %{errored}.'
+              unselected: 'Tieto projekty už boli zrušené z výberu na realizáciu: %{errored}.'
+            select_a_project: Vyberte projekt.
+            select_a_selection: Vyberte stav realizácie.
+            success:
+              selected: 'Tieto projekty boli úspešne vybrané na realizáciu: %{successful}.'
+              unselected: 'Tieto projekty boli úspešne zrušené z výberu na realizáciu: %{successful}.'
+        proposals_imports:
+          create:
+            invalid: Pri importovaní návrhov do projektov sa vyskytol problém.
+            success: '%{number} návrhov bolo úspešne importovaných do projektov.'
+          new:
+            default_budget: Predvolený rozpočet
+            origin_component_id: Pôvodný komponent
+            title: Importovať návrhy do projektov
+        reminders:
+          orders:
+            description: Používatelia dostanú e-mail s odkazmi na rozpočty, v ktorých majú čakajúce hlasovanie.
+            title:
+              one: Chystáte sa poslať e-mailovú pripomienku %{count} používateľovi
+              other: Chystáte sa poslať e-mailovú pripomienku %{count} používateľom
+      admin_log:
+        budget:
+          create: '%{user_name} vytvoril/a rozpočet %{resource_name} v priestore %{space_name}'
+          delete: '%{user_name} vymazal/a rozpočet %{resource_name} v priestore %{space_name}'
+          update: '%{user_name} aktualizoval/a rozpočet %{resource_name} v priestore %{space_name}'
+      budget_information_modal:
+        back_to: Späť na %{component_name}
+        close_modal: Zavrieť modálne okno
+        continue: Pokračovať
+        more_information: Viac informácií o rozpočte
+      budgets_list:
+        budgets: Rozpočty
+        cancel_order:
+          more_than_one: zmazať svoj hlas pre %{name} a začať odznova
+          only_one: zmazať svoj hlas a začať odznova.
+        count:
+          one: '%{count} rozpočet'
+          other: '%{count} rozpočtov'
+        empty: Zatiaľ tu nie sú žiadne rozpočty
+        finished_message: Dokončili ste proces hlasovania. Ďakujeme za účasť!
+        highlighted_cta: Hlasovať za %{name}
+        if_change_opinion: Ak ste zmenili názor, môžete
+        orders:
+          highest_cost: Najvyššie náklady
+          label: Zoradiť rozpočty podľa
+          lowest_cost: Najnižšie náklady
+          random: Náhodné poradie
+        progress: Dokončiť hlasovanie
+        remove_vote: Odstrániť hlas
+        show: Zobraziť projekty
+        vote: Hlasovať
+        voted_budgets: Odohlasované rozpočty
+        voted_on: Hlasovali ste za %{links}.
+      last_activity:
+        new_vote_at: Nové hlasovanie o rozpočte v
+      limit_announcement:
+        cant_vote: V tomto rozpočte nemôžete hlasovať. <a href="%{landing_path}">Skúste iný rozpočet</a>.
+        limit_reached: Máte aktívne hlasy v %{links}. Ak chcete hlasovať v tomto rozpočte, musíte <a href="%{landing_path}">zmazať svoj hlas a začať odznova</a>.
+      models:
+        budget:
+          fields:
+            name: Názov
+            projects_count: Počet projektov
+            total_budget: Celkový rozpočet
+        project:
+          fields:
+            map: Mapa
+      order_summary_mailer:
+        order_summary:
+          voted_on_space: Hlasovali ste v rozpočte %{budget_name} pre participatívny priestor %{space_name}.
+      projects:
+        budget_confirm:
+          are_you_sure: Ak zmeníte názor, svoj hlas môžete neskôr zmeniť.
+        budget_excess:
+          budget_excess:
+            description: Tento projekt prekračuje maximálny rozpočet a nemôže byť pridaný. Ak chcete, môžete odstrániť už vybraný projekt, aby ste mohli znova hlasovať podľa svojich preferencií.
+          description: Tento projekt prekračuje maximálny rozpočet a nemôže byť pridaný. Ak chcete, môžete odstrániť už vybraný projekt, aby ste mohli znova hlasovať podľa svojich preferencií.
+          projects_excess:
+            description: Tento projekt prekračuje maximálny počet projektov a nemôže byť pridaný. Ak chcete, môžete odstrániť už vybraný projekt, aby ste mohli znova hlasovať podľa svojich preferencií.
+            title: Prekročený maximálny počet projektov
+        budget_summary:
+          checked_out:
+            description: Už ste hlasovali za rozpočet. Ak ste zmenili názor, môžete svoj hlas zmazať.
+          vote: Hlasovať za rozpočet
+        empty: Zatiaľ tu nie sú žiadne projekty
+        exit_modal:
+          cancel: Návrat k hlasovaniu
+          exit: Ukončiť hlasovanie
+          message: Váš hlas nebol zaregistrovaný, pretože ste ešte nedokončili proces hlasovania. Naozaj chcete ukončiť hlasovanie?
+          title: Ešte ste nehlasovali
+        filters:
+          status: Stav
+          status_values:
+            all: Všetky
+            not_selected: Nevybrané
+            selected: Vybrané
+        order_progress:
+          assigned: Priradené
+          budget: Rozpočet
+          dynamic_help:
+            minimum_reached: Dosiahli ste minimum potrebné na hlasovanie
+          minimum: Minimum
+          minimum_projects_rule:
+            description: <b>Vyberte aspoň %{minimum_number} projektov</b>, ktoré chcete, a hlasujte podľa svojich preferencií.
+          projects_rule:
+            description: <b>Vyberte aspoň %{minimum_number} a najviac %{maximum_number} projektov</b>, ktoré chcete, a hlasujte podľa svojich preferencií.
+          projects_rule_maximum_only:
+            description: <b>Vyberte najviac %{maximum_number} projektov</b>, ktoré chcete, a hlasujte podľa svojich preferencií.
+          vote_threshold_percent_rule:
+            description: <b>Priraďte aspoň %{minimum_budget}</b> projektom, ktoré chcete, a hlasujte podľa svojich preferencií.
+        orders:
+          selected: Vybrané
+        project:
+          add: Pridať projekt %{resource_name} k vášmu hlasu.
+          remove: Odstrániť projekt %{resource_name} z vášho hlasu.
+          selected: Vybrané
+          votes:
+            one: hlas
+            other: hlasov
+          you_voted: Hlasovali ste za toto
+        project_budget_button:
+          add_descriptive: Pridať projekt %{resource_name} k vášmu hlasu.
+          added_descriptive: Projekt %{resource_name} bol pridaný k vášmu hlasu.
+        project_filter:
+          added: Pridané
+          all: Všetky
+        projects_for: Projekty pre %{name}
+        select_projects: Pridať projekty
+      prompt: Vybrať rozpočet
+      vote_reminder_mailer:
+        vote_reminder:
+          email_budgets: 'Oblasti, kde máte nedokončené hlasovanie:'
+          email_intro: Začali ste hlasovanie v participatívnom rozpočte, ale nedokončili ste ho.
+          email_link: Prejsť na pokračovanie v hlasovaní
+          email_outro: Nezabudnite prosím dokončiť hlasovanie. Ak chcete hlasovať, musíte najprv vybrať návrh alebo návrhy, za ktoré chcete hlasovať, a potom potvrdiť svoj hlas tlačidlom „Hlasovať“.
+          email_subject:
+            one: Máte nedokončené hlasovanie v participatívnom rozpočte
+            other: Máte nedokončené hlasovania v participatívnom rozpočte
+    comments:
+      admin:
+        shared:
+          availability_fields:
+            enabled: Komentáre povolené
+            end_time: Komentáre povolené do
+            start_time: Komentáre povolené od
+      comment_thread:
+        accessibility_label: Vlákno komentárov začal/a %{full_name} dňa %{date}
+      comments:
+        create:
+          error: Pri vytváraní komentára sa vyskytol problém.
+        delete:
+          error: Komentár sa nepodarilo odstrániť.
+        update:
+          error: Pri aktualizácii komentára sa vyskytol problém.
+      comments_title: Komentár
+      last_activity:
+        new_comment: 'Nový komentár:'
+    components:
+      accountability:
+        actions:
+          comment: Komentár
+      add_comment_form:
+        account_message: Prihláste sa alebo si vytvorte účet a pridajte svoj komentár.
+        form:
+          form_error: Text je povinný a nemôže byť dlhší ako %{length} znakov.
+          submit_reply: Zverejniť odpoveď
+          submit_root_comment: Zverejniť komentár
+        opinion:
+          label: Váš názor na túto tému
+          negative: Negatívny
+          negative_selected: Váš názor na túto tému je negatívny
+          neutral_selected: Váš názor na túto tému je neutrálny
+          positive: Pozitívny
+          positive_selected: Váš názor na túto tému je pozitívny
+      blogs:
+        actions:
+          comment: Komentovať
+          create: Vytvoriť
+          destroy: Odstrániť
+          update: Aktualizovať
+      budgets:
+        actions:
+          comment: Komentár
+        settings:
+          global:
+            form:
+              errors:
+                budget_voting_rule_only_one: Musí byť povolené iba jedno pravidlo hlasovania.
+                budget_voting_rule_required: Vyžaduje sa jedno pravidlo hlasovania.
+            geocoding_enabled: Mapy povolené
+            landing_page_content: Vstupná stránka rozpočtov
+            more_information_modal: Modálne okno s viacerými informáciami
+            resources_permissions_enabled: Oprávnenia na akcie je možné nastaviť pre každý projekt
+            title: Názov
+            vote_rule_selected_projects_enabled: 'Povoliť pravidlo: Minimálny a maximálny počet projektov, za ktoré sa má hlasovať'
+            vote_selected_projects_maximum: Maximálny počet projektov na výber
+            vote_selected_projects_minimum: Minimálny počet projektov na výber
+            workflow: Pracovný postup
+            workflow_choices:
+              all: 'Hlasovať vo všetkých: umožňuje účastníkom hlasovať vo všetkých rozpočtoch.'
+              one: 'Hlasovať v jednom: umožňuje účastníkom hlasovať v akomkoľvek rozpočte, ale iba v jednom.'
+          step:
+            highlighted_heading: Zvýraznený nadpis
+            landing_page_content: Vstupná stránka rozpočtov
+            list_heading: Nadpis zoznamu
+            more_information_modal: Modálne okno s viacerými informáciami
+            title: Názov
+            votes: Hlasovanie
+            votes_choices:
+              disabled: Hlasovanie zakázané
+              finished: Hlasovanie ukončené
+      comment:
+        cancel_reply: Zrušiť odpoveď
+        comment_label: Komentár %{comment_id}
+        comment_label_reply: Komentár %{comment_id} (odpoveď na komentár %{parent_comment_id})
+        confirm_destroy: Naozaj chcete odstrániť tento komentár?
+        controls_label: Ovládacie prvky komentára
+        delete: Odstrániť
+        deleted_at: Komentár odstránený dňa %{date}
+        edit: Upraviť
+        edited: Upravené
+        hide_replies:
+          one: Skryť odpoveď
+          other: Skryť %{count} odpovedí
+        moderated_at: Komentár moderovaný dňa %{date}
+        report:
+          reasons:
+            does_not_belong: Obsahuje nezákonnú činnosť, vyhrážky samovraždou, osobné údaje alebo niečo iné, čo podľa vás nepatrí na %{organization_name}.
+          title: Nahlásiť nevhodný obsah
+        show_replies:
+          one: Zobraziť odpoveď
+          other: Zobraziť %{count} odpovedí
+        single_comment_link_title: Získať odkaz
+      comments:
+        blocked_comments_for_unauthorized_user_warning: Ak chcete momentálne komentovať, musíte byť overený, ale môžete si prečítať predchádzajúce.
+        single_comment_warning: <a href="%{url}">Zobraziť všetky komentáre</a>
+        title:
+          one: '%{count} komentár'
+          other: '%{count} komentárov'
+      component_order_selector:
+        no_content: Nenašli sme žiadny obsah vyhovujúci týmto kritériám.
+        order:
+          order: Hlasovanie o rozpočte
+      debates:
+        actions:
+          comment: Komentovať
+        settings:
+          step:
+            creation_enabled: Účastníci môžu vytvárať debaty
+      down_vote_button:
+        label:
+          one: Tlačidlo Nepáči sa mi to. %{count} nepáči sa mi to
+          other: Tlačidlo Nepáči sa mi to. %{count} nepáči sa mi to
+        text: Nesúhlasím s týmto komentárom
+      dummy:
+        settings:
+          global:
+            guided: Riadený vstup
+            guided_help: Text pomocníka
+            guided_readonly: Zakázaný vstup
+            guided_rich: Riadený formátovaný vstup
+            guided_rich_help_html: HTML <strong>text</strong> pomocníka
+            guided_rich_readonly_html: HTML <strong>text</strong> pomocníka pre zakázaný vstup
+            readonly_attribute: Atribút iba na čítanie
+            test: Test
+            test_choices:
+              a: Možnosť A
+              b: Možnosť B
+              c: Možnosť C
+            test_options:
+              baz: Baz
+          step:
+            readonly_step_attribute: Atribút kroku iba na čítanie
+            test_options:
+              baz: Baz
+      edit_comment_modal_form:
+        close: Zavrieť
+        form:
+          body:
+            label: Komentár
+            placeholder: Čo si o tom myslíte?
+          submit: Odoslať
+        title: Upraviť svoj komentár
+      meetings:
+        actions:
+          comment: Komentovať
+          reply_poll: Odpovedať na anketu
+        settings:
+          global:
+            creation_enabled_for_participants: Účastníci môžu vytvárať stretnutia
+            maps_enabled: Mapy povolené
+            registration_code_enabled: Registračný kód a QR povolené
+            terms_and_conditions_url_for_meeting_creators: URL adresa podmienok pre tvorcov stretnutí
+          step:
+            creation_enabled_for_participants: Vytváranie stretnutí účastníkmi je povolené
+      pagination:
+        page_title: '%{component_name} - Strana %{current_page} z %{total_pages}'
+      proposals:
+        actions:
+          comment: Komentovať
+          vote: Hlasovať
+          vote_comment: Hlasovať za komentár
+        settings:
+          global:
+            attachments_allowed_help: Povolením tejto možnosti sa návrhy predvolene zobrazia v režime mriežky a na karte sa zobrazí prvý obrázok.
+            can_accumulate_votes_beyond_threshold: Môže zhromažďovať hlasy nad stanovenú hranicu
+            default_sort_order: Predvolené zoradenie návrhov
+            default_sort_order_help: Automaticky znamená, že ak sú hlasy povolené, návrhy sa zobrazia náhodne zoradené, a ak sú hlasy zablokované, zoradia sa podľa najvyššieho počtu hlasov.
+            default_sort_order_options:
+              automatic: Automaticky
+              most_commented: Najviac komentované
+              most_followed: Najviac sledované
+              most_voted: S najväčším počtom hlasov
+              random: Náhodne
+              recent: Najnovšie
+              with_more_authors: S viacerými autormi
+            minimum_votes_per_user: Minimálny počet hlasov na používateľa
+            proposal_edit_time: Úprava návrhu
+            proposal_edit_time_choices:
+              infinite: Povoliť úpravu návrhov na neobmedzený čas
+              limited: Povoliť úpravu návrhov v konkrétnom časovom rámci
+            proposal_wizard_step_2_help_text: Text pomocníka pre krok „Zverejniť“ v sprievodcovi návrhom
+            vote_limit: Limit hlasov na účastníka
+          step:
+            amendments_visibility_choices:
+              all: Pozmeňujúce návrhy sú viditeľné pre všetkých
+              participants: Pozmeňujúce návrhy sú viditeľné iba pre ich autorov
+            creation_enabled: Účastníci môžu vytvárať návrhy
+            creation_enabled_readonly: Toto nastavenie je zakázané, keď aktivujete funkciu Participatívne texty. Ak chcete nahrať návrhy ako participatívny text, kliknite na tlačidlo Participatívne texty a postupujte podľa pokynov.
+            default_sort_order: Predvolené zoradenie návrhov
+            default_sort_order_help: Automaticky znamená, že ak sú hlasy povolené, návrhy sa zobrazia náhodne zoradené, a ak sú hlasy zablokované, zoradia sa podľa najvyššieho počtu hlasov.
+            default_sort_order_options:
+              automatic: Automatické
+              most_commented: Najviac komentované
+              most_followed: Najviac sledované
+              most_voted: Najviac hlasované
+              random: Náhodné
+              recent: Najnovšie
+              with_more_authors: S viacerými autormi
+            publish_answers_immediately_help_html: Pamätajte, že ak odpoviete na akýkoľvek návrh bez tohto povolenia, budete ich musieť zverejniť manuálne ich výberom a použitím akcie na zverejnenie. Pre viac informácií o tom, ako to funguje, si pozrite <a href="https://docs.decidim.org/en/admin/components/proposals/answers#_publication" target="_blank">stránku dokumentácie k odpovediam na návrhy</a>.
+            votes_blocked: Hlasy zablokované
+            votes_enabled: Hlasy povolené
+            votes_hidden: Hlasy skryté (ak sú hlasy povolené, zaškrtnutím tohto políčka sa skryje počet hlasov)
+      up_vote_button:
+        label:
+          one: Tlačidlo Páči sa mi to. %{count} páči sa mi to
+          other: Tlačidlo Páči sa mi to. %{count} páči sa mi to
+        text: Súhlasím s týmto komentárom
+    conferences:
+      admin:
+        conference_invites:
+          new:
+            explanation: Účastník bude pozvaný, aby sa pripojil ku konferencii. Ak jeho e-mail nie je zaregistrovaný, bude pozvaný aj do organizácie.
+        conferences:
+          form:
+            slug_help_html: 'URL slugy sa používajú na generovanie URL adries, ktoré odkazujú na túto konferenciu. Akceptujú sa iba písmená, čísla a pomlčky a musia začínať písmenom. Príklad: %{url}'
+        content_blocks:
+          highlighted_conferences:
+            max_results: Maximálny počet zobrazených prvkov
+        diplomas:
+          edit:
+            title: Certifikát o účasti
+        invite_join_conference_mailer:
+          invite:
+            invited_user_to_join_a_conference: '%{invited_by} vás pozval/a, aby ste sa pripojili ku konferencii na %{application}. Môžete to prijať prostredníctvom odkazu nižšie.'
+        send_conference_diploma_mailer:
+          diploma_user:
+            certificate_of_attendance: Certifikát o účasti
+      conference_program:
+        program_item:
+          other_category: Iné
+      conference_registrations:
+        create:
+          unauthorized: Pred registráciou na konferenciu sa musíte prihlásiť.
+        decline_invitation:
+          unauthorized: Pred odmietnutím pozvánky sa musíte prihlásiť.
+      conference_speaker:
+        go_to_twitter: Prejsť na X
+        show:
+          speaking_at: Vystupuje na
+      conference_speakers:
+        index:
+          speakers:
+            one: Rečník
+            other: Rečníci
+      conferences:
+        show:
+          already_have_an_account?: Už máte účet?
+          are_you_new?: Nový účastník?
+          make_conference_registration: Zaregistrovať sa na konferenciu
+          manage_registration: Spravovať registráciu
+          sign_in_description: Prihláste sa pre registráciu na konferenciu
+          sign_up_description: Vytvorte si účet pre registráciu na konferenciu
+      last_activity:
+        new_conference: 'Nová konferencia:'
+      mailer:
+        conference_registration_mailer:
+          confirmation:
+            subject: Vaša registrácia na konferenciu bola potvrdená.
+          pending_validation:
+            subject: Vaša registrácia na konferenciu čaká na potvrdenie.
+      pages:
+        home:
+          highlighted_conferences:
+            see_all_spaces: Zobraziť všetky konferencie
+      registration_types:
+        index:
+          no_registrations: Žiadne registrácie
+    content_blocks:
+      announcement:
+        name: Oznámenie
+      cta:
+        name: Obrázok, text a tlačidlo s výzvou na akciu
+      cta_settings_form:
+        background_image: Obrázok na pozadí
+        button_text: Text výzvy na akciu
+        button_url: URL výzvy na akciu
+        description: Popis
+      hero:
+        name: Hlavný obrázok a výzva na akciu
+      highlighted_elements_settings_form:
+        components:
+          all: Všetky
+          label: 'Vyberte komponent:'
+        orders:
+          label: 'Zoradiť prvky podľa:'
+          random: Náhodne
+          recent: Najnovšie
+      last_activity_settings_form:
+        max_last_activity_users: Maximálny počet zobrazených avatarov používateľov s nedávnou aktivitou
+      main_data:
+        name: Hlavné údaje
+      metadata:
+        name: Metadáta
+      participatory_space_stats:
+        name: Štatistiky
+      social_networks_metadata:
+        name: Sociálne siete
+      static_page:
+        section:
+          name: Sekcia
+          section_content: Obsah
+        summary:
+          name: Zhrnutie
+          summary_content: Obsah
+        two_pane_section:
+          left_column: Ľavý stĺpec
+          name: Dvojstĺpcová sekcia
+          right_column: Pravý stĺpec
+    core:
+      actions:
+        login_before_access: Pred prístupom sa, prosím, prihláste do svojho účtu.
+        unauthorized: Na vykonanie tejto akcie nemáte oprávnenie.
+      application_helper:
+        filter_area_values:
+          all: Všetky
+        filter_scope_values:
+          all: Všetky
+    debates:
+      actions:
+        close: Zavrieť
+        new: Nová debata
+      admin:
+        debate_closes:
+          edit:
+            close: Zatvoriť
+            title: Zatvoriť debatu
+        debates:
+          form:
+            debate_type: Typ debaty
+            finite: Konečná (so začiatočným a koncovým časom)
+            open: Otvorená (bez začiatočného alebo koncového času)
+      admin_log:
+        debate:
+          close: '%{user_name} zatvoril/a debatu %{resource_name} v priestore %{space_name}'
+      debate_m:
+        commented_time_ago: Komentované pred %{time}
+      debates:
+        close:
+          invalid: Pri zatváraní debaty sa vyskytol problém.
+          success: Debata bola úspešne zatvorená.
+        close_debate_modal:
+          cancel: Zrušiť
+          description: Aké je zhrnutie alebo záver tejto debaty?
+          send: Zatvoriť debatu
+        debates:
+          empty: Zatiaľ tu nie sú žiadne debaty.
+          empty_filters: Neexistujú žiadne debaty s týmito kritériami.
+        edit:
+          back: Späť
+          save: Uložiť zmeny
+          title: Upraviť debatu
+        filters:
+          activity: Moja aktivita
+          commented: Komentované
+          my_debates: Moje debaty
+          participants: Účastníci
+          state: Stav
+          state_values:
+            closed: Zatvorené
+        new:
+          title: Vytvoriť novú debatu
+        orders:
+          label: Zoradiť debaty podľa
+          random: Náhodné poradie
+          recent: Najnovšie
+          updated: Nedávno aktualizované
+        show:
+          close_debate: Zatvoriť
+          debate_conclusions_are: 'Debata bola zatvorená dňa %{date} s týmito závermi:'
+          edit_conclusions: Upraviť závery
+          participants_count: Účastníci
+        update:
+          invalid: Pri aktualizácii debaty sa vyskytol problém.
+          success: Debata bola úspešne aktualizovaná.
+      last_activity:
+        debate_updated: 'Debata aktualizovaná:'
+        new_debate: 'Nová debata:'
+      models:
+        debate:
+          fields:
+            end: Koniec
+            start: Začiatok
+    design:
+      components:
+        accordions:
+          content_panel: Obsah panela
+          demo: Ukážka
+          demo_description: V celej aplikácii sa akordeóny používajú hlavne na zobrazenie/skrytie obsahu v kartách alebo na zbalenie/rozbalenie viditeľných textov.
+          description_accordions_html: Akordeóny sú javascriptová funkcia dostupná vďaka externej knižnici s názvom %{link_code} a11y-accordion-component.
+          github_source_html: Zdrojový kód na GitHub %{github_link}
+          panel: Panel
+          title: Akordeóny
+          trigger: Spúšťač
+          usage: Použitie
+          usage_p: Akordeón vyžaduje aspoň tri prvky
+          usage_p_1_html: 1. Obalový <code>div</code> s dátovým atribútom <code>data-controller="accordion"</code> nad všetkými dostupnými spúšťačmi a panelmi.
+          usage_p_2_html: 2. Spúšťací prvok, na ktorý môže používateľ kliknúť (ako tlačidlo), ukazujúci na zbaľovací prvok prostredníctvom <code>data-controls="panel"</code>, kde <i>panel</i> je <code>id</code> panela.
+          usage_p_3_html: 3. Skrývateľný prvok, ktorého <code>id</code> sa zhoduje s hodnotou data-controls, na ktorú odkazuje spúšťač.
+        activities:
+          activities: Aktivity
+        address:
+          title: Adresa
+        announcement:
+          iam_an_announcement: Som oznámenie
+          this_is_the_body: Toto je telo
+          this_is_the_title: Toto je názov
+          title: Oznámenie
+        author:
+          title: Autor
+        buttons:
+          description_html: 'Tlačidlá sú vytvorené pomocou rôznych kombinácií tried CSS: triedy <code>button</code>, veľkosti a farby.'
+          title: Tlačidlá
+        cards:
+          title: Karty
+        dialogs:
+          dialog_demo_description_html: Dialógové okná alebo modálne komponenty sú implementované prostredníctvom rails helpera <code>decidim_modal</code>.
+          dialogs_description_html: Dialógové okná sú javascriptová funkcia dostupná vďaka externej knižnici s názvom <a href="https://github.com/jonathanlevaillant/a11y-dialog-component" target="_blank" rel="noopener noreferrer">a11y-dialog-component</a>.
+          tips_description: 'Ak chcete zobraziť komplexné modálne okno so zodpovedajúcimi štýlmi, použite nasledujúce značky:'
+          tips_description_html: Venujte pozornosť <i>dátovým atribútom</i> a <i>id</i>. Napríklad id <code>[data-dialog-title]</code> začína na <i>dialog-title</i> plus <i>id modálneho okna</i>.
+          title: Dialógové okná
+          usage_description: Dialógové okno vyžaduje dva prvky
+          usage_description_2_html: 2. Modálny prvok, ktorého <code>id</code> sa zhoduje s hodnotou data-target, na ktorú odkazuje spúšťač.
+          usage_description_html: 1. Prvok, na ktorý môže používateľ kliknúť, s dátovým atribútom <code>data-dialog-open="example"</code>, kde example je <code>id</code> modálneho okna.
+        follow:
+          title: Sledovať
+        forms:
+          disabled: Zakázané
+          emojis: Emodži
+          emojis_description: Funguje iba pre textové pole (textarea)
+          errors: Chyby
+          errors_description: Nevzťahuje sa na výber (select)
+          header_alert: Táto stránka pochádza zo staršieho zobrazenia. Obsah je zastaraný.
+          help_texts: Texty pomocníka
+          html_regular_inputs: Bežné vstupy HTML
+          min_max_length: Min/Max dĺžka
+          min_max_length_description: Funguje iba pre input type='text' a textarea
+          multiselect: Viacnásobný výber
+          multiselect_description_html: Viacnásobné výbery sú javascriptová funkcia dostupná vďaka externej knižnici s názvom <a href="https://tom-select.js.org/" target="_blank" rel="noopener noreferrer">Tom Select</a>.
+          regular_inputs_description: 'Zobrazuje iba bežné typy, úplný dostupný zoznam: date, datetime-local, email, month, number, password, search, tel, text, time, url, week'
+          textarea_required: vyžaduje sa textarea
+          title: Formuláre
+        report:
+          title: Nahlásiť
+        share:
+          title: Zdieľať
+        tab_panels:
+          title: Panely kariet
+        tooltips:
+          demo: Ukážka
+          demo_description: Aby tento komponent fungoval, účastník musí prejsť myšou na prvok.
+          description: Popis (tooltip) je komponent, na ktorý môžu používatelia prejsť myšou, aby o ňom získali ďalšie informácie.
+          github_source_html: Zdrojový kód na GitHub %{github_link}
+          title: Popisy (Tooltips)
+          usage: Použitie
+          usage_p: 'Popis vyžaduje použitie helpera `with_tooltip` s tromi argumentmi:'
+          usage_p_1_html: 1. Reťazec s hodnotou popisu. V príklade na tejto stránke je to „Hello world“.
+          usage_p_2_html: 2. Voliteľná trieda so symbolom, kde sa popis zobrazí. Možné hodnoty sú <code>:top</code>, <code>:bottom</code>, <code>:right</code> alebo <code>:left</code>.
+          usage_p_3_html: 3. Blok s reťazcom, na ktorý musí používateľ prejsť myšou, aby sa zobrazil.
+      foundations:
+        accessibility:
+          accessibility_labels: Štítky prístupnosti
+          accessibility_labels_paragraph: Pri definovaní prvkov sa vždy uistite, že dávajú zmysel pre používateľov čítačiek obrazovky.
+          accessibility_title: Prístupnosť
+          adjacent_links: Susediace odkazy
+          adjacent_links_header: Susediace odkazy na rovnaký zdroj
+          adjacent_links_paragraph: Ak má rovnaký zdroj viacero susediacich odkazov, ktoré naň smerujú, sťažuje to takýmto používateľom prezeranie stránky, pretože by mohli musieť prejsť viacerými odkazmi, aby sa dostali k ďalšiemu zdroju.
+          color_contrast: Farebný kontrast
+          color_contrast_paragraph: Pri vytváraní používateľských rozhraní alebo úprave farieb sa vždy uistite, že svojimi zmenami nenarušíte prístupnosť. Môžete použiť nástroj na kontrolu farebného kontrastu, aby ste sa uistili, že vaše farby majú dostatočný kontrast voči farbe pozadia, na ktorom sú zobrazené.
+          decidim_follows_html: Decidim sa riadi %{link}
+          dynamic_changes_header: Dynamická funkcionalita mení kontext stránky neintuitívne
+          dynamic_changes_paragraph: Zmeny vo vstupoch formulára by nemali automaticky meniť kontext stránky.
+          elements_hidden: Skryté prvky
+          elements_hidden_header: Prvky skryté pred API pre prístupnosť
+          elements_hidden_paragraph: Ak chcete skryť prvok pred asistenčnými technológiami, použite na ňom atribút aria-hidden="true".
+          heading_on: Nadpis v dôležitých sekciách
+          illogical_heading_order: Nelogické poradie nadpisov
+          illogical_heading_paragraph: Každá stránka by mala mať logické poradie nadpisov pri použití prvkov nadpisov <h1>, <h2>, <h3>, <h4>, <h5> a <h6>.
+          important_sections_heading: Nadpis v dôležitých sekciách
+          important_sections_paragraph: Je veľmi dôležité, aby každá dôležitá sekcia stránky mala nadpis, čo uľahčí pochopenie toho, aké dôležité sekcie sa na stránke nachádzajú, len prechádzaním jej nadpisov.
+          learn_more_about_html: Zistite viac o %{link}
+          links_and_buttons: Odkazy a tlačidlá
+          links_and_buttons_paragraph: Prvky kotvy (t. j. odkazy) sú určené na odkazovanie na iné stránky alebo na pozície kotvy v rámci stránky. Ak má prvok napr. otvoriť nejakú skrytú položku na danej stránke, mali by ste namiesto toho použiť prvok <button>.
+          unique_h1: Jedinečný H1
+          unique_h1_paragraph: Každá stránka by mala mať jedinečný nadpis H1
+          use_aria: Použite ARIA
+          use_aria_header: Kde je to možné, použite atribúty ARIA
+          use_aria_paragraph: Mnohé prvky, ktoré poskytujú interaktívnu funkcionalitu na webovej stránke, vyžadujú atribúty ARIA, aby boli prístupné.
+          wcag_guidelines: Smernice pre prístupnosť obsahu webu (WCAG)
+        color:
+          color_header: Farba
+          description_p1: Poskytujeme základnú paletu s niekoľkými farbami, takže jednoduché prispôsobenia sú ľahké. Základnú paletu môžete upraviť buď v oblasti administrácie, alebo v konfiguračnom súbore Tailwind, ak potrebujete pokročilejšie prispôsobenie.
+          description_p2_html: Pri prispôsobovaní farieb majte na pamäti %{contrast_link}. Kontrast vášho výberu si môžete overiť pomocou %{checker_link} alebo iných podobných nástrojov.
+          wcag_compliant_rations: Pomer kontrastu v súlade s WCAG 2.1 AA
+          wcag_contrast_checker: Nástroj na kontrolu kontrastu WebAIM
+        iconography:
+          description_iconography: Ikony používame na posilnenie významu akcií, názvov atď.
+          description_iconography_html: 'Používame open source knižnicu Remixicon: %{iconography_link}'
+          title: Ikonografia
+        layout:
+          breakpoint: Bod zlomu
+          breakpoints: Body zlomu
+          centered: Zarovnané na stred
+          code: Kód
+          columns: Pričom počet stĺpcov je 10, 8 alebo 6.
+          description_layout_p1: Pre počítače používa Decidim 12-stĺpcovú mriežku s obmedzeným počtom šablón (konfigurácií mriežky) pre rôzne typy obsahu. Cieľom je, aby mal daný typ obsahu (domovská stránka, zoznam prvkov, jednotlivá položka) charakteristické rozloženie, takže používatelia môžu pochopiť, v akom druhu obsahu sa nachádzajú, len na základe celkového vzhľadu stránky.
+          description_layout_p2: Tieto jednoduché pravidlá by sa mali dodržiavať pri vytváraní nových modulov alebo prispôsobovaní existujúcich, aby si stránka Decidim zachovala svoju konzistenciu.
+          desktop: Počítač
+          full_width: Plná šírka
+          layout_list_1: 'Domovská stránka (stránky, priestoru): plná šírka'
+          layout_list_2: 'Zoznam prvkov (priestorov, položiek v priestore atď.): ľavý bočný panel'
+          layout_list_3: 'Jednotlivá položka (návrh, príspevok na blogu): zarovnané na stred, voliteľne s pravým bočným panelom'
+          left_aside: Ľavý bočný panel
+          mobile: Mobil
+          not_required: Nevyžaduje sa
+          properties: Vlastnosti
+          right_aside: Pravý bočný panel
+          section_p_breakpoints: 'Na správu responzívnej šírky prvkov sa spoliehame na predvolenú triedu Tailwind `container`. Podporované rozlíšenia sú:'
+          section_p_code: Pri implementácii nových modulov máte k dispozícii niekoľko pomocníkov (helpers), ktorí vám automaticky poskytnú kód potrebný na nastavenie štruktúry HTML. Mali by ste používať týchto pomocníkov namiesto priameho používania prvkov div s triedami, aby ste zachovali konzistenciu.
+          section_p_code_html: Základné rozloženia nájdete v %{link_section_code}
+          section_p_desktop: Systém mriežky pre počítače sa skladá z 12 flexibilných stĺpcov s medzerou medzi stĺpcami 16px a ľavým a pravým okrajom 48px
+          section_p_mobile: Mobilný mriežkový systém sa skladá zo 4 flexibilných stĺpcov s medzerou medzi stĺpcami 16px a ľavým a pravým okrajom 16px.
+          section_p_tablet: Systém mriežky pre tablety sa skladá z 8 flexibilných stĺpcov s medzerou medzi stĺpcami 16px a ľavým a pravým okrajom 24px
+          tablet: Tablet
+          title: Rozloženie
+        typography:
+          description: Tieto usmernenia zhrňujú, ako používať typografiu v Decidime, a slúžia ako mantinely pre dizajnérov, aby mohli slobodne navrhovať s ohľadom na najlepšie typografické postupy.
+          headings:
+            characters: Znakov na riadok
+            layout: Stĺpce rozloženia
+            size: Veľkosť
+          title: Typografia
+          typefaces_description_1: Decidim používa ako primárne písmo Source Sans Pro. Toto písmo podporuje 310 jazykov
+          typefaces_description_2: Tieto písma sú licencované pod Open Font License
+      helpers:
+        accountability: Zodpovednosť
+        accountability_cards_html: Používa sa na kartách <i>Projektov zodpovednosti</i>. Táto karta vyžaduje na správne zobrazenie prostriedky modulu, t. j. <code>append_stylesheet_pack_tag \"decidim_accountability\"</code>
+        activity: Aktivita
+        address_description: Bunka adresy prijme zdroj a prehľadá geolokalizovateľné atribúty, aby vygenerovala špecifické značkovanie.
+        address_description_2: V závislosti od typu obsahu môže byť adresou online URL. V takýchto prípadoch sú zobrazené informácie takmer rovnaké, ale prispôsobené tak, aby vyhovovali.
+        ally_link: a11y-dropdown-component
+        argument: Argument
+        assemblies: Zhromaždenia
+        assembly_g: Zhromaždenie G
+        assembly_s: Zhromaždenie S
+        avatar: Avatar
+        avatar_description: Používa sa v úzkych priestoroch, kde je autor sekundárnou informáciou.
+        background: Pozadie a okraje
+        base: Základ
+        block_text: Použite blok extra_data
+        blog_cards_html: Používa sa na kartách <i>Blogov</i>
+        blogs: Blogy
+        budget_card_html: Používa sa na kartách <i>Rozpočtových projektov</i>. Táto karta vyžaduje na správne zobrazenie prostriedky modulu, t. j. <code>append_stylesheet_pack_tag \"decidim_budgets\"</code>
+        budgets: Rozpočty
+        callout_class: Trieda upozornenia
+        callout_description: Tento atribút aplikuje stav na oznámenie. Predvolene používa sekundárnu farbu.
+        card_g: Karta G
+        card_l: Karta L
+        card_s: Karta S
+        colors: Farby
+        compact: Kompaktné
+        compact_description: Táto verzia autora je bežným spôsobom identifikácie tvorcu zdroja.
+        conference_g: Konferencia G
+        conference_s: Konferencia S
+        conferences: Konferencie
+        context: Kontext
+        context_description: Táto bunka zobrazuje niektoré informácie o používateľovi. Je to vizuálna pomôcka na identifikáciu tvorcu zdroja/obsahu.
+        context_description_2: Pri zdrojoch sa táto bunka zobrazuje pod hlavným nadpisom. Pri inom obsahu sa zobrazuje vedľa samotného obsahu.
+        debate_l: Debata L
+        debate_s: Debata S
+        debates: Debaty
+        debates_cards_html: Používa sa na kartách <i>Debát</i>
+        debates_cards_text: Použite inú šablónu pre blok obrázka
+        default: Predvolené
+        default_description: Volanie bunky bez ďalších argumentov, iba so samotným používateľom.
+        demo: Demo
+        demo_text: 'Táto bunka prijíma model položiek LastActivity a zobrazuje nasledujúce prvky:'
+        demo_text_2: Používa sa na stránke poslednej aktivity, v bloku obsahu a v rozbaľovacích ponukách.
+        description: Popis
+        disabled: Neaktívne
+        dropdowns: Rozbaľovacie ponuky
+        dropdowns_demo_1_description: 'Nasledujúci príklad nebude viditeľný na počítači, ale na mobilnom zariadení:'
+        dropdowns_demo_description: Rozbaľovacie ponuky sa používajú v celej aplikácii na zbalenie veľkých, ľahko čitateľných ponúk pre stolné zariadenia, ktoré sú však pre mobilné zariadenia príliš rozsiahle.
+        dropdowns_demo_description_html: 'Táto funkcia javascriptu je vylepšená malým css prostredníctvom pomenovania: skrytý obsah MUSÍ MAŤ <code>id</code> začínajúce na <i>dropdown-menu</i>.'
+        dropdowns_description_html: Rozbaľovacie ponuky sú funkciou javascriptu dostupnou vďaka externej knižnici s názvom %{link}.
+        dropdowns_usage_1_description: 2. Skrývateľný prvok, ktorého <code>id</code> sa zhoduje s hodnotou data-target, na ktorú odkazuje spúšťač.
+        dropdowns_usage_description: 'Rozbaľovacia ponuka vyžaduje dva prvky:'
+        dropdowns_usage_description_html: 1. Prvok, s ktorým môže používateľ interagovať, s dátovými atribútmi <code>data-controller="dropdown" data-target="dropdown-menu-element"</code>.
+        dummy_description: Popis fiktívneho zdroja
+        dummy_title: Názov fiktívneho zdroja
+        follow_button: Tlačidlo Sledovať
+        follower_description_html: Uistite sa, že čiastočná šablóna <code>decidim/shared/login_modal</code> je prítomná v DOM. Táto čiastočná šablóna sa umiestni do rozloženia aplikácie, keď je používateľ prihlásený.
+        form_elements: Prvky formulára
+        generic_cards: Všeobecné karty
+        grid: Mriežka
+        hex_code: Hex kód
+        highlight: Zvýraznenie
+        highlight_description: Používané zdrojmi, ktoré umožňujú zvýraznenie
+        html_tips: Tipy pre HTML
+        icons: Ikony
+        image_and_description: Obrázok a popis
+        initiative_g: initiative_g
+        initiative_s: initiative_s
+        initiatives: Iniciatívy
+        list: Zoznam
+        main_colors: Hlavné farby
+        meeting_l: Stretnutie L
+        meetings: Stretnutia
+        meetings_html: Používané kartami <i>Stretnutia</i>
+        metadata_items: Položky metadát
+        metadata_text: Každý zdroj definuje svoje vlastné položky metadát
+        participatory_process_g: Participatívny proces G
+        participatory_process_group_g: Skupina participatívnych procesov G
+        participatory_process_group_s: Skupina participatívnych procesov S
+        participatory_process_s: Participatívny proces S
+        participatory_processes: Participatívne procesy
+        plain_text: Som len obyčajný text
+        plain_text_description: Ako prvý argument môžete poskytnúť obyčajný text aj objekt hash
+        plain_text_vs_hash: Obyčajný text vs Hash
+        post_g: Príspevok G
+        post_l: Príspevok L
+        post_s: Príspevok S
+        project_l: Projekt L
+        project_s: Projekt S
+        proposal_l: Návrh L
+        proposal_s: Návrh S
+        proposals: Návrhy
+        report_button: Tlačidlo Nahlásiť
+        report_usage_description: Tlačidlo Nahlásiť otvorí modálne okno na označenie aktuálneho zdroja.
+        result_l: Výsledok L
+        rgba_code: RGBA kód
+        search: Hľadať
+        send: Odoslať
+        share_button: Tlačidlo Zdieľať
+        share_usage_description_html: Uistite sa, že čiastočná šablóna <code>decidim/shared/share_modal</code> je prítomná v DOM. Táto čiastočná šablóna je umiestnená v rozložení aplikácie.
+        sizes: Veľkosti
+        source_code: Zdrojový kód
+        state: Stav
+        tab_panels_context_description: Tento komponent panelu kariet zhromažďuje všetok súvisiaci obsah alebo iné zdroje zobrazeného hlavného prvku, aby sa ušetril vertikálny priestor. Kliknutím na kartu sa aktivuje vytvorený panel a zobrazí sa obsah.
+        tab_panels_context_description_html: Používa sa hlavne v rámci <i>layout_item</i> alebo <i>layout_center</i>, za hlavným obsahom zdroja.
+        tab_panels_usage_description: 'Tento komponent prijíma pole hashov a preusporiada výstup každej položky do štruktúry panelu kariet. Dostupné vlastnosti pre každý panel:'
+        tab_panels_usage_description_arguments_html: '<strong>args</strong>: <i>Array</i>. Argumenty pre predchádzajúcu metódu'
+        tab_panels_usage_description_html: '<strong>enabled</strong>: <i>Boolean</i>. Podmienečné vykreslenie karty'
+        tab_panels_usage_description_id_html: '<strong>id</strong>: <i>String</i>. Jedinečné id'
+        tab_panels_usage_description_rails_html: '<strong>method</strong>: <i>Symbol</i>. Akákoľvek funkcia, ktorej rails rozumie'
+        tab_panels_usage_description_remixicon_html: '<strong>icon</strong>: <i>String</i>. Kľúč Remixicon'
+        tab_panels_usage_description_tab_html: '<strong>text</strong>: <i>String</i>. Názov karty'
+        tailwind: Názov Tailwind
+        text: Text
+        transparent: Priehľadné
+        transparent_description: 'V prípade tmavšieho pozadia:'
+        types: Typy
+        typography_texts: Typografia a texty
+        usage: Použitie
+        usage_background_1: Pozadie bočného panela
+        usage_background_2: Pozadie vybraného filtra bočného panela
+        usage_background_3: Predvolená farba ikony
+        usage_background_4: Čiary a oddeľovače
+        usage_background_5: Pozadie pätičky
+        usage_background_6: Pozadie rozloženia administrátora
+        usage_base_1: Pozadie hlavného navigačného komponentu\nNavigačné ponuky na domovskej stránke a domovskej stránke priestoru
+        usage_base_2: Hlavná farba pre odkazy a tlačidlá
+        usage_base_3: Grafické ornamenty a farba zvýraznenia\nOkraj kariet a položiek zoznamu pri ukázaní myšou
+        usage_formelements_1: Predvolené pozadie vstupných prvkov
+        usage_formelements_2: Pozadie vstupných prvkov v neaktívnom stave
+        usage_state_1: Okraj oznámenia o úspechu\nVýplň ikony upozornenia\nPozadie tlačidla pri správe o úspechu
+        usage_state_2: Okraj oznámenia o varovaní
+        usage_state_3: Okraj oznámenia o upozornení\nVýplň ikony upozornenia
+        usage_typography_1: Nadpisy a názvy sekcií
+        usage_typography_2: Vložený text
+        usage_typography_3: Text na tmavom pozadí
+        usage_typography_4: Odkazy a tlačidlá
+        value: Hodnota
+        variations: Variácie
+        variations_cards_description: Každá karta bude vyzerať inak v závislosti od vlastností zobrazeného zdroja. Toto správanie môžete prepísať v konkrétnej bunke.
+        variations_description: Existujú tri rôzne verzie tejto bunky. Každá sa lepšie hodí vzhľadom na kontext, v ktorom sa zobrazuje.
+        variations_text: V závislosti od typu aktivity môže bunka zobrazovať rôzny obsah, informovať o rôznych zdrojoch, či už patria do participatívneho priestoru alebo nie, či majú autora alebo nie.
+      home:
+        index:
+          by_sharing_principles: Zdieľaním princípov, filozofie a dôvodov, ktoré stoja za rozhodnutiami o dizajne, chceme posilniť komunitu, aby prispievala konzistentne, a tak sme dosiahli najlepšiu skúsenosť účastníkov.
+          decidim_guide: Sprievodca dizajnom všetkého v Decidime
+          different_ui_components: Zároveň dokumentujeme rôzne používané komponenty a vzory používateľského rozhrania, ktoré by sa mali opätovne použiť alebo rozšíriť.
+          github_source: Zdrojový kód na GitHube
+          home_header: Sprievodca dizajnom Decidim
+          welcome_sentence: Vitajte v Sprievodcovi dizajnom Decidim (DDG). Tento sprievodca je zdrojom pre dizajnérov a vývojárov, ktorí potrebujú prispôsobovať, vyvíjať nové moduly a integrovať nové funkcie.
+    devise:
+      omniauth_registrations:
+        create:
+          email_already_exists: Rovnakú e-mailovú adresu už používa iný účet.
+        new:
+          nickname_help: Váš alias v organizácii %{organization}. Môže obsahovať iba písmená, čísla, '-' a '_'.
+          subtitle: Pre dokončenie vytvorenia účtu, prosím, vyplňte nasledujúci formulár
+      registrations:
+        create:
+          error: Pri vytváraní vášho účtu sa vyskytol problém.
+        new:
+          sign_up: Vytvoriť účet
+          subtitle: Vytvorte si účet, aby ste sa mohli zapojiť do platformy.
+          terms: podmienky používania
+      sessions:
+        new:
+          sign_in_disabled: Môžete pristupovať pomocou externého účtu.
+          sign_up_disabled: Vytváranie účtov je zakázané, na prístup môžete použiť existujúci účet.
+        user:
+          timed_out: Boli ste príliš dlho neaktívny a boli ste automaticky odhlásený zo služby. Ak chcete službu naďalej používať, znova sa prihláste.
+      shared:
+        newsletter_modal:
+          buttons:
+            uncheck: Ponechať nezaškrtnuté
+          notice: '<p>Dobrý deň, ste si istý, že nechcete dostávať newsletter?
+
+            Zvážte, prosím, opätovné zaškrtnutie políčka pre newsletter nižšie.
+
+            Je pre nás veľmi dôležité, aby ste mohli dostávať občasné e-maily
+
+            s dôležitými oznámeniami. Toto nastavenie môžete kedykoľvek zmeniť na
+
+            stránke nastavení upozornení.</p>
+
+            <p>Ak políčko nezaškrtnete, môžu vám uniknúť dôležité informácie
+
+            o nových možnostiach participácie v rámci platformy.<br>
+
+            Ak sa aj napriek tomu chcete vyhnúť prijímaniu newslettrov, vaše
+
+            rozhodnutie plne chápeme.</p>
+
+            <p>Ďakujeme za prečítanie!</p>'
+        password_fields:
+          hidden_password: Vaše heslo je skryté
+          hide_password: Skryť heslo
+          show_password: Zobraziť heslo
+          shown_password: Vaše heslo je zobrazené
+        placeholder_email: ahoj@example.org
+    doorkeeper:
+      authorizations:
+        new:
+          connect_your_account_html: Prepojte svoj účet prihlásením do %{organization}.
+    editor_images:
+      create:
+        error: Chyba pri nahrávaní obrázka.
+        success: Obrázok bol úspešne nahraný.
+      drag_and_drop_help: Pridajte obrázky ich potiahnutím a pustením alebo vložením.
+    errors:
+      files:
+        file_cannot_be_processed: Súbor nie je možné spracovať
+        file_resolution_too_large: Rozlíšenie súboru je príliš veľké
+        not_inside_organization: Súbor nie je pripojený k žiadnej organizácii.
+      internal_server_error:
+        copied: Text bol skopírovaný!
+        copy_error_message_clarification: Kopírovať chybové hlásenie do schránky
+        copy_to_clipboard: Kopírovať do schránky
+        date_and_time: Dátum a čas
+        reference: Referencia
+        request_method: Metóda požiadavky
+        try_later: Skúste to prosím neskôr. Ak chyba pretrváva, skopírujte nasledujúce informácie a pošlite ich správcom platformy spolu s akýmikoľvek ďalšími informáciami, ktoré chcete zdieľať.
+        unknown: Neznáme
+        url: URL
+        user: ID používateľa
+      not_found:
+        title: Stránka, ktorú hľadáte, sa nenašla
+    events:
+      amendments:
+        emendation_promoted:
+          follower:
+            email_intro: 'Pre %{amendable_title} bola zverejnená úprava. Môžete si ju pozrieť na tejto stránke:'
+            email_outro: Toto upozornenie ste dostali, pretože ste autorom %{amendable_title}.
+      assemblies:
+        create_assembly_member:
+          email_outro: Toto upozornenie ste dostali, pretože ste boli pozvaní do zhromaždenia. Pozrite si <a href="%{resource_url}">stránku zhromaždenia</a> a zapojte sa!
+          email_subject: Boli ste pozvaní stať sa členom zhromaždenia %{resource_name}!
+          notification_title: Boli ste zaregistrovaní ako člen zhromaždenia <a href="%{resource_path}">%{resource_name}</a>. Pozrite si <a href="%{resource_path}">stránku zhromaždenia</a> a zapojte sa!
+      assembly:
+        role_assigned:
+          email_intro: Boli ste priradení ako %{role} pre zhromaždenie „%{resource_title}“.
+          email_outro: Toto upozornenie ste dostali, pretože ste %{role} zhromaždenia „%{resource_title}“.
+          email_subject: Boli ste priradení ako %{role} pre „%{resource_title}“.
+          notification_title: Boli ste priradení ako %{role} pre zhromaždenie <a href="%{resource_url}">%{resource_title}</a>.
+      comments:
+        comment_downvoted:
+          email_intro: Váš komentár v „%{resource_title}“ získal negatívny hlas. Teraz má celkovo %{upvotes} pozitívnych hlasov a %{downvotes} negatívnych hlasov.
+          email_outro: Toto upozornenie ste dostali, pretože ste autorom tohto komentára.
+          email_subject: Váš komentár v „%{resource_title}“ získal negatívny hlas.
+          notification_title: Váš <a href="%{resource_path}">komentár</a> v „%{resource_title}“ získal negatívny hlas. Teraz má celkovo %{upvotes} pozitívnych hlasov a %{downvotes} negatívnych hlasov.
+        comment_upvoted:
+          email_intro: Váš komentár v „%{resource_title}“ získal pozitívny hlas. Teraz má celkovo %{upvotes} pozitívnych hlasov a %{downvotes} negatívnych hlasov.
+          email_outro: Toto upozornenie ste dostali, pretože ste autorom tohto komentára.
+          email_subject: Váš komentár v „%{resource_title}“ získal pozitívny hlas.
+          notification_title: Váš <a href="%{resource_path}">komentár</a> v „%{resource_title}“ získal pozitívny hlas. Teraz má celkovo %{upvotes} pozitívnych hlasov a %{downvotes} negatívnych hlasov.
+      conferences:
+        role_assigned:
+          email_intro: Boli ste priradený ako %{role} pre konferenciu "%{resource_title}".
+          email_outro: Toto upozornenie ste dostali, pretože ste %{role} konferencie "%{resource_title}".
+          email_subject: Boli ste priradený ako %{role} pre "%{resource_title}".
+          notification_title: Boli ste priradený ako %{role} pre konferenciu <a href="%{resource_url}">%{resource_title}</a>.
+      debates:
+        create_debate_event:
+          space_followers:
+            email_intro: 'Dobrý deň,
+
+              v participatívnom priestore %{participatory_space_title} bola vytvorená nová debata „%{resource_title}“, pozrite si ju a zapojte sa:'
+            email_outro: Toto upozornenie ste dostali, pretože sledujete participatívny priestor %{participatory_space_title}. Prijímanie upozornení môžete zrušiť kliknutím na predchádzajúci odkaz.
+            email_subject: Nová debata „%{resource_title}“ v priestore %{participatory_space_title}
+            notification_title: Debata <a href="%{resource_path}">%{resource_title}</a> bola vytvorená v priestore <a href="%{participatory_space_url}">%{participatory_space_title}</a>.
+        creation_enabled:
+          notification_title: Teraz môžete začať <a href="%{resource_path}">nové debaty</a> v priestore <a href="%{participatory_space_url}">%{participatory_space_title}</a>.
+        debate_closed:
+          affected_user:
+            email_intro: 'Debata „%{resource_title}“ bola zatvorená. Závery si môžete prečítať na jej stránke:'
+            email_outro: Toto upozornenie ste dostali, pretože sledujete debatu „%{resource_title}“. Sledovanie môžete zrušiť kliknutím na predchádzajúci odkaz.
+            email_subject: Debata „%{resource_title}“ bola zatvorená
+            notification_title: Debata <a href="%{resource_path}">%{resource_title}</a> bola zatvorená.
+          follower:
+            email_intro: 'Debata „%{resource_title}“ bola zatvorená. Závery si môžete prečítať na jej stránke:'
+            email_outro: Toto upozornenie ste dostali, pretože sledujete debatu „%{resource_title}“. Sledovanie môžete zrušiť kliknutím na predchádzajúci odkaz.
+            email_subject: Debata „%{resource_title}“ bola zatvorená
+            notification_title: Debata <a href="%{resource_path}">%{resource_title}</a> bola zatvorená.
+      gamification:
+        badge_earned:
+          email_intro: Gratulujeme! Získali ste <a href="%{resource_url}">odznak %{badge_name}</a> (úroveň %{current_level}).
+          email_subject: 'Získali ste nový odznak: %{badge_name}!'
+          notification_title: Gratulujeme! Získali ste <a href="%{resource_path}">odznak %{badge_name}</a> (úroveň %{current_level}).
+        level_up:
+          email_intro: Gratulujeme! Dosiahli ste úroveň %{current_level} pre <a href="%{resource_url}">odznak %{badge_name}</a>!
+          email_subject: Dosiahli ste úroveň %{current_level} pre odznak %{badge_name}!
+          notification_title: Gratulujeme! Dosiahli ste úroveň %{current_level} pre <a href="%{resource_path}">odznak %{badge_name}</a>!
+      initiatives:
+        admin:
+          initiative_sent_to_technical_validation:
+            email_intro: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie. Pozrite si ju v <a href="%{admin_initiative_url}">paneli administrátora</a>
+            email_outro: Toto upozornenie ste dostali, pretože ste administrátorom platformy.
+            email_subject: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie.
+            notification_title: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie. Pozrite si ju v <a href="%{admin_initiative_path}">paneli administrátora</a>
+        initiative_sent_to_technical_validation:
+          email_intro: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie. Pozrite si ju v <a href="%{admin_initiative_url}">paneli administrátora</a>
+          email_outro: Toto upozornenie ste dostali, pretože ste administrátorom platformy.
+          email_subject: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie.
+          notification_title: Iniciatíva „%{resource_title}“ bola odoslaná na technické overenie. Pozrite si ju v <a href="%{admin_initiative_path}">paneli administrátora</a>
+        support_threshold_reached:
+          email_intro: Iniciatíva %{resource_title} dosiahla hranicu počtu podpisov
+          email_outro: Toto upozornenie ste dostali, pretože ste administrátorom platformy.
+          email_subject: Hranica počtu podpisov bola dosiahnutá
+          notification_title: Iniciatíva <a href="%{resource_path}">%{resource_title}</a> dosiahla hranicu počtu podpisov
+      meetings:
+        meeting_created:
+          button_text: Zaregistrovať sa na stretnutie
+      nickname_event:
+        notification_body: Opravili sme spôsob používania prezývok, aby nevznikali duplicity, a preto sme odstránili pravidlo rozlišovania veľkých a malých písmen. <br/> Vaša prezývka bola vytvorená po inej s rovnakým menom, preto sme ju automaticky premenovali. Môžete si ju zmeniť v <a href="%{link_to_account_settings}">nastaveniach vášho účtu</a>.
+      notification_event:
+        notification_title: Vyskytla sa udalosť pre <a href="%{resource_path}">%{resource_title}</a>.
+      participatory_process:
+        role_assigned:
+          email_intro: Boli ste priradený/á ako %{role} pre participatívny proces "%{resource_title}".
+          email_outro: Toto upozornenie ste dostali, pretože ste %{role} participatívneho procesu "%{resource_title}".
+          email_subject: Boli ste priradený/á ako %{role} pre "%{resource_title}".
+          notification_title: Boli ste priradený/á ako %{role} pre participatívny proces <a href="%{resource_url}">%{resource_title}</a>.
+      proposals:
+        admin:
+          proposal_note_created:
+            email_intro: '%{author_name} vytvoril/a súkromnú poznámku v %{resource_title}. Pozrite si to v <a href="%{admin_proposal_info_url}">paneli administrátora</a>.'
+            email_outro: Toto upozornenie ste dostali, pretože môžete hodnotiť návrh.
+            email_subject: Niekto zanechal poznámku k návrhu %{resource_title}.
+        collaborative_draft_access_accepted:
+          email_intro: '%{requester_name} bol/a prijatý/á ako prispievateľ do spoločného konceptu <a href="%{resource_url}">%{resource_title}</a>.'
+          email_outro: Toto upozornenie ste dostali, pretože ste spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        collaborative_draft_access_rejected:
+          email_intro: '%{requester_name} bol/a odmietnutý/á ako prispievateľ do spoločného konceptu <a href="%{resource_url}">%{resource_title}</a>.'
+          email_outro: Toto upozornenie ste dostali, pretože ste spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        collaborative_draft_access_requested:
+          email_intro: '%{requester_name} požiadal/a o prístup ako prispievateľ. Žiadosť môžete <strong>prijať alebo odmietnuť</strong> na stránke spoločného konceptu <a href="%{resource_url}">%{resource_title}</a>.'
+          email_outro: Toto upozornenie ste dostali, pretože ste spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        collaborative_draft_access_requester_accepted:
+          email_intro: Boli ste prijatý/á ako prispievateľ do spoločného konceptu <a href="%{resource_url}">%{resource_title}</a>.
+          email_outro: Toto upozornenie ste dostali, pretože ste požiadali o to, aby ste sa stali spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        collaborative_draft_access_requester_rejected:
+          email_intro: Boli ste odmietnutý/á ako prispievateľ do spoločného konceptu <a href="%{resource_url}">%{resource_title}</a>.
+          email_outro: Toto upozornenie ste dostali, pretože ste požiadali o to, aby ste sa stali spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        collaborative_draft_withdrawn:
+          email_outro: Toto upozornenie ste dostali, pretože ste spolupracovníkom <a href="%{resource_url}">%{resource_title}</a>.
+        creation_enabled:
+          notification_title: Teraz môžete predkladať <a href="%{resource_path}">nové návrhy</a> v <a href="%{participatory_space_url}">%{participatory_space_title}</a>.
+        proposal_published_for_space:
+          notification_title: Návrh <a href="%{resource_path}">%{resource_title}</a> bol pridaný do %{participatory_space_title} používateľom %{author}.
+          notification_title_official: Oficiálny návrh <a href="%{resource_path}">%{resource_title}</a> bol pridaný do %{participatory_space_title}.
+        proposal_state_changed:
+          affected_user:
+            email_intro: 'Návrh „%{resource_title}“ zmenil svoj stav na „%{state}“. Odpoveď si môžete prečítať na tejto stránke:'
+            email_outro: Toto upozornenie ste dostali, pretože ste autorom „%{resource_title}“.
+            email_subject: Váš návrh zmenil svoj stav (%{state})
+            notification_title: Váš návrh <a href="%{resource_path}">%{resource_title}</a> zmenil svoj stav na „%{state}“.
+          follower:
+            email_intro: 'Návrh „%{resource_title}“ zmenil svoj stav na „%{state}“. Odpoveď si môžete prečítať na tejto stránke:'
+            email_outro: Toto upozornenie ste dostali, pretože sledujete „%{resource_title}“. Sledovanie môžete zrušiť pomocou predchádzajúceho odkazu.
+            email_subject: Návrh, ktorý sledujete, zmenil svoj stav (%{state})
+            notification_title: Návrh <a href="%{resource_path}">%{resource_title}</a> zmenil svoj stav na „%{state}“.
+        voting_enabled:
+          email_intro: 'Môžete hlasovať za návrhy v %{participatory_space_title}! Začnite sa zapájať na tejto stránke:'
+          email_subject: Hlasovanie o návrhoch sa začalo pre %{participatory_space_title}
+          notification_title: Teraz môžete začať <a href="%{resource_path}">hlasovať za návrhy</a> v <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+      reports:
+        resource_hidden:
+          email_intro: Administrátor odstránil váš %{resource_type}, pretože bol nahlásený ako %{report_reasons}.
+          email_outro: Toto upozornenie ste dostali, pretože ste autorom odstráneného obsahu.
+          email_subject: Váš %{resource_type} bol odstránený
+          notification_title: 'Administrátor odstránil váš %{resource_type}, pretože bol nahlásený ako %{report_reasons}.</br>
+
+            <i>%{resource_content}</i>'
+      users:
+        user_officialized:
+          email_outro: Toto upozornenie ste dostali, pretože ste administrátorom organizácie.
+          email_subject: '%{name} bol/a oficializovaný/á'
+      verifications:
+        verify_with_managed_user:
+          email_outro: Skontrolujte <a href="%{conflicts_url}">zoznam konfliktov overení</a> a kontaktujte účastníka, aby ste overili jeho údaje a vyriešili problém.
+          email_subject: Neúspešný pokus o overenie voči inému účastníkovi
+    filters:
+      linked_classes:
+        answer: Odpoveď
+    fingerprint:
+      explanation: Text nižšie je skrátená, hašovaná reprezentácia tohto obsahu. Je to užitočné na zabezpečenie toho, že obsah nebol pozmenený, pretože jediná úprava by viedla k úplne inej hodnote.
+    followers:
+      followers_count:
+        one: '%{count} sledujúci'
+        other: '%{count} sledujúcich'
+    following:
+      following_count:
+        one: '%{count} sledovanie'
+        other: '%{count} sledovaní'
+      no_followings: Zatiaľ nikoho a nič nesleduje.
+      non_public_followings: Niektoré zo sledovaných zdrojov nie sú verejné.
+    follows:
+      create:
+        participatory_space: Sledujete <span>%{resource_name}</span>
+    forms:
+      admin:
+        questionnaires:
+          actions:
+            back: Späť na odpovede
+            show: Odpovede
+          display_condition:
+            condition_question: Otázka
+            condition_type: Podmienka
+            condition_types:
+              equal: Rovná sa
+              match: Obsahuje text
+              not_equal: Nerovná sa
+            condition_value: Zahrnutý text
+            display_condition: Podmienka zobrazenia
+            mandatory: Táto podmienka musí byť splnená vždy bez ohľadu na stav iných podmienok
+            remove: Odstrániť
+            save_warning: Nezabudnite uložiť formulár pred konfiguráciou podmienok zobrazenia
+            select_condition_question: Vyberte otázku
+            select_condition_type: Vyberte typ podmienky
+          edit:
+            title: Upraviť dotazník
+          form:
+            collapse: Zbaliť všetky otázky
+            expand: Rozbaliť všetky otázky
+            preview: Náhľad
+            title: Upraviť formulár pre %{questionnaire_for}
+          matrix_row:
+            matrix_row: Riadok
+          question:
+            add_display_condition: Pridať podmienku zobrazenia
+            add_display_condition_info: Uložte formulár pre konfiguráciu podmienok zobrazenia
+            add_matrix_row: Pridať riadok
+            collapse: Zbaliť
+            expand: Rozbaliť
+          separator:
+            remove: Odstrániť
+            separator: Oddeľovač
+          title_and_description:
+            collapse: Zbaliť
+            description: Popis
+            expand: Rozbaliť
+            remove: Odstrániť
+            title: Názov
+            title_and_description: Názov a popis
+          update:
+            success: Formulár bol úspešne uložený.
+      admin_log:
+        questionnaire:
+          update: '%{user_name} aktualizoval/a dotazník %{resource_name}'
+      attachment_link:
+        explanation: Pokyny pre odkazy na prílohy
+        help_messages:
+          - Akceptované sú len správne formáty URL.
+          - Upozorňujeme, že odkazy musia byť verejné, aby k nim mali prístup všetci účastníci.
+      errors:
+        error: V tomto poli je chyba.
+        impersonate_user:
+          reason: Pri správe nespravovaného účastníka musíte uviesť dôvod.
+      file_help:
+        file:
+          explanation: 'Pokyny pre súbor:'
+          message_1: Musí to byť obrázok alebo dokument.
+          message_2: Ak ide o obrázok, mal by to byť najlepšie obrázok na šírku bez textu. Platforma obrázok oreže.
+        icon:
+          explanation: 'Pokyny pre ikonu:'
+          message_1: Musí to byť štvorcový obrázok.
+          message_2: Odporúčaná veľkosť tohto obrázka je 512x512.
+        image:
+          explanation: 'Pokyny pre obrázok:'
+          message_1: Najlepšie obrázok na šírku, ktorý neobsahuje žiadny text.
+          message_2: Služba obrázok oreže.
+      file_validation:
+        allowed_file_extensions: 'Povolené prípony súborov: %{extensions}'
+        max_file_dimension: 'Maximálne rozmery súboru: %{resolution} pixelov'
+        max_file_size: 'Maximálna veľkosť súboru: %{megabytes} MB'
+      files:
+        extension_allowlist: 'Akceptované formáty: %{extensions}'
+      images:
+        dimensions: '%{width} x %{height} px'
+        processors:
+          resize_and_pad: Veľkosť tohto obrázka sa zmení a doplní na %{dimensions}.
+          resize_to_fit: Veľkosť tohto obrázka sa zmení tak, aby sa zmestil do %{dimensions}.
+      meetings:
+        attendees_count_help_text: Nezabudnite uviesť celkový počet účastníkov vášho stretnutia, či už osobne, online alebo hybridne.
+      question_types:
+        files: Súbory
+        matrix_multiple: Matica (Viacero možností)
+        matrix_single: Matica (Jedna možnosť)
+        title_and_description: Názov a popis
+      questionnaires:
+        show:
+          answer_questionnaire:
+            already_have_an_account?: Už ste sa zaregistrovali?
+            are_you_new?: Nový účastník?
+            sign_in_description: Prihláste sa pre prístup k prieskumu.
+            sign_up_description: Zaregistrujte sa pre prístup k prieskumu.
+          current_step: Krok %{step}
+          empty: Pre tento formulár zatiaľ nie sú nakonfigurované žiadne otázky.
+          of_total_steps: z %{total_steps}
+          questionnaire_js_disabled:
+            body: Niektoré funkcie tohto formulára budú vypnuté. Pre lepšiu skúsenosť si vo svojom prehliadači povoľte JavaScript.
+            title: JavaScript je vypnutý
+          questionnaire_not_published:
+            body: Tento formulár zatiaľ nie je zverejnený.
+      step_navigation:
+        show:
+          back: Späť
+          continue: Pokračovať
+      upload:
+        labels:
+          add_attachment: Pridať prílohu
+          add_file: Pridať súbor
+          add_image: Pridať obrázok
+          edit_image: Upraviť obrázok
+          error: Chyba!
+          file_size_too_large: 'Veľkosť súboru je príliš veľká! Maximálna veľkosť súboru: %{megabytes} MB'
+          filename: Názov súboru
+          remove: Odstrániť
+          replace: Nahradiť
+          save: Uložiť
+          title: Názov
+          title_required: Názov je povinný!
+          uploaded: Nahrané
+          validating: Overuje sa...
+          validation_error: Chyba overenia! Skontrolujte, či má súbor povolenú príponu alebo veľkosť.
+        select_file: Vybrať súbor
+      upload_help:
+        dropzone: Sem presuňte súbory alebo kliknite na tlačidlo pre nahranie
+        explanation: Pokyny pre %{attribute}
+    gamification:
+      badges:
+        attended_meetings:
+          unearned_another: Tento účastník sa zatiaľ nezúčastnil žiadneho stretnutia.
+          unearned_own: Zatiaľ ste sa nezúčastnili žiadneho stretnutia.
+        commented_debates:
+          unearned_own: Zatiaľ ste sa nezúčastnili žiadnych debát.
+        followers:
+          unearned_another: Tento účastník zatiaľ nemá žiadnych sledujúcich.
+          unearned_own: Zatiaľ nemáte žiadnych sledujúcich.
+        initiatives:
+          description: Tento odznak získate, keď spustíte nové iniciatívy a spojíte sa s ostatnými na ich realizácii.
+          description_another: Tento účastník má publikovaných %{score} iniciatív.
+          description_own: Máte publikovaných %{score} iniciatív.
+          name: Publikované iniciatívy
+          next_level_in: Publikujte ešte %{score} iniciatív, aby ste dosiahli ďalšiu úroveň!
+          unearned_another: Tento účastník zatiaľ nepublikoval žiadne iniciatívy.
+          unearned_own: Zatiaľ nemáte publikované žiadne iniciatívy.
+        proposal_votes:
+          description: Tento odznak získate, keď hlasujete za návrhy iných ľudí.
+          description_another: Tento účastník hlasoval za %{score} návrhov.
+          description_own: Hlasovali ste za %{score} návrhov.
+          name: Hlasy za návrhy
+          next_level_in: Hlasujte za ďalších %{score} návrhov, aby ste dosiahli ďalšiu úroveň!
+          unearned_another: Tento účastník zatiaľ nehlasoval za žiadne návrhy.
+          unearned_own: Zatiaľ ste nehlasovali za žiadne návrhy.
+        proposals:
+          unearned_another: Tento účastník zatiaľ nevytvoril žiadne návrhy.
+        test:
+          unearned_another: Tento účastník zatiaľ nevytvoril žiadne testy.
+      reached_top: Dosiahli ste najvyššiu úroveň pre tento odznak.
+      title: Čo sú to odznaky?
+    groups:
+      roles:
+        creator: Administrátor
+    help:
+      main_topic:
+        description: Prečítajte si viac o %{organization}.
+        title: Všeobecné
+      participatory_spaces:
+        assemblies:
+          contextual: '<p><strong>Zhromaždenie</strong> je skupina členov organizácie, ktorí sa pravidelne stretávajú, aby prijímali rozhodnutia o konkrétnej oblasti alebo rozsahu pôsobnosti organizácie.</p> <p>Zhromaždenia organizujú stretnutia, niektoré sú neverejné a niektoré verejné. Ak sú verejné, je možné sa na nich zúčastniť (napríklad: účasť, ak to kapacita dovoľuje, pridávanie bodov do programu alebo pripomienkovanie návrhov a rozhodnutí prijatých týmto orgánom).</p> <p>Príklady: Valné zhromaždenie (ktoré sa schádza raz ročne, aby hlasovaním určilo hlavné smery činnosti organizácie, ako aj jej výkonné orgány), poradný výbor pre rovnosť (ktorý sa schádza každé dva mesiace, aby predkladal návrhy na zlepšenie rodových vzťahov v organizácii), hodnotiaca komisia (ktorá sa schádza každý mesiac, aby monitorovala proces) alebo garančný orgán (ktorý zhromažďuje incidenty, zneužitia alebo návrhy na zlepšenie rozhodovacích postupov) sú všetko príklady zhromaždení.</p>
+
+            '
+          page: '<p><strong>Zhromaždenie</strong> je skupina členov organizácie, ktorí sa pravidelne stretávajú, aby prijímali rozhodnutia o konkrétnej oblasti alebo rozsahu pôsobnosti organizácie.</p> <p>Zhromaždenia organizujú stretnutia, niektoré sú neverejné a niektoré verejné. Ak sú verejné, je možné sa na nich zúčastniť (napríklad: účasť, ak to kapacita dovoľuje, pridávanie bodov do programu alebo pripomienkovanie návrhov a rozhodnutí prijatých týmto orgánom).</p> <p>Príklady: Valné zhromaždenie (ktoré sa schádza raz ročne, aby hlasovaním určilo hlavné smery činnosti organizácie, ako aj jej výkonné orgány), poradný výbor pre rovnosť (ktorý sa schádza každé dva mesiace, aby predkladal návrhy na zlepšenie rodových vzťahov v organizácii), hodnotiaca komisia (ktorá sa schádza každý mesiac, aby monitorovala proces) alebo garančný orgán (ktorý zhromažďuje incidenty, zneužitia alebo návrhy na zlepšenie rozhodovacích postupov) sú všetko príklady zhromaždení.</p>
+
+            '
+          title: Čo sú zhromaždenia?
+        conferences:
+          contextual: '<p><strong>Konferencia</strong> je súbor stretnutí usporiadaných do programu s množstvom ľudí pozvaných ako rečníci a ďalšími informačnými poľami typickými pre veľké kongresy alebo spoločenské podujatia (registrácia, zoznam organizácií, ktoré podujatie podporujú alebo sponzorujú atď.).</p> <p>Príklady: Konferencia môže byť relevantným podujatím pre organizáciu a jej členov, alebo sa môže uskutočniť ako súčasť participatívneho procesu či nasledovať po konzultácii.</p>
+
+            '
+          page: '<p><strong>Konferencia</strong> je súbor stretnutí usporiadaných do programu s množstvom ľudí pozvaných ako rečníci a ďalšími informačnými poľami typickými pre veľké kongresy alebo spoločenské podujatia (registrácia, zoznam organizácií, ktoré podujatie podporujú alebo sponzorujú atď.).</p> <p>Príklady: Konferencia môže byť relevantným podujatím pre organizáciu a jej členov, alebo sa môže uskutočniť ako súčasť participatívneho procesu či nasledovať po konzultácii.</p>
+
+            '
+          title: Čo sú konferencie?
+        initiatives:
+          contextual: '<p><strong>Iniciatíva</strong> je návrh, ktorý môže ktokoľvek z vlastnej iniciatívy (nezávisle od iných kanálov alebo participatívnych priestorov) presadzovať prostredníctvom zberu (digitálnych) podpisov, aby organizácia vykonala konkrétnu akciu (úprava predpisu, začatie projektu, zmena názvu oddelenia alebo ulice atď.).</p> <p>Predkladatelia iniciatívy môžu definovať jej ciele, získavať podporu, diskutovať, šíriť ju a definovať miesta stretnutí, kde sa môžu zbierať podpisy od účastníkov alebo otvárať diskusie pre ďalších účastníkov.</p> <p>Príklady: Iniciatíva môže zbierať podpisy na zvolanie konzultácie medzi všetkými ľuďmi v organizácii, na vytvorenie alebo zvolanie zhromaždenia, alebo na začatie procesu zvýšenia rozpočtu pre určité územie alebo oblasť organizácie. Počas procesu zberu podpisov sa k tejto požiadavke môže pridať viac ľudí a posunúť ju v organizácii ďalej.</p>
+
+            '
+    initiatives:
+      admin:
+        answers:
+          edit:
+            answer: Odpoveď
+            title: Odpoveď na %{title}
+          info_initiative:
+            created_at: Vytvorené
+            description: Popis
+            initiative_votes_count: Počet hlasov
+            initiatives: Iniciatívy
+            state: Stav
+        committee_requests:
+          index:
+            invite_to_committee_help: Zdieľajte tento odkaz a pozvite ďalších účastníkov do výboru predkladateľov.
+            no_members_yet: Vo výbore predkladateľov nie sú žiadni členovia.
+        content_blocks:
+          highlighted_initiatives:
+            order:
+              default: Predvolené (Najstaršie)
+              label: 'Zoradiť prvky podľa:'
+              most_recent: Najnovšie
+        exports:
+          initiatives: Iniciatívy
+        index:
+          initiatives_types:
+            alert_html: <p>Musíte vytvoriť aspoň jeden typ iniciatívy, aby účastníci mohli začať vytvárať iniciatívy.</p><p> %{link}</p>
+            button: Nový typ iniciatívy
+        initiatives:
+          accept:
+            success: Iniciatíva bola úspešne prijatá.
+          discard:
+            success: Iniciatíva bola úspešne vyradená.
+          edit:
+            confirm_send_to_technical_validation: Ste si istí?
+            success: Iniciatíva bola odoslaná na technické overenie.
+          form:
+            settings: Nastavenia
+          initiative_attachments:
+            documents: Dokumenty
+            edit: Upraviť
+            new: Nové
+            photos: Fotografie
+          publish:
+            success: Iniciatíva bola úspešne publikovaná.
+          reject:
+            success: Iniciatíva bola úspešne zamietnutá.
+          unpublish:
+            success: Publikovanie iniciatívy bolo úspešne zrušené.
+          update:
+            error: Pri aktualizácii iniciatívy sa vyskytol problém.
+            success: Iniciatíva bola úspešne aktualizovaná.
+        initiatives_settings:
+          edit:
+            update: Aktualizovať
+          form:
+            comments: Najviac komentované
+            date: Najnovšie
+            publication_date: Nedávno publikované
+            random: Náhodné
+            signatures: Najviac podpísané
+        initiatives_type_scopes:
+          create:
+            error: Pri vytváraní nového rozsahu pre danú iniciatívu sa vyskytol problém.
+            success: Nový rozsah pre daný typ iniciatívy bol vytvorený.
+          destroy:
+            success: Rozsah bol úspešne odstránený.
+          update:
+            error: Pri aktualizácii rozsahu sa vyskytol problém.
+            success: Rozsah bol úspešne aktualizovaný.
+        initiatives_types:
+          create:
+            error: Pri vytváraní typu iniciatívy sa vyskytol problém.
+            success: Nový typ iniciatívy bol úspešne vytvorený. Musíte definovať aspoň jeden rozsah pre tento typ iniciatívy, aby sa dal použiť.
+          destroy:
+            success: Typ iniciatívy bol úspešne odstránený.
+          form:
+            child_scope_threshold_enabled_help_html: 'Tento konfiguračný príznak nepodporuje offline hlasy. Povoľuje podrozsahy a funguje s obsluhou autorizácie, ktorá priraďuje rozsah používateľovi. Uistite sa, že ste vybrali túto autorizáciu nižšie v nastaveniach autorizácie. Aby to fungovalo, rozsahy musia byť nakonfigurované hierarchicky: 1 rodič - N detí. Viac informácií o tom, ako táto konfigurácia funguje, nájdete na <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">stránke dokumentácie pre administrátorov iniciatív</a>.'
+            only_global_scope_enabled_help_html: Začiarknite tento príznak, ak ste povolili „Podpis podrozsahu“ a nakonfigurovali globálny rozsah ako váš nadradený rozsah. Povolením tohto sa výber typu iniciatívy v sprievodcovi vytváraním iniciatívy preskočí. Viac informácií o tom, ako táto konfigurácia funguje, nájdete na tomto <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">odkaze</a>.
+            options: Možnosti
+          update:
+            error: Pri aktualizácii typu iniciatívy sa vyskytol problém.
+            success: Typ iniciatívy bol úspešne aktualizovaný.
+      admin_log:
+        initiative:
+          unpublish: '%{user_name} zrušil/a iniciatívu %{resource_name}'
+        initiatives_settings:
+          update: '%{user_name} aktualizoval/a nastavenia iniciatív'
+        initiatives_type:
+          create: '%{user_name} vytvoril/a typ iniciatív %{resource_name}'
+          delete: '%{user_name} odstránil/a typ iniciatív %{resource_name}'
+          update: '%{user_name} aktualizoval/a typ iniciatív %{resource_name}'
+      admin_states:
+        accepted: Dostatok podpisov
+        rejected: Nedostatok podpisov
+        validating: Technické overenie
+      application_helper:
+        filter_state_values:
+          accepted: Dostatok podpisov
+          all: Všetky
+          answered: Zodpovedané
+          rejected: Nedostatok podpisov
+        filter_type_values:
+          all: Všetky
+      committee_requests:
+        approve:
+          success: Žiadosť bola schválená.
+        new:
+          help_text: Chystáte sa požiadať o členstvo vo výbore navrhovateľov tejto iniciatívy.
+        revoke:
+          success: Žiadosť bola zrušená.
+      create_initiative:
+        fill_data:
+          fill_data_help: <ul> <li>Skontrolujte obsah svojej iniciatívy. Je váš názov ľahko zrozumiteľný? Je cieľ vašej iniciatívy jasný?</li> <li>Musíte si vybrať typ podpisu. Osobne, online alebo kombinácia oboch</li> <li>Aký je geografický rozsah iniciatívy?</li> </ul>
+          select_area: Vyberte oblasť
+        promotal_committee:
+          individual_help_text: Vaša iniciatíva bola vytvorená a uložená ako koncept. Teraz musíte pridať ľudí do výboru navrhovateľov.
+        select_initiative_type:
+          new: Vytvoriť novú iniciatívu
+          verification_required: Overte svoj účet, aby ste mohli presadzovať túto iniciatívu
+      edit:
+        accept: Prijať iniciatívu
+        back: Späť
+        confirm: Ste si istí?
+        discard: Zrušiť iniciatívu
+        export_pdf_signatures: Exportovať PDF s podpismi
+        export_votes: Exportovať podpisy
+        reject: Zamietnuť iniciatívu
+        title: Upraviť iniciatívu
+        update: Aktualizovať
+      events:
+        approve_membership_request:
+          email_outro: 'Toto upozornenie ste dostali, pretože ste sa prihlásili do tejto iniciatívy: %{resource_title}'
+        revoke_membership_request:
+          email_outro: 'Toto upozornenie ste dostali, pretože ste sa prihlásili do tejto iniciatívy: %{resource_title}.'
+        spawn_committee_request_event:
+          email_outro: 'Toto upozornenie ste dostali, pretože ste autorom tejto iniciatívy: %{resource_title}'
+      form:
+        add_image: Pridať obrázok
+        edit_image: Upraviť obrázok
+        image_legend: (Voliteľné) Pridať obrázok
+      index:
+        uninitialized: Iniciatívy zatiaľ nie sú nakonfigurované administrátorom.
+      initiative_signatures:
+        fill_personal_data:
+          help: Ak chcete podpísať iniciatívu, vyplňte nasledujúce polia svojimi osobnými údajmi.
+      initiative_votes:
+        create:
+          invalid: Údaje poskytnuté na podpísanie iniciatívy nie sú platné.
+          success_html: Gratulujeme! Iniciatíva <strong> %{title}</strong> bola úspešne podpísaná.
+        sms_code:
+          invalid: Váš overovací kód sa nezhoduje s naším. Prosím, skontrolujte SMS, ktorú sme vám poslali.
+      initiatives:
+        committee_members:
+          approve: Schváliť
+          confirm_approve: Naozaj chcete schváliť tohto člena?
+          confirm_revoke: Naozaj chcete odvolať tohto člena?
+          invite_to_committee_help: Zdieľajte tento odkaz a pozvite ďalších účastníkov do prípravného výboru.
+          link: Odkaz
+          no_members_yet: V prípravnom výbore nie sú žiadni členovia.
+          revoke: Odvolať
+          title: Členovia výboru
+        filters:
+          area: Oblasť
+          scope: Pôsobnosť
+        initiatives:
+          closed_initiatives_warning: V súčasnosti nie sú žiadne otvorené iniciatívy, ale tu nájdete zoznam všetkých uzavretých iniciatív.
+          no_initiatives_warning: Vašim kritériám vyhľadávania nezodpovedajú žiadne iniciatívy.
+        orders:
+          recently_published: Najnovšie zverejnené
+        print:
+          address: Adresa
+          author_title: Autor iniciatívy
+          email: E-mail
+          full_name: Celé meno
+          general_title: Žiadosť o prijatie iniciatívy
+          id_number: Identifikačné číslo
+          initiative:
+            attachments: Priložená dokumentácia (nižšie uveďte názov každého dokumentu)
+            description: 'Popis:'
+            title: 'Názov:'
+            type: Typ iniciatívy
+          legal_text: Zozbierané osobné údaje budú spracované a uchovávané organizáciou dôverne v súlade s platnou legislatívou.
+          members_header: Členovia prípravného výboru iniciatívy
+          phone_number: Telefónne číslo
+          place_date: Miesto, dátum
+          postal_code: PSČ
+          province: Kraj/Štát
+          signature: Podpis
+        result:
+          answer_title: Táto iniciatíva bola zodpovedaná.
+        show:
+          area: Oblasť
+          before_send_to_technical_validation_announcement: 'Pred odoslaním vašej iniciatívy na technickú validáciu musíte do prípravného výboru pridať ešte %{count} členov.<br/><br/>Zdieľajte tento odkaz s ľuďmi, ktorých chcete mať vo svojom výbore: %{href}'
+          confirm: Chystáte sa odoslať iniciatívu administrátorovi na kontrolu a zverejnenie. Po zverejnení ju už nebudete môcť upravovať. Ste si istý?
+          edit: Upraviť
+          initiative_data: Údaje o iniciatíve
+          scope: Pôsobnosť
+          send_to_technical_validation: Odoslať na technickú validáciu
+          send_to_technical_validation_announcement: Ak je všetko v poriadku, kliknite na „Odoslať na technickú validáciu“, aby administrátor skontroloval a zverejnil vašu iniciatívu
+          signature_collection: Zber podpisov
+          state: Stav
+          type: Typ
+      last_activity:
+        new_initiative: 'Nová iniciatíva:'
+      modal:
+        not_authorized:
+          authorizations_page: Zobraziť autorizácie
+          explanation: Na vytvorenie novej iniciatívy musíte byť overený.
+          title: Vyžaduje sa autorizácia
+      pages:
+        home:
+          highlighted_initiatives:
+            active_spaces: Aktívne iniciatívy
+            see_all_spaces: Zobraziť všetky iniciatívy
+      show:
+        badge_name:
+          accepted: Dostatok podpisov
+          created: Koncept
+          discarded: Zahodené
+          rejected: Nedostatok podpisov
+          validating: Technická validácia
+      update:
+        error: Pri aktualizácii iniciatívy sa vyskytol problém.
+        success: Iniciatíva bola úspešne aktualizovaná.
+    last_activities:
+      name: Posledné aktivity
+      no_activities_warning: Pre tento typ aktivity nie sú k dispozícii žiadne záznamy na zobrazenie.
+    linked_resource_from:
+      included_in: Zahrnuté v
+    links:
+      invalid_url: Neplatná URL
+      warning:
+        body_1: Chystáte sa navštíviť externý odkaz a chceli by sme vás požiadať o opatrnosť ohľadom obsahu na externej stránke.
+        body_2: Pred pokračovaním skontrolujte odkaz, ktorý sa chystáte navštíviť, a uistite sa, že ho považujete za bezpečnú stránku.
+        cancel: Zrušiť
+        proceed: Pokračovať
+        title: Otvoriť externý odkaz
+    log:
+      base_presenter:
+        publish_with_space: '%{user_name} zverejnil/a %{resource_name} v %{space_name}'
+        unpublish_with_space: '%{user_name} zrušil/a zverejnenie %{resource_name} z %{space_name}'
+        update_permissions_with_space: '%{user_name} aktualizoval/a oprávnenia pre %{resource_name} v %{space_name}'
+      value_types:
+        assembly_presenter:
+          not_found: 'Zhromaždenie sa nenašlo v databáze (ID: %{id})'
+        conference_presenter:
+          not_found: 'Konferencia nebola nájdená v databáze (ID: %{id}).'
+    machine_translations:
+      automatic: automatický preklad do %{locale_name}
+    map:
+      dynamic:
+        screen_reader_explanation: Nasledujúci prvok je mapa, ktorá zobrazuje položky na tejto stránke ako body na mape. Prvok je možné použiť s čítačkou obrazovky, ale môže byť ťažšie pochopiteľný.
+        skip_button: Preskočiť mapu
+      static:
+        latlng_text: 'zemepisná šírka: %{latitude}, zemepisná dĺžka: %{longitude}'
+        map_service_brand: OpenStreetMap
+    meetings:
+      actions:
+        invalid_destroy:
+          proposals_count:
+            one: 'Stretnutie nie je možné odstrániť, pretože je s ním spojený %{count} návrh:'
+            other: 'Stretnutie nie je možné odstrániť, pretože je s ním spojených %{count} návrhov:'
+        manage_poll: Spravovať anketu
+        new_meeting: Nové stretnutie
+      admin:
+        agenda:
+          create:
+            invalid: Pri vytváraní tohto programu sa vyskytol problém.
+            success: Program bol úspešne vytvorený.
+          update:
+            invalid: Pri aktualizácii tohto programu sa vyskytol problém.
+            success: Program bol úspešne aktualizovaný.
+        exports:
+          meeting_comments: Komentáre
+        invites:
+          index:
+            registrations_disabled: Nemôžete pozvať účastníka, pretože registrácie sú zakázané.
+        meetings:
+          close:
+            invalid: Pri uzatváraní tohto stretnutia sa vyskytol problém.
+            success: Stretnutie bolo úspešne uzavreté.
+          create:
+            invalid: Pri vytváraní tohto stretnutia sa vyskytol problém.
+            success: Stretnutie bolo úspešne vytvorené. Upozorňujeme, že zatiaľ nie je publikované, musíte ho publikovať manuálne.
+          edit:
+            title: Upraviť stretnutie
+          form:
+            disclaimer: 'Zrieknutie sa zodpovednosti: Použitím externého registračného systému beriete na vedomie, že organizátori %{organization} nezodpovedajú za údaje poskytnuté používateľmi externej službe.'
+            iframe_embed_type_html: 'Iba niekoľko služieb umožňuje vkladanie do stretnutia alebo živej udalosti z nasledujúcich domén: %{domains}'
+            location_hints_help: 'Tipy k miestu: ďalšie informácie. Príklad: poschodie budovy, ak ide o osobné stretnutie, alebo heslo stretnutia, ak ide o online stretnutie s obmedzeným prístupom.'
+            online_meeting_url_help: 'Odkaz: umožnite účastníkom pripojiť sa priamo k vášmu stretnutiu'
+            registration_url_help: 'Odkaz: umožnite účastníkom prejsť na externú službu, ktorú používate na registrácie'
+            select_a_meeting_type: Vyberte typ stretnutia
+            select_a_registration_type: Vyberte typ registrácie
+            select_an_iframe_access_level: Vyberte úroveň prístupu pre iframe
+          publish:
+            invalid: Pri publikovaní tohto stretnutia sa vyskytol problém.
+            success: Stretnutie bolo úspešne publikované.
+          unpublish:
+            invalid: Pri zrušení publikovania tohto stretnutia sa vyskytol problém.
+            success: Publikovanie stretnutia bolo úspešne zrušené.
+          update:
+            invalid: Pri aktualizácii tohto stretnutia sa vyskytol problém.
+            success: Stretnutie bolo úspešne aktualizované.
+        meetings_poll:
+          form:
+            title: Upraviť dotazník ankety pre %{questionnaire_for}
+          update:
+            invalid: Pri aktualizácii tejto ankety stretnutia sa vyskytol problém.
+            success: Anketa stretnutia bola úspešne aktualizovaná.
+        poll:
+          form:
+            announcement_html:
+              - Keď otázka získa odpovede alebo je publikovaná/uzavretá, už ju nie je možné upravovať.
+              - Otázku môžete pridať kedykoľvek.
+              - Anketa bude uzavretá, keď budú publikované výsledky všetkých vytvorených otázok.
+              - Navštívte <a href='%{admin_link}'>stránku správy ankety</a>, kde môžete odosielať otázky a publikovať výsledky.
+        registrations:
+          form:
+            registration_email_help: Tento text sa zobrazí v strede e-mailu s potvrdením registrácie. Hneď za registračným kódom.
+            reserved_slots_help: Ponechajte 0, ak nemáte vyhradené miesta.
+      admin_log:
+        questionnaire:
+          update: '%{user_name} aktualizoval/a dotazník pre stretnutie %{meeting_name}'
+      application_helper:
+        filter_meeting_space_values:
+          all: Všetky
+      calendar:
+        meeting_to_event:
+          read_more: Prečítajte si viac o tomto stretnutí
+      calendar_modal:
+        copy_calendar_url: Kopírovať
+        copy_calendar_url_clarification: Kopírovať URL kalendára do schránky
+        copy_calendar_url_copied: Skopírované!
+        copy_calendar_url_description: Všetky zverejnené stretnutia si môžete pozrieť vo svojej aplikácii kalendára alebo u poskytovateľa. Skopírujte a vložte túto URL adresu do svojho kalendára pomocou možnosti „Pridať nový kalendár z URL“.
+        copy_calendar_url_explanation: Upozorňujeme, že exportujete výber stretnutí, pretože sú aktívne filtre. Ak ich chcete exportovať všetky, najprv zrušte všetky filtre.
+        copy_calendar_url_message: URL adresa bola úspešne skopírovaná do schránky.
+      close_meeting_reminder_mailer:
+        close_meeting_reminder:
+          body: Stretnutie <a href="%{meeting_path}">„%{meeting_title}“</a> čaká na uzavretie. Pridajte správu zo stretnutia pomocou tlačidla „Uzavrieť stretnutie“.
+          greetings: S pozdravom,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+          hello: Dobrý deň %{username},
+          subject: Teraz môžete uzavrieť stretnutie „%{meeting_title}“ so správou
+      content_blocks:
+        upcoming_meetings:
+          name: Nadchádzajúce stretnutia
+      iframe_access_level:
+        all: Všetci návštevníci
+        registered: Registrovaní účastníci tohto stretnutia
+        signed_in: Iba prihlásení účastníci
+      iframe_embed_type:
+        embed_in_meeting_page: Vložiť na stránku stretnutia
+        none: Žiadne
+        open_in_live_event_page: Otvoriť na stránke živého podujatia
+        open_in_new_tab: Otvoriť URL v novej karte
+      last_activity:
+        meeting_updated: 'Stretnutie bolo aktualizované:'
+        new_meeting: 'Nové stretnutie:'
+      layouts:
+        live_event:
+          close: zavrieť
+      meeting:
+        not_allowed: Nemáte povolenie na zobrazenie tohto stretnutia.
+      meeting_closes:
+        edit:
+          back: Späť
+          close: Uzavrieť stretnutie
+          title: Uzavrieť stretnutie
+      meetings:
+        calendar_modal:
+          add_to_calendar: Pridať do kalendára
+          apple: Pridať do Apple kalendára
+          full_details_html: Pre všetky podrobnosti prejdite na %{link}
+          google: Pridať do Google kalendára
+          outlook: Pridať do Outlook kalendára
+        count:
+          meetings_count:
+            one: '%{count} stretnutie'
+            other: '%{count} stretnutí'
+        create:
+          invalid: Pri vytváraní tohto stretnutia sa vyskytol problém.
+          success: Stretnutie ste úspešne vytvorili.
+        edit:
+          back: Späť
+          title: Upraviť vaše stretnutie
+          update: Aktualizovať
+        filters:
+          activity: Moja aktivita
+          all: Všetky
+          date_values:
+            all: Všetky
+            past: Minulé
+            upcoming: Nadchádzajúce
+          my_meetings: Moje stretnutia
+          origin: Pôvod
+          origin_values:
+            all: Všetky
+            official: Oficiálne
+            participants: Účastníci
+          type: Typ
+          type_values:
+            all: Všetky
+            hybrid: Hybridné
+            in_person: Osobné
+            online: Online
+        form:
+          address_help: 'Adresa: používa Geocoder na nájdenie polohy'
+          available_slots_help: Ponechajte 0, ak máte k dispozícii neobmedzený počet miest
+          disclaimer: 'Zrieknutie sa zodpovednosti: Použitím externého registračného systému si uvedomujete, že organizátori %{organization} nezodpovedajú za údaje poskytnuté používateľmi externej službe.'
+          iframe_embed_type_html: 'Iba niekoľko služieb umožňuje vloženie do stretnutia alebo živého podujatia z nasledujúcich domén: %{domains}'
+          location_help: 'Miesto: správa pre používateľov označujúca miesto stretnutia'
+          location_hints_help: 'Tipy k miestu: doplňujúce informácie. Príklad: poschodie budovy, ak ide o osobné stretnutie, alebo heslo stretnutia, ak ide o online stretnutie s obmedzeným prístupom.'
+          online_meeting_url_help: 'Odkaz: umožnite účastníkom pripojiť sa priamo k vášmu stretnutiu'
+          registration_url_help: 'Odkaz: umožnite účastníkom prejsť na externú službu, ktorú používate na registrácie'
+          select_a_meeting_type: Vyberte typ stretnutia
+          select_a_registration_type: Vyberte typ registrácie
+          select_an_iframe_access_level: Vyberte úroveň prístupu pre iframe
+        index:
+          click_here: Zobraziť všetky stretnutia
+          new_meeting: Nové stretnutie
+          see_all: Zobraziť všetky stretnutia
+          see_all_withdrawn: Zobraziť všetky stiahnuté stretnutia
+          text_banner: Prezeráte si zoznam stretnutí stiahnutých ich autormi. %{go_back_link}.
+        meeting:
+          edit_close_meeting: Upraviť správu zo stretnutia
+          edit_meeting: Upraviť
+          join_meeting: Pripojiť sa k stretnutiu
+          reply_poll: Odpovedať na anketu
+          view_poll: Zobraziť anketu
+        meetings:
+          no_meetings_warning: Žiadne stretnutia nezodpovedajú vašim kritériám vyhľadávania alebo nie je naplánované žiadne stretnutie.
+        new:
+          back: Späť
+          create: Vytvoriť
+          title: Vytvoriť nové stretnutie
+        show:
+          leave: Zrušiť vašu registráciu
+          leave_confirmation: Naozaj chcete zrušiť svoju registráciu na toto stretnutie?
+          link_available_soon: Odkaz bude čoskoro k dispozícii
+          link_closed: Odkaz na pripojenie k stretnutiu bude k dispozícii niekoľko minút pred jeho začiatkom
+          live_event: Toto stretnutie práve prebieha
+          micro_camera_permissions_warning: Po kliknutí na tlačidlo nižšie budete požiadaní o povolenie pre mikrofón a/alebo kameru a pripojíte sa k videokonferencii
+          visit_finished: Zobraziť minulé stretnutie
+          withdraw_btn_hint: Ak zmeníte názor, môžete svoje stretnutie stiahnuť. Stretnutie sa nevymaže, zobrazí sa v zozname stiahnutých stretnutí.
+          withdraw_confirmation_html: Naozaj chcete stiahnuť toto stretnutie?<br><br><strong>Túto akciu nie je možné zrušiť!</strong>
+          withdraw_meeting: Stiahnuť
+        update:
+          invalid: Pri aktualizácii stretnutia sa vyskytol problém.
+          success: Stretnutie ste úspešne aktualizovali.
+      models:
+        meeting:
+          fields:
+            official_meeting: Oficiálne stretnutie
+      polls:
+        questions:
+          closed_question:
+            announcement: Odpovede na túto otázku boli uzavreté.
+            question: Otázka
+            question_results: Výsledky
+          index:
+            empty_questions: Počas tohto stretnutia budú odoslané niektoré otázky a budete na ne môcť odpovedať. Zobrazia sa tu.
+          index_admin:
+            edit: Upraviť v paneli správcu
+            question: Otázka
+            results: Výsledky
+            send: Odoslať
+            sent: Odoslané
+            statuses:
+              closed: Výsledky odoslané (uzavreté)
+              published: Odoslané (otvorené)
+              unpublished: Čaká na odoslanie
+          published_question:
+            max_choices_alert: Je vybratých príliš veľa možností
+            question: Otázka
+            question_replied: Otázka zodpovedaná
+            reply_question: Odpovedať na otázku
+      public_participants_list:
+        attending_participants: Účastníci
+        hidden_participants_count:
+          one: a %{count} ďalšia osoba
+          other: a %{count} ďalších osôb
+      registration_type:
+        on_different_platform: Na inej platforme
+        on_this_platform: Na tejto platforme
+        registration_disabled: Registrácia zakázaná
+      registrations:
+        create:
+          success: Úspešne ste sa pripojili k stretnutiu. Keďže ste sa na toto stretnutie zaregistrovali, budete upozornení na prípadné aktualizácie.
+      type_of_meeting:
+        hybrid: Hybridné
+        in_person: Osobne
+        online: Online
+      types:
+        withdraw: Stiahnuté
+      withdraw:
+        error: Pri sťahovaní stretnutia sa vyskytol problém.
+        success: Stretnutie bolo úspešne stiahnuté.
+    menu:
+      assemblies: Zhromaždenia
+    messaging:
+      conversation_mailer:
+        new_conversation:
+          outro: Užite si platformu!
+        new_message:
+          outro: Užite si platformu!
+      conversations:
+        add_conversation_users:
+          participant_with_disabled_message_reception: Tento účastník si neželá prijímať súkromné správy.
+        create:
+          error: Konverzácia sa nezačala. Skúste to znova neskôr.
+        error_modal:
+          correct_errors: Opravte chyby a skúste to znova.
+          intro: 'Vo vašej správe sa vyskytli nasledujúce chyby:'
+          ok: OK
+        index:
+          no_conversations: Zatiaľ nemáte žiadne konverzácie.
+        reply_form:
+          placeholder: Vaša odpoveď...
+          send: Odoslať
+        show:
+          back: Späť na všetky konverzácie
+          deleted_accounts: Nemôžete viesť konverzáciu s odstránenými účtami.
+          not_allowed: Tento účastník neprijíma priame správy.
+        start:
+          placeholder: Vaša správa...
+        update:
+          error: Správa nebola odoslaná pre chybu.
+    metadata:
+      progress:
+        active: Aktívne
+        finished: 'Dokončené: %{end_date}'
+        not_started: Zatiaľ nezačaté
+        remaining: Zostáva %{time_distance}
+    models:
+      questionnaire_template:
+        fields:
+          questions: Počet otázok
+          title: Názov dotazníka
+      template:
+        fields:
+          created_at: Vytvorené
+        name: Šablóna
+    moderations:
+      actions:
+        expand: Rozbaliť
+        parent_hidden: Tento zdroj nemôžete odkryť, pretože jeho nadradený prvok je stále skrytý.
+      admin:
+        reportable:
+          unhide:
+            parent_invalid: Vyskytol sa problém pri odkrývaní zdroja. Nadradený prvok nie je viditeľný.
+      models:
+        moderation:
+          fields:
+            created_at: Nahlásené dňa
+            deleted_resource: Odstránený zdroj
+            participatory_space: Participatívny priestor
+            report_count: Počet nahlásení
+            reportable_id: ID
+            reportable_type: Typ
+            reports: Dôvod
+        report:
+          fields:
+            details: Podrobnosti o dôvode
+            locale: Jazyk
+            reason: Dôvod
+    newsletter_mailer:
+      newsletter:
+        no_reply_notice: Tento e-mail bol odoslaný z e-mailovej adresy pre upozornenia, ktorá neprijíma prichádzajúce e-maily. Na túto správu neodpovedajte.
+        note: Tento e-mail ste dostali, pretože ste prihlásený/á na odber noviniek na %{organization_name}. Svoje nastavenia môžete zmeniť na <a href="%{link}">stránke upozornení</a>.
+        see_on_website: Nezobrazuje sa vám tento e-mail správne? Pozrite si ho na <a href="%{link}" target="_blank" class="see-on-website">webovej stránke</a>.
+    newsletters:
+      unsubscribe:
+        check_subscription_html: Ak by ste ich chceli znova dostávať, odber si môžete kedykoľvek obnoviť na <a href="%{link}" target="_blank">stránke nastavení</a>.
+        error: Pri odhlasovaní z odberu sa vyskytol problém.
+        subscription_preferences: Aktualizovali sme vaše preferencie odberu a už nebudete dostávať novinky od %{organization_name}.
+        unsubscribe: Odhlásiť sa z odberu noviniek
+    newsletters_opt_in:
+      unauthorized: Ľutujeme, tento odkaz už nie je dostupný.
+      update:
+        error: Pri ukladaní nastavení noviniek sa vyskytol problém.
+        success: Nastavenia noviniek boli úspešne aktualizované.
+    newsletters_opt_in_mailer:
+      notify:
+        body_1: Spracovanie osobných údajov a ich ochrana sú pre nás všetkých čoraz dôležitejšie. Vďaka Všeobecnému nariadeniu o ochrane údajov (GDPR) z 25. mája 2018 majú jednotlivci lepšiu kontrolu nad svojimi osobnými údajmi. Z tohto dôvodu potrebujeme váš súhlas, aby sme vám mohli naďalej posielať relevantné informácie o aktivitách %{organization_name}.
+    notification_mailer:
+      event_received:
+        no_translation_available: Ľutujeme, pri odosielaní e-mailu sa nepodarilo získať automatický preklad. Preklad pôvodného textu si môžete pozrieť na nasledujúcom odkaze %{link}.
+        original_text: 'Pôvodný text:'
+        same_language: Obsah bol zverejnený vo vašom preferovanom jazyku (%{language}), preto sa v tomto e-maile nezobrazuje automatický preklad.
+        translated_text: 'Automaticky preložený text:'
+    notifications:
+      action_error: Pri aktualizácii nastavení upozornení sa vyskytol problém.
+      show:
+        missing_event: Ups, toto upozornenie patrí k položke, ktorá už nie je dostupná. Môžete ho zahodiť.
+        moderated: Obsah bol skrytý prostredníctvom moderovania.
+    notifications_digest_mailer:
+      header:
+        daily: Denný prehľad upozornení
+        real_time: V reálnom čase
+        weekly: Týždenný prehľad upozornení
+      hello: Dobrý deň %{name},
+      intro:
+        daily: 'Toto sú upozornenia za posledný deň na základe aktivity, ktorú sledujete:'
+        real_time: 'Toto je upozornenie na aktivitu, ktorú sledujete:'
+        weekly: 'Toto sú upozornenia za posledný týždeň na základe aktivity, ktorú sledujete:'
+      outro: Tieto upozornenia ste dostali, pretože sledujete tento obsah alebo jeho autorov. Ich sledovanie môžete zrušiť na ich príslušných stránkach.
+      see_more: Zobraziť viac upozornení
+      subject: Toto je váš e-mailový prehľad
+    notifications_settings:
+      show:
+        administrators: Administrátori
+        allow_public_contact: Povoliť komukoľvek poslať mi priamu správu, aj keď ho nesledujem.
+        allow_push_notifications: Dostávajte push upozornenia, aby ste zistili, čo sa deje, keď nie ste na platforme. Môžete ich kedykoľvek vypnúť.
+        email_on_moderations: Chcem dostať e-mail zakaždým, keď je niečo alebo niekto nahlásený na moderovanie.
+        notification_settings:
+          close_meeting_reminder: Chcem dostávať e-mailové pripomienky o nezverejnených správach z uzavretých stretnutí
+        notifications_sending_frequencies:
+          daily: Denne
+          none: Žiadne
+          real_time: V reálnom čase
+          weekly: Týždenne
+        notifications_sending_frequency: Ako často chcete dostávať e-maily s upozorneniami?
+        push_notifications: Push upozornenia
+        push_notifications_reminder: Ak chcete dostávať upozornenia z platformy, musíte ich najprv povoliť v nastaveniach prehliadača.
+    offline:
+      name: Offline
+      show:
+        message_1: Zdá sa, že ste momentálne offline.
+        message_2: Skúste to znova neskôr.
+        retry: Skúsiť znova
+    orders:
+      checkout:
+        error: Pri spracovaní vášho hlasu sa vyskytol problém.
+      destroy:
+        error: Pri rušení vášho hlasu sa vyskytol problém.
+        success: Váš hlas bol úspešne zrušený.
+    pad_iframe:
+      explanation: Použite tento blok na spoločné písanie poznámok počas stretnutia, aby bolo neskôr jednoduchšie spísať zápisnicu.
+    pages:
+      home:
+        footer_sub_hero:
+          footer_sub_hero_body_html: Budujme otvorenejšiu, transparentnejšiu a spolupracujúcejšiu spoločnosť.<br /> Pridajte sa, zapojte sa a rozhodujte.
+        hero:
+          participate_title: Zapojte sa do procesov platformy
+        sub_hero:
+          register_title: Vytvoriť účet
+      show:
+        empty: Na tejto stránke zatiaľ nie je žiadny obsah.
+      terms_of_service:
+        accept:
+          error: Vyskytol sa problém s prijatím podmienok služby.
+          success: Skvelé! Prijali ste podmienky služby.
+        form:
+          agreement: Súhlasím s týmito podmienkami
+          legend: Súhlas s podmienkami služby
+        refuse:
+          modal_body: Ak odmietnete, nebudete môcť platformu používať, môžete si <a href="%{download_your_data_path}">stiahnuť svoje údaje</a> a/alebo <a href="%{delete_path}">odstrániť svoj účet</a>.
+          modal_btn_continue: Prijať podmienky a pokračovať
+          modal_btn_exit: Pozriem si to neskôr
+          modal_button: Odmietnuť podmienky
+          modal_title: Naozaj odmietate aktualizované podmienky používania?
+        required_review:
+          alert: Aktualizovali sme naše Podmienky používania, prosím, prečítajte si ich.
+          body: Nájdite si chvíľu na prečítanie aktualizácií našich Podmienok používania. V opačnom prípade nebudete môcť platformu používať.
+          title: 'Povinné: Prečítajte si aktualizácie našich podmienok používania'
+    participatory_process_groups:
+      content_blocks:
+        extra_data:
+          developer_group: Propaguje
+          name: Metadáta
+          participatory_scope: O čom sa rozhoduje
+          participatory_structure: Ako sa rozhoduje
+          target: Kto sa zúčastňuje
+        html:
+          name: HTML blok
+        html_1:
+          name: Prvý HTML blok
+        html_2:
+          name: Druhý HTML blok
+        html_3:
+          name: Tretí HTML blok
+        main_data:
+          name: Názov a popis
+        participatory_processes:
+          active: Aktívne participatívne procesy
+          name: Participatívne procesy
+        title:
+          meta_scope: Rozsah
+          participatory_processes:
+            one: 1 proces
+            other: '%{count} procesov'
+      related_processes:
+        help: Všetky vybrané procesy budú priradené k tejto skupine, vrátane tých, ktoré sú už priradené k iným skupinám.
+    participatory_processes:
+      admin:
+        content_blocks:
+          highlighted_processes:
+            active: Aktívne
+            all: Všetky
+            selection_criteria: Kritériá výberu
+        new_import:
+          accepted_types:
+            json: JSON
+        participatory_process_groups:
+          form:
+            metadata: Metadáta
+            title: O tomto procese
+            visibility: Viditeľnosť
+        participatory_process_imports:
+          form:
+            slug_help_html: 'URL slugy sa používajú na generovanie adries URL, ktoré odkazujú na tento proces. Akceptujú sa iba písmená, čísla a pomlčky a musia začínať písmenom. Príklad: %{url}'
+        participatory_processes:
+          form:
+            slug_help_html: 'URL slugy sa používajú na generovanie adries URL, ktoré odkazujú na tento proces. Akceptujú sa iba písmená, čísla a pomlčky a musia začínať písmenom. Príklad: %{url}'
+            visibility: Viditeľnosť
+      content_blocks:
+        extra_data:
+          name: Fáza a trvanie
+        hero:
+          name: Hlavný obrázok a CTA
+        related_processes:
+          name: Súvisiace procesy
+      last_activity:
+        new_participatory_process: 'Nový participatívny proces:'
+      pages:
+        home:
+          highlighted_processes:
+            active_spaces: Aktívne procesy
+            see_all_spaces: Zobraziť všetky procesy
+      participatory_processes:
+        description:
+          area_name: Oblasť
+          data: Údaje o procese
+          developer_group: Skupina navrhovateľov
+          local_area: Oblasť organizácie
+          meta_scope: Rozsah
+          participatory_scope: O čom sa rozhoduje
+          participatory_structure: Ako sa rozhoduje
+          target: Kto sa zúčastňuje
+          title: O tomto procese
+        filters:
+          all_types: Všetky typy
+          date: Dátum
+          explanations:
+            no_active: Žiadne aktívne procesy.
+            no_active_nor_upcoming: Žiadne aktívne ani nadchádzajúce procesy.
+          filter_by: Zobraziť
+          type: Typ
+        show:
+          title: O tomto procese
+      show:
+        belongs_to_group: Tento proces patrí do
+        related_assemblies: Súvisiace zhromaždenia
+    participatory_spaces:
+      highlighted_results:
+        see_all: Zobraziť všetky výsledky
+    passwords:
+      update:
+        error: Pri aktualizácii hesla sa vyskytol problém.
+        success: Heslo bolo úspešne aktualizované.
+    profile:
+      inaccessible_message: Tento profil je neprístupný z dôvodu porušenia podmienok používania!
+    profiles:
+      default_officialization_text_for_users: Tento účastník je verejne overený, jeho/jej meno alebo rola boli overené a zodpovedajú jeho/jej skutočnému menu a role.
+      show:
+        conversations: Konverzácie
+        officialized: Oficiálny účastník
+        send_private_message: Poslať súkromnú správu
+      user:
+        actions:
+          disabled_message: Správa
+          message: Správa
+    proposals:
+      actions:
+        delete_proposal_state_confirm: Naozaj chcete odstrániť tento stav?
+        destroy: Odstrániť stav
+        edit_proposal_state: Upraviť stav
+        new_proposal_state: Nový stav
+      admin:
+        exports:
+          proposal_comments: Komentáre
+        import_proposals_mailer:
+          notify_failure:
+            body: Vyskytol sa problém pri importe návrhov z komponentu %{origin_component_name} do komponentu %{target_component_name}.
+            subject: Pri importe návrhov sa vyskytla chyba
+          notify_success:
+            added_proposals:
+              one: Jeden návrh bol importovaný.
+              other: '%{count} návrhov bolo importovaných.'
+            body: Úspešne importované návrhy z komponentu %{origin_component_name} do komponentu %{target_component_name}. Výsledky si môžete skontrolovať v administračnom rozhraní.
+            subject: Návrhy boli úspešne importované
+        imports:
+          help:
+            answers: 'Dokument na import by mal obsahovať nasledujúce názvy stĺpcov v prípade súborov CSV alebo Excel, alebo názvy kľúčov v prípade súborov JSON (ostatné stĺpce budú ignorované):
+
+              <ul>
+
+              <li><b>id:</b> ID návrhu na odpoveď</li>
+
+              <li><b>state:</b> Jeden zo stavov „accepted“, „evaluating“ alebo „rejected“</li>
+
+              <li><b>answer/en:</b> Odpoveď v anglickom jazyku. Bude to závisieť od konfigurácie jazyka vašej platformy.</li>
+
+              </ul>
+
+              '
+            proposals: 'Súbor musí mať nasledujúce názvy stĺpcov v prípade súborov CSV alebo Excel, alebo názvy kľúčov v prípade súborov JSON:
+
+              <ul>
+
+              <li><b>title/en:</b> Názov v anglickom jazyku. Bude to závisieť od konfigurácie jazyka vašej platformy.</li>
+
+              <li><b>body/en:</b> Telo v anglickom jazyku. Bude to závisieť od konfigurácie jazyka vašej platformy.</li>
+
+              <li><b>taxonomies/ids:</b> ID pre taxonómie (ak je ich viac, oddeľte ich čiarkou)</li>
+
+              </ul>
+
+              '
+          label:
+            answers: Importovať odpovede zo súboru
+            proposals: Importovať návrhy zo súboru
+          resources:
+            answers:
+              one: odpoveď na návrh
+              other: odpovedí na návrhy
+            proposals:
+              one: návrh
+              other: návrhov
+          title:
+            answers: Importovať odpovede na návrhy zo súboru
+            proposals: Importovať návrhy zo súboru
+        participatory_texts:
+          new_import:
+            accepted_mime_types:
+              odt: ODT
+            document_legend: 'Pridajte dokument menší ako 2 MB, každá sekcia až do hĺbky 3 úrovní bude analyzovaná do návrhov. Podporované formáty sú: %{valid_mime_types}'
+          publish:
+            invalid: Vyskytol sa problém pri zverejňovaní návrhov.
+            success: Všetky návrhy boli zverejnené.
+        proposal_notes:
+          create:
+            error: Vyskytol sa problém pri vytváraní tejto poznámky k návrhu.
+            success: Poznámka k návrhu bola úspešne vytvorená.
+        proposal_states:
+          create:
+            error: Chyba pri vytváraní stavu
+            success: Stav bol úspešne vytvorený
+          destroy:
+            success: Stav bol úspešne odstránený
+          edit:
+            title: Upraviť stav
+            update: Aktualizovať
+          form:
+            preview: Náhľad
+          index:
+            title: Stavy
+          new:
+            create: Vytvoriť
+            title: Nový stav
+          update:
+            error: Chyba pri aktualizácii stavu
+            success: Stav bol úspešne aktualizovaný
+        proposals:
+          answer:
+            invalid: Vyskytol sa problém pri odpovedaní na tento návrh.
+            success: Návrh bol úspešne zodpovedaný.
+          create:
+            invalid: Vyskytol sa problém pri vytváraní tohto návrhu.
+            success: Návrh bol úspešne vytvorený.
+          index:
+            statuses: Stavy
+          publish_answers:
+            number_of_proposals: Odpovede pre %{number} návrhov budú zverejnené?
+            select_a_proposal: Prosím, vyberte návrh.
+          show:
+            link: Zobraziť návrh
+            votes_count: Počet hlasov
+        proposals_imports:
+          create:
+            invalid: Pri importovaní návrhov sa vyskytol problém.
+            success: Proces importu sa začal. Po jeho dokončení vás budeme informovať.
+          new:
+            title: Importovať návrhy z iného komponentu
+        proposals_merges:
+          create:
+            invalid: 'Pri zlučovaní vybratých návrhov sa vyskytol problém, pretože niektoré z nich:'
+        proposals_splits:
+          create:
+            invalid: 'Pri rozdeľovaní vybratých návrhov sa vyskytol problém, pretože niektoré z nich:'
+      application_helper:
+        filter_origin_values:
+          participants: Účastníci
+      content_blocks:
+        highlighted_proposals:
+          name: Návrhy
+      last_activity:
+        new_proposal: 'Nový návrh:'
+        proposal_updated: 'Návrh bol aktualizovaný:'
+      models:
+        proposal_state:
+          css_class: CSS trieda
+          title: Stav
+      new:
+        limit_reached: Nemôžete vytvárať nové návrhy, pretože ste prekročili limit.
+      proposal_votes:
+        create:
+          error: Pri hlasovaní za návrh sa vyskytol problém.
+      proposals:
+        dynamic_map_instructions:
+          description: Súradnice sa aktualizujú po kliknutí na tlačidlo 'náhľad'. Adresa sa však nezmení.
+          instructions: Bod na mape môžete presunúť.
+        edit_draft:
+          title: Upraviť koncept návrhu
+        edit_form_fields:
+          marker_added: Značka bola pridaná na mapu.
+        filters:
+          voted: Hlasované
+        index:
+          click_here: Zobraziť všetky návrhy
+          grid_mode: Režim mriežky
+          list_mode: Režim zoznamu
+          see_all: Zobraziť všetky návrhy
+          text_banner: Prezeráte si zoznam návrhov stiahnutých ich autormi. %{go_back_link}.
+        new:
+          title: Vytvoriť nový návrh
+        orders:
+          most_voted: Najviac hlasov
+        participatory_texts:
+          view_index:
+            document_index: Index dokumentu
+        placeholder:
+          address: 37 Homewood Drive Brownsburg, IN 46112
+        preview:
+          announcement_body: Váš návrh bol uložený ako koncept. Aby sa zobrazil na stránke, musí byť zverejnený.
+          announcement_title: Váš návrh ešte nebol zverejnený
+        proposals:
+          empty: Zatiaľ tu nie sú žiadne návrhy.
+          empty_filters: Neexistujú žiadne návrhy s týmito kritériami.
+        show:
+          withdraw_btn_hint: Svoj návrh môžete stiahnuť, ak zmeníte názor, pokiaľ ste nedostali žiadny hlas. Návrh sa neodstráni, zobrazí sa v zozname stiahnutých návrhov.
+          withdraw_confirmation_html: Naozaj chcete stiahnuť tento návrh?<br><br><strong>Túto akciu nie je možné zrušiť!</strong>
+        update:
+          title: Aktualizovať návrh
+        vote_button:
+          already_voted: Hlasované
+          already_voted_hover: Stiahnuť hlas
+          maximum_votes_reached: Limit hlasov bol dosiahnutý
+          no_votes_remaining: Nezostávajú žiadne hlasy
+          vote: Hlasovať
+          votes_blocked: Hlasovať
+        votes_count:
+          count:
+            one: Hlas
+            other: Hlasov
+        voting_rules:
+          can_accumulate_votes_beyond_threshold:
+            description: Každý návrh môže získať viac ako %{limit} hlasov
+          minimum_votes_per_user:
+            description: Musíte rozdeliť minimálne %{votes} podpôr medzi rôzne návrhy, aby sa vaše podpory brali do úvahy.
+          threshold_per_proposal:
+            description: Aby boli návrhy overené, musia dosiahnuť %{limit} hlasov.
+          title: Pravidlá účasti
+          vote_limit:
+            description: Môžete hlasovať až pre %{limit} návrhov.
+            votes: Zostáva %{number} hlasov
+        wizard_aside:
+          back_from_step_1: Späť na návrhy
+          back_from_step_2: Späť na úpravu
+        wizard_steps:
+          current_step: Aktuálny krok
+          step_2: Zverejnite svoj návrh
+          title: Kroky vytvorenia návrhu
+      proposals_picker:
+        no_proposals: Žiadne návrhy nezodpovedajú vašim kritériám vyhľadávania alebo neexistujú žiadne návrhy.
+      withdraw:
+        errors:
+          has_votes: Tento návrh nie je možné stiahnuť, pretože už má hlasy.
+    reported_mailer:
+      hidden_automatically:
+        content: Nahlásený obsah
+        details: Podrobnosti
+        hello: Dobrý deň %{name},
+        manage_moderations: Spravovať moderovanie
+        participatory_space: Participatívny priestor
+        reason: Dôvod
+        report_html: <p>Nasledujúci <a href="%{url}">obsah</a> bol automaticky skrytý.</p>
+        subject: Zdroj bol automaticky skrytý
+      hidden_manually:
+        content: Nahlásený obsah
+        details: Podrobnosti
+        hello: Dobrý deň %{name},
+        manage_moderations: Spravovať moderovanie
+        participatory_space: Participatívny priestor
+        reason: Dôvod
+        report_html: <p>Nasledujúci <a href="%{url}">obsah</a> bol skrytý moderátorom %{moderator}.</p>
+        subject: Zdroj bol skrytý moderátorom %{moderator}
+      report:
+        authors: Autori
+        content: Nahlásený obsah
+        content_original_language: Pôvodný jazyk obsahu
+        date: Nahlásené dňa
+        details: Podrobnosti
+        id: ID
+        participatory_space: Participatívny priestor
+        reason: Dôvod
+        see_report: Zobraziť nahlásenie
+    reports:
+      hide:
+        success: Tento zdroj bol skrytý.
+      parent_hidden:
+        report_details: Nadradený zdroj bol skrytý
+    resource_links:
+      included_proposals:
+        project_proposal: Návrhy zahrnuté v tomto projekte
+    resources:
+      initiative:
+        actions:
+          comment: Komentovať
+    search:
+      name: Hľadať
+      results: Výsledky vyhľadávania
+    searches:
+      filters:
+        resource: '%{label} medzi %{collection}'
+        search: Hľadať
+      filters_small_view:
+        filter_and_search: Filtrovať a hľadať
+    security:
+      selfxss_warning:
+        description: Táto funkcia prehliadača je určená pre vývojárov a nemali by ste sem nič vkladať, aj keď vás o to niekto požiadal. Vloženie obsahu do tohto okna môže ohroziť vaše súkromie a poskytnúť hackerom prístup k vášmu účtu.
+        title: Stoj!
+    shared:
+      confirm_modal:
+        cancel: Zrušiť
+        close_modal: Zavrieť okno
+        ok: OK
+        title: Potvrdiť
+      confirm_unload: Táto stránka obsahuje neuložené zmeny. Naozaj chcete opustiť túto stránku?
+      embed:
+        title: Vložený video obsah
+      filter_form_help:
+        help: Nižšie uvedený formulár dynamicky filtruje výsledky vyhľadávania pri zmene podmienok vyhľadávania.
+        skip: Preskočiť na výsledky
+      flag_modal:
+        does_not_belong: Obsahuje nezákonnú činnosť, vyhrážky samovraždou, osobné údaje alebo niečo iné, čo podľa vás nepatrí na %{organization_name}.
+        hide: Skryť
+        hide_content: Skryť tento obsah
+        reason: Dôvod
+      flag_user_modal:
+        already_reported: Tento obsah je už nahlásený a bude skontrolovaný administrátorom.
+        block: Zablokovať tohto účastníka
+        description: Čo je na tomto účastníkovi nevhodné?
+        does_not_belong: Obsahuje nezákonnú činnosť, vyhrážky samovraždou, osobné údaje alebo niečo iné, čo podľa vás nepatrí na %{organization_name}.
+        hide: Skryť všetok ich obsah
+        offensive: Obsahuje rasizmus, sexizmus, nadávky, osobné útoky, vyhrážky smrťou, nabádanie na samovraždu alebo akúkoľvek formu prejavu nenávisti.
+        report: Nahlásiť
+        spam: Obsahuje clickbait, reklamu, podvody alebo skriptovacie boty.
+        title: Nahlásiť nevhodného účastníka
+      follow_button:
+        log_in_before_follow: Pred vykonaním tejto akcie sa prosím prihláste
+      login_modal:
+        please_log_in: Prosím, prihláste sa
+        sign_up: Vytvoriť účet
+      mentions_modal:
+        remove_recipient: Odstrániť príjemcu %{name}
+      progress: Priebeh
+      public_participation:
+        public_participation: Zobraziť moju účasť verejne
+      share_modal:
+        copy_share_link: Kopírovať
+        copy_share_link_clarification: Kopírovať odkaz na zdieľanie do schránky
+        copy_share_link_copied: Skopírované!
+        copy_share_link_message: Odkaz bol úspešne skopírovaný do schránky.
+        share_to: Zdieľať na %{service}
+    statistics:
+      assemblies_count: Zhromaždenia
+      conferences_count: Konferencie
+      debates_count: Debaty
+      followers_count: Sledujúci
+      headline: Štatistiky
+      meetings_count: Stretnutia
+      no_stats: Zatiaľ tu nie sú žiadne štatistiky.
+      orders_count: Podpory
+      pages_count: Stránky
+      participants_count: Účastníci
+      posts_count: Príspevky
+      processes_count: Procesy
+      proposals_accepted: Prijaté návrhy
+      proposals_count: Návrhy
+      results_count: Výsledky
+      users_count: Účastníci
+      votes_count: Hlasy
+    surveys:
+      last_activity:
+        new_survey: 'Nový prieskum:'
+      survey_confirmation_mailer:
+        confirmation:
+          body: Úspešne ste odpovedali na prieskum %{questionnaire_title} v rámci %{participatory_space}
+          subject: Potvrdenie odpovede na dotazník %{questionnaire_title}
+        export_name: Odpovede na prieskum
+    system:
+      actions:
+        new_admin: Nový administrátor
+        new_oauth_application: Nová aplikácia OAUTH
+        new_organization: Nová organizácia
+      admins:
+        create:
+          success: Administrátor bol úspešne vytvorený.
+        destroy:
+          success: Administrátor bol úspešne odstránený.
+        update:
+          success: Administrátor bol úspešne aktualizovaný.
+      dashboard:
+        show:
+          admins: Administrátori
+          current_organizations: Aktuálne organizácie
+          system_checks: Systémové kontroly
+      default_pages:
+        placeholders:
+          summary: Pridajte zmysluplné zhrnutie na statickú stránku %{page} na paneli administrátora.
+        terms-of-service: Podmienky služby
+      devise:
+        passwords:
+          edit:
+            change_your_password: Zmeniť heslo
+            minimum_characters: (minimálne %{minimum} znakov)
+          new:
+            forgot_your_password: Zabudli ste heslo
+            send_me_reset_password_instructions: Pošlite mi pokyny na obnovenie hesla
+        shared:
+          links:
+            did_not_receive_confirmation_instructions?: Nedostali ste pokyny na potvrdenie?
+            did_not_receive_unlock_instructions?: Nedostali ste pokyny na odomknutie?
+            forgot_your_password?: Zabudli ste heslo?
+            log_in: Prihlásiť sa
+            sign_up: Vytvoriť účet
+      menu:
+        oauth_applications: Aplikácie OAuth
+      models:
+        oauth_application:
+          fields:
+            created_at: Vytvorené
+            name: Názov aplikácie OAuth
+            organization_name: Organizácia
+        organization:
+          fields:
+            content_security_policy: Zásady zabezpečenia obsahu
+            file_upload_settings: Nastavenia nahrávania súborov
+      oauth_applications:
+        create:
+          error: Pri vytváraní tejto aplikácie sa vyskytol problém.
+          success: Aplikácia bola úspešne vytvorená.
+        destroy:
+          error: Pri odstraňovaní tejto aplikácie sa vyskytol problém.
+          success: Aplikácia bola úspešne odstránená.
+        edit:
+          save: Uložiť
+          title: Upraviť aplikáciu
+        form:
+          select_organization: Vyberte organizáciu
+        index:
+          confirm_delete: Naozaj chcete odstrániť túto aplikáciu?
+          title: Aplikácie OAuth
+        new:
+          save: Uložiť
+          title: Nová aplikácia
+        update:
+          error: Pri aktualizácii tejto aplikácie sa vyskytol problém.
+          success: Aplikácia bola úspešne aktualizovaná.
+      organizations:
+        advanced_settings:
+          hide: Skryť pokročilé nastavenia
+          show: Zobraziť pokročilé nastavenia
+        create:
+          error_invitation: Pri vytváraní novej organizácie sa vyskytol problém. Skontrolujte meno administrátora organizácie.
+          success_html: "<p>\n  Organizácia bola úspešne vytvorená.\n</p>\n<ol>\n  <li>Možno budete musieť aktualizovať kód vašej aplikácie, aby ste povolili požiadavky na %{host}, musíte pridať nasledujúce do vašej\n  konfigurácie prostredia (napr. <code>config/environment/production.rb</code>) alebo do vášho <code>config/application.rb</code>:\n    <p> config.hosts << \"%{host}\" </p>\n  </li>\n  <li>\n    Po dokončení budete mať prístup k vašej platforme cez <a href=\"http://%{host}\">http://%{host}</a>\n  </li>\n  <li>\n    Na adresu <b>%{email}</b> sme poslali e-mail, ktorý musíte potvrdiť.\n  </li>\n</ol>\n"
+        csp_settings:
+          connect_src: Connect src
+          connect_src_hint: 'Smernica connect-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <script>.
+
+            Platforma pridá ''self'', ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          default_src: Default src
+          default_src_hint: 'Smernica default-src je predvolená politika pre načítanie obsahu, ako sú JavaScript, obrázky, CSS, písma, požiadavky AJAX, rámce, médiá HTML5.
+
+            Platforma pridá "''self'' ''unsafe-inline''", ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          font_src: Font src
+          font_src_hint: 'Smernica font-src obmedzuje adresy URL, ktoré je možné načítať pomocou @font-face.
+
+            Platforma pridá ''self'', ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          frame_src: Frame src
+          frame_src_hint: 'Smernica frame-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <frame>, <iframe> a <object>.
+
+            Platforma pridá ''self'', ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          img_src: Img src
+          img_src_hint: 'Smernica img-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <img>, <image>, <picture> a <svg>.
+
+            Platforma pridá ''self'', ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          media_src: Media src
+          media_src_hint: 'Smernica media-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <video>, <audio> a <source>.
+
+            Platforma pridá ''self'', ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          script_src: Script src
+          script_src_hint: 'Smernica script-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <script>.
+
+            Platforma pridá "''self'' ''unsafe-inline'' ''unsafe-eval''", ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+          style_src: Style src
+          style_src_hint: 'Smernica style-src obmedzuje adresy URL, ktoré je možné načítať pomocou prvkov <style>.
+
+            Platforma pridá "''self'' ''unsafe-inline''", ale umožňuje vám pridať ďalšie. Ak si nie ste istí, nechajte pole prázdne.
+
+            '
+        edit:
+          confirm_resend_invitation: Naozaj chcete znova odoslať pozvánku?
+          resend_invitation: Znova odoslať pozvánku
+          title: Upraviť organizáciu
+        file_upload_settings:
+          content_types:
+            admin_hint: Tieto typy MIME sú povolené pre nahrávanie v sekcii administrátora. Administrátori by si mali byť vedomí rizík spojených s nahrávaním niektorých formátov dokumentov, takže sa dá očakávať, že budú pri nahrávaní súborov opatrnejší.
+            default_hint: Tieto typy MIME sú predvolene povolené pre všetkých používateľov.
+            intro_html: Pre typy MIME môžete pridať zástupné znaky pomocou hviezdičky, napr. <code>image/*</code>.
+            title: Povolené typy MIME
+          file_extensions:
+            admin_hint: Tieto prípony súborov sú povolené pre nahrávanie v sekcii administrátora. Administrátori by si mali byť vedomí rizík spojených s nahrávaním niektorých formátov dokumentov, takže sa dá očakávať, že budú pri nahrávaní súborov opatrnejší.
+            default_hint: Tieto prípony súborov sú predvolene povolené pre všetkých používateľov.
+            image_hint: Tieto prípony súborov sú povolené pre akýkoľvek druh nahrávania obrázkov.
+            title: Povolené prípony súborov
+          file_sizes:
+            avatar_hint: Megabajty (MB). Tento limit veľkosti súboru sa používa na nahrávanie obrázkov avatarov.
+            default_hint: Megabajty (MB). Tento limit veľkosti súboru je predvolený a používa sa pre všetky nahrávania súborov, pokiaľ nie je uvedené inak.
+            title: Maximálne veľkosti súborov
+          intro: 'Pri zvažovaní zmeny týchto nastavení buďte mimoriadne opatrní. Čím menej povolíte, tým lepšie.
+
+            Povolenie konkrétnych prípon súborov alebo typov MIME môže vystaviť používateľov systému bezpečnostným rizikám a môže tiež ovplyvniť prístupnosť webovej stránky.
+
+            '
+        new:
+          default: Predvolené?
+          enabled: Povolené
+          locale: Jazyk
+          organization_admin_email_hint: Na túto adresu pošleme e-mail, aby ste ju mohli potvrdiť a nastaviť si heslo.
+          reference_prefix_hint: Referenčná predpona sa používa na jedinečnú identifikáciu zdrojov v celej organizácii.
+          secondary_hosts_hint: Každý z nich zadajte do nového riadka.
+        resend_invitation:
+          error: Pri odosielaní pozvánky sa vyskytol problém.
+          success: Pozvánka bola úspešne odoslaná.
+        smtp_settings:
+          fieldsets:
+            sender: Odosielateľ
+          instructions:
+            from_label: 'Odosielateľ e-mailu bude: "názov-vašej-organizácie <vasa-organizacia@example.org>". Nechajte prázdne, ak chcete použiť rovnaký názov, aký je definovaný pre organizáciu.'
+          placeholder:
+            from_email: vasa-organizacia@example.org
+            from_label: názov-vašej-organizácie
+        users_registration_mode:
+          enabled: Povoliť účastníkom vytvoriť si účet a prihlásiť sa
+          existing: Nepovoliť účastníkom vytvoriť si účet, ale povoliť prihlásenie existujúcim účastníkom
+      shared:
+        organizations_list:
+          confirm_resend_invitation: Naozaj chcete znova odoslať pozvánku?
+          resend_invitation: Znova odoslať pozvánku
+      system_checks:
+        active_job_queue:
+          decidim_documentation: Dokumentácia Decidim
+          error: Fronta ActiveJob nie je nakonfigurovaná. Toto nie je odporúčané nastavenie pre produkciu. Prečítajte si viac na %{error_extra}.
+          success: Fronta ActiveJob je správne nakonfigurovaná.
+        secret_key:
+          error: 'Tajný kľúč nie je správne definovaný. Uložte ho do premennej prostredia SECRET_KEY_BASE a reštartujte server: %{error_extra}'
+          success: Tajný kľúč je správne nakonfigurovaný.
+      titles:
+        decidim: Decidim
+    templates:
+      admin:
+        block_user_templates:
+          edit:
+            title: Upraviť šablónu správy o zablokovaní používateľa
+          form:
+            save: Uložiť
+          index:
+            confirm_delete: Naozaj chcete odstrániť túto šablónu?
+            title: Správy o zablokovaní používateľa
+          new:
+            title: Nová šablóna správy o zablokovaní používateľa
+          template_chooser:
+            select_template: Vyberte šablónu odpovede
+        proposal_answer_templates:
+          edit:
+            title: Upraviť šablónu odpovede na návrh
+          form:
+            component_constraint_help: Upozorňujeme, že sa zobrazia iba participatívne priestory s komponentmi typu „návrhy“.
+            hint1_html: <strong>%{organization}</strong> bude nahradené názvom organizácie
+            hint2_html: <strong>%{name}</strong> bude nahradené menom autora
+            hint3_html: <strong>%{admin}</strong> bude nahradené menom administrátora (toho, kto odpovedá na návrh)
+            hint_html: <strong>Tip:</strong> Tieto premenné môžete použiť kdekoľvek v šablóne odpovede a pri použití šablóny budú nahradené
+            save: Uložiť
+          index:
+            component_constraint: Pridať obmedzenie
+            confirm_delete: Naozaj chcete odstrániť túto šablónu?
+            missing_state: Chýbajúci stav
+            proposal_state_id: Interný stav
+            title: Odpovede na návrhy
+          new:
+            title: Nová šablóna odpovede na návrh
+          template_chooser:
+            select_template: Vyberte šablónu odpovede
+        questionnaire_templates:
+          choose:
+            description: Môžete vytvoriť nový dotazník alebo si môžete vybrať preddefinovanú šablónu a neskôr ju upraviť. Vyberte možnosť.
+            label: Vybrať šablónu
+            placeholder: Vybrať šablónu
+          edit:
+            edit: Upraviť
+            empty: Zatiaľ tu nie sú žiadne otázky.
+            questionnaire: Dotazník
+            title: Upraviť šablónu dotazníka
+          form:
+            title: Šablóna dotazníka %{questionnaire_for}
+          index:
+            confirm_delete: Naozaj chcete odstrániť túto šablónu?
+            title: Šablóny dotazníkov
+          new:
+            title: Nová šablóna dotazníka
+          preview:
+            current_step: Krok %{step}
+            of_total_steps: z %{total_steps}
+            tos_agreement: Účasťou súhlasíte s podmienkami poskytovania služby
+      admin_log:
+        template:
+          create: '%{user_name} vytvoril/a šablónu dotazníka %{resource_name}'
+          delete: '%{user_name} odstránil/a šablónu dotazníka %{resource_name}'
+          duplicate: '%{user_name} duplikoval/a šablónu dotazníka %{resource_name}'
+          update: '%{user_name} aktualizoval/a šablónu dotazníka %{resource_name}'
+      template_types:
+        block_user: Blokovať správy používateľa
+        proposal_answer_templates: Odpovede na návrhy
+        questionnaires: Dotazníky
+    translation_bar:
+      help_text: <strong>Upozornenie:</strong> Obsah môže byť automaticky preložený a nemusí byť 100% presný.
+      show_original: Zobraziť pôvodný text
+      show_translated: Zobraziť automaticky preložený text
+    user_activity:
+      index:
+        no_activities_warning: Tento účastník zatiaľ nemá žiadnu aktivitu.
+    user_conversations:
+      index:
+        time_ago: pred %{time}
+    user_report_mailer:
+      notify:
+        body_1: Používateľ %{user} bol nahlásený používateľom %{token}
+        body_2: 'Dôvod: %{reason}'
+        details: Podrobnosti poskytnuté používateľom
+        greetings: S pozdravom,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+        hello: Dobrý deň %{admin},
+        subject: V %{organization_name} bol nahlásený nový používateľ
+    user_update_mailer:
+      notify:
+        body_1: Túto správu vám posielame, aby sme vás informovali o aktualizácii vášho účtu.
+        body_2: V prípade, že ste takúto aktualizáciu nevykonali sami, prihláste sa do svojho účtu a zmeňte si heslo. V prípade, že sa nemôžete prihlásiť, kontaktujte podporu platformy.
+        greetings: S pozdravom,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+        hello: Dobrý deň %{user}
+        main_body: 'Boli zmenené nasledujúce údaje: %{updates}.'
+        update_fields: '%{updates} a %{last_update}'
+      subject: Váš účet bol aktualizovaný
+    verifications:
+      authorizations:
+        create:
+          success: Boli ste úspešne autorizovaní.
+          transferred: 'Na základe vašej autorizácie sme obnovili nasledujúce údaje o účasti:'
+        destroy:
+          success: Úspešne ste odstránili autorizáciu.
+        index:
+          granted_verification: Udelené overenie
+          introduce_code: Zadajte kód
+          pending_verification: Čakajúce overenie
+          subscribe: Odoberať
+          unauthorized_methods: Metódy overenia
+        renew_modal:
+          info_renew: Ak chcete aktualizovať údaje, pokračujte v obnove.
+      dummy_authorization:
+        extra_explanation:
+          user_postal_codes:
+            one: Účasť je obmedzená na účastníkov s PSČ %{postal_codes} a vaše PSČ je %{user_postal_code}.
+            other: 'Účasť je obmedzená na účastníkov s niektorým z nasledujúcich PSČ: %{postal_codes}. Vaše PSČ je %{user_postal_code}.'
+      id_documents:
+        admin:
+          config:
+            update:
+              success: Konfigurácia bola úspešne aktualizovaná.
+          confirmations:
+            create:
+              error: Overenie sa nezhoduje. Skúste to znova alebo overenie zamietnite, aby ho účastník mohol opraviť.
+              success: Účastník bol úspešne overený.
+          offline_confirmations:
+            create:
+              error: Overenie sa nezhoduje. Skúste to znova alebo povedzte účastníkovi, aby ho opravil.
+              success: Účastník bol úspešne overený.
+          rejections:
+            create:
+              success: Overenie bolo zamietnuté. Účastník bude vyzvaný na opravu svojich dokladov.
+        authorizations:
+          create:
+            error: Vyskytol sa problém pri nahrávaní vášho dokladu.
+            success: Doklad bol úspešne nahraný.
+          edit:
+            being_reviewed: Kontrolujeme vaše doklady. Čoskoro budete overení.
+            rejection_clarity: Uistite sa, že informácie sú na nahranom obrázku jasne viditeľné.
+            rejection_correctness: Uistite sa, že zadané informácie sú správne.
+            rejection_notice: Vyskytol sa problém s vaším overením. Skúste to znova.
+          update:
+            error: Vyskytol sa problém pri opätovnom nahrávaní vášho dokladu.
+            success: Doklad bol úspešne opätovne nahraný.
+        identification_number: Identifikačné číslo
+      postal_letter:
+        admin:
+          postages:
+            create:
+              error: Chyba pri označovaní listu ako odoslaného.
+              success: List bol úspešne označený ako odoslaný.
+        authorizations:
+          create:
+            error: Vyskytol sa problém s vašou požiadavkou.
+            success: Ďakujeme! Na vašu adresu pošleme overovací kód.
+          edit:
+            title: Zadajte overovací kód, ktorý ste dostali.
+            waiting_for_letter: Čoskoro vám na vašu adresu pošleme list s overovacím kódom.
+          update:
+            error: Váš overovací kód sa nezhoduje s naším. Prosím, skontrolujte list, ktorý sme vám poslali.
+            success: Gratulujeme. Boli ste úspešne overení.
+      sms:
+        authorizations:
+          create:
+            error: Vyskytol sa problém s vašou požiadavkou.
+            success: Ďakujeme! Poslali sme SMS na váš telefón.
+          destroy:
+            success: Overovací kód bol úspešne obnovený. Prosím, znova zadajte svoje telefónne číslo.
+          edit:
+            resend: Nedostali ste overovací kód?
+          update:
+            error: Váš overovací kód sa nezhoduje s naším. Prosím, skontrolujte SMS, ktorú sme vám poslali.
+            success: Gratulujeme. Boli ste úspešne overení.
+    version:
+      show:
+        back_to_resource: Späť
+        changes_at_title: Zmeny v „%{title}“
+        number_of_versions: Verzie
+        version_created_at: Verzia vytvorená
+    versions:
+      resource_version:
+        of_versions: (z %{number})
+        see_other_versions: zobraziť iné verzie
+        version: Verzia číslo %{number}
+    versions_list_item:
+      show:
+        version_index: Verzia %{index} z %{total}
+    welcome_notification:
+      default_body: <p>Ahoj {{name}}, ďakujeme, že si sa pridal/a k {{organization}} a vitaj!</p><ul><li>Ak chceš získať rýchlu predstavu o tom, čo tu môžeš robiť, pozri si sekciu <a href="{{help_url}}">Pomocník</a>.</li><li>Po jej prečítaní získaš svoj prvý odznak. Tu je <a href="{{badges_url}}">zoznam všetkých odznakov</a>, ktoré môžeš získať účasťou v {{organization}}</li><li>V neposlednom rade sa pridaj k ostatným, zdieľaj s nimi skúsenosti zo zapojenia a účasti v {{organization}}. Podávaj návrhy, komentuj, diskutuj, premýšľaj o tom, ako prispieť k spoločnému dobru, poskytuj argumenty na presvedčenie, počúvaj a čítaj, aby si sa nechal/a presvedčiť, vyjadruj svoje nápady konkrétnym a priamym spôsobom, reaguj trpezlivo a rozhodne, obhajuj svoje nápady a zachovaj si otvorenú myseľ pre spoluprácu a pripojenie sa k nápadom iných.</li></ul>
+  devise:
+    failure:
+      timeout: Platnosť vašej relácie vypršala. Ak chcete pokračovať, prihláste sa znova.
+      unauthenticated: Pred pokračovaním sa musíte prihlásiť alebo si vytvoriť účet.
+    invitations:
+      edit:
+        nickname_help: Vaša prezývka v %{organization}. Môže obsahovať iba písmená, čísla, '-' a '_'.
+    mailer:
+      email_changed:
+        message: Kontaktujeme vás, aby sme vás upozornili, že váš e-mail sa mení na %{email}.
+      invitation_instructions:
+        ignore: 'Ak nechcete prijať pozvánku, ignorujte tento e-mail.<br />
+
+          Váš účet nebude vytvorený, kým neprejdete na odkaz vyššie a nenastavíte si prezývku a heslo.'
+      invite_admin:
+        subject: Boli ste pozvaný/á na spravovanie %{organization}
+      invite_collaborator:
+        subject: Boli ste pozvaný/á na spoluprácu v %{organization}
+      organization_admin_invitation_instructions:
+        subject: Boli ste pozvaný/á na spravovanie %{organization}
+      password_change:
+        message: Kontaktujeme vás, aby sme vás upozornili, že vaše heslo bolo zmenené.
+      reset_password_instructions:
+        instruction_2: Ak ste o to nepožiadali, ignorujte tento e-mail.
+        instruction_3: Vaše heslo sa nezmení, kým neprejdete na odkaz vyššie a nevytvoríte si nové.
+      unlock_instructions:
+        message: Váš účet bol uzamknutý z dôvodu nadmerného množstva neúspešných pokusov o prihlásenie.
+    passwords:
+      edit:
+        old_password_help: Ak chcete potvrdiť zmeny vo vašom účte, zadajte svoje aktuálne heslo.
+        title: Zmena hesla
+      no_token: Na túto stránku nemôžete pristúpiť bez toho, aby ste prišli z e-mailu na obnovenie hesla. Ak prichádzate z e-mailu na obnovenie hesla, uistite sa, že ste použili celú poskytnutú adresu URL.
+    registrations:
+      new:
+        sign_up: Vytvoriť účet
+    sessions:
+      already_signed_out: Úspešne ste sa odhlásili.
+      signed_in: Úspešne ste sa prihlásili.
+      signed_out: Úspešne ste sa odhlásili.
+    shared:
+      links:
+        didn_t_receive_confirmation_instructions: Nedostali ste pokyny na potvrdenie?
+        didn_t_receive_unlock_instructions: Nedostali ste pokyny na odomknutie?
+        log_in_with_provider: Prihlásiť sa pomocou %{provider}
+        sign_up: Vytvoriť účet
+    unlocks:
+      unlocked: Váš účet bol úspešne odomknutý. Pre pokračovanie sa prosím prihláste.
+  editor:
+    extensions:
+      image:
+        altLabel: Alternatívny text pre obrázok
+        nodeView:
+          resizer:
+            control:
+              resize: Zmeniť veľkosť obrázka (%position%)
+            position:
+              bottomLeft: ľavý dolný roh
+              bottomRight: pravý dolný roh
+              topLeft: ľavý horný roh
+              topRight: pravý horný roh
+        uploadError: Nahrávanie súboru zlyhalo.
+      link:
+        bubbleMenu:
+          edit: Upraviť
+          remove: Odstrániť
+          url: URL
+        hrefLabel: URL odkazu
+        targetLabel: Cieľ
+        targets:
+          blank: Nová karta
+          default: Predvolené (rovnaká karta)
+      videoEmbed:
+        titleLabel: Názov
+        urlLabel: URL videa
+    inputDialog:
+      buttons:
+        cancel: Zrušiť
+        remove: Odstrániť
+        save: Uložiť
+      close: Zavrieť okno
+    toolbar:
+      control:
+        blockquote: Citácia
+        bold: Tučné
+        bulletList: Neusporiadaný zoznam
+        codeBlock: Blok kódu
+        common:
+          eraseStyles: Vymazať štýly
+        hardBreak: Zlom riadka
+        heading: Štýl textu
+        image: Obrázok
+        indent:
+          indent: Zväčšiť odsadenie
+          outdent: Zmenšiť odsadenie
+        italic: Kurzíva
+        link: Odkaz
+        orderedList: Usporiadaný zoznam
+        underline: Podčiarknuté
+        videoEmbed: Vložené video
+      textStyle:
+        heading: Nadpis %level%
+        normal: Normálny
+    upload:
+      uploadedFile: Nahraný súbor
+  emojis:
+    add_custom: Pridať vlastné emoji
+    button: Pridať emoji
+    categories:
+      activity: Aktivita
+      custom: Vlastné
+      flags: Vlajky
+      foods: Jedlo a nápoje
+      frequent: Často používané
+      nature: Zvieratá a príroda
+      objects: Objekty
+      people: Smajlíky a ľudia
+      places: Cestovanie a miesta
+      search: Výsledky vyhľadávania
+      symbols: Symboly
+    pick: Vyberte emoji…
+    search: Hľadať
+    search_no_results_1: Ale nie!
+    search_no_results_2: Toto emoji sa nenašlo
+    skins:
+      '1': Predvolené
+      '2': Svetlý
+      '3': Stredne svetlý
+      '4': Stredný
+      '5': Stredne tmavý
+      '6': Tmavý
+      choose: Vyberte predvolený odtieň pleti
+  errors:
+    messages:
+      allowed_file_content_types: 'povolené sú len súbory s nasledujúcimi príponami: %{types}'
+      already_confirmed: už bol potvrdený, skúste sa prihlásiť
+      blank: nemôže byť prázdne
+      cannot_be_blank: nemôže byť prázdne
+      cannot_have_comments: nemôže mať komentáre
+      confirmation: nezhoduje sa s %{attribute}
+      cycle_detected: nadradený prvok rozsahu nemôže byť jedným z jeho potomkov
+      empty: nemôže byť prázdne
+      nesting_too_deep: nemôže byť vo vnútri podkategórie
+      not_found: sa nenašiel. Vytvorili ste si už predtým účet?
+      too_short: je príliš krátke (menej ako %{count} znakov)
+      url_format: Táto URL adresa je v nesprávnom formáte
+  forms:
+    correct_errors: Vo formulári sú chyby, pre pokračovanie ich prosím opravte.
+    length_validator:
+      minimum:
+        one: Aspoň %{count} znak
+        other: Aspoň %{count} znakov
+    required_explanation: '* Povinné polia sú označené hviezdičkou'
+  layouts:
+    decidim:
+      admin:
+        global_moderations:
+          title: Globálne moderovania
+      announcements:
+        view_less: Zobraziť menej
+        view_more: Viac informácií
+      assemblies:
+        assembly:
+          more_info: Viac informácií
+          take_part: Zúčastniť sa
+        index:
+          promoted_assemblies: Zvýraznené zhromaždenia
+        metadata:
+          children_item:
+            one: '%{count} zhromaždenie'
+            other: '%{count} zhromaždení'
+        order_by_assemblies:
+          assemblies:
+            one: '%{count} zhromaždenie'
+            other: '%{count} zhromaždení'
+      assembly_navigation:
+        assembly_member_menu_item: Členovia
+      conference_hero:
+        manage_registration: Spravovať registráciu
+      data_consent:
+        details:
+          columns:
+            description: Popis
+            name: Názov
+            service: Služba
+          items:
+            _session_id:
+              description: Umožňuje webovým stránkam zapamätať si používateľa v rámci webovej stránky pri prechode medzi webovými stránkami.
+              service: Táto webová stránka
+            decidim-consent:
+              description: Ukladá informácie o súboroch cookie povolených používateľom na tejto webovej stránke.
+              service: Táto webová stránka
+            pwaInstallPromptSeen:
+              description: Ukladá stav, či už používateľ videl upozornenie na inštaláciu progresívnej webovej aplikácie (PWA).
+              service: Táto webová stránka
+          types:
+            cookie: Súbor cookie
+            local_storage: Lokálne úložisko
+        dialog:
+          accept_all: Prijať všetky
+          accept_only_essential: Prijať len nevyhnutné
+          description: Na našej webovej stránke používame súbory cookie na zlepšenie výkonu a obsahu stránky. Súbory cookie nám umožňujú poskytovať individuálnejší používateľský zážitok a kanály sociálnych médií.
+          settings: Nastavenia
+          title: Informácie o súboroch cookie používaných na webovej stránke
+        modal:
+          accept_all: Prijať všetky
+          accept_only_essential: Prijať iba nevyhnutné
+          analytics:
+            description: Tieto súbory cookie sa používajú na meranie a analýzu návštevnosti webovej stránky s cieľom pomôcť ju vylepšiť.
+            title: Analytika a štatistiky
+          description: Súbory cookie používame na zabezpečenie základných funkcií webovej stránky a na zlepšenie vášho online zážitku. Používanie súborov cookie môžete kedykoľvek nakonfigurovať a prijať, a upraviť svoje možnosti súhlasu.
+          essential:
+            description: Tieto súbory cookie umožňujú kľúčové funkcie webovej stránky a pomáhajú udržiavať jej používateľov v bezpečí. Automaticky sa ukladajú v prehliadači a nie je možné ich zakázať.
+            title: Nevyhnutné
+          marketing:
+            description: Tieto súbory cookie zhromažďujú informácie o tom, ako používate webovú stránku, a môžu sa použiť na poskytovanie personalizovanejšieho marketingu naprieč rôznymi webovými stránkami, ktoré používate.
+            title: Marketing
+          preferences:
+            description: Tieto súbory cookie umožňujú webovej stránke zapamätať si voľby, ktoré ste v minulosti na tejto webovej stránke urobili, aby používateľom webovej stránky poskytli personalizovanejší zážitok.
+            title: Preferencie
+          save_settings: Uložiť nastavenia
+          title: Nastavenia súborov cookie
+          toggle: Prepnúť %{consent_category}
+        warning:
+          all_categories: všetky súbory cookie
+          change_settings: Zmeniť nastavenia súborov cookie
+          consent_required: Ak chcete zobraziť tento obsah, musíte povoliť %{categories}.
+      footer:
+        cc_by_license: Licencia Creative Commons
+        current_organization_img: '%{organization} (Späť domov)'
+        data_consent_settings: Nastavenia súborov cookie
+        decidim_logo: Logo Decidim
+        decidim_title: Decidim
+        help: Pomocník
+        resources: Zdroje
+        sign_up: Vytvoriť účet
+        social_media: Sociálne siete
+        terms_of_service: Podmienky používania
+      header:
+        main_menu: Hlavné menu
+        user_menu: Používateľské menu
+      language_chooser:
+        choose_language: Vybrať jazyk
+      navigation:
+        aria_label: 'Navigačné menu: %{title}'
+      notifications_dashboard:
+        mark_as_read: Označiť ako prečítané
+      offline_banner:
+        cache_version_page: Ups! Vaša sieť je offline. Toto je predtým uložená verzia stránky, ktorú navštevujete, obsah možno nie je aktuálny.
+      participatory_process_groups:
+        participatory_process_group:
+          browse_resource: Prehľadávať skupinu procesov %{resource_name}
+      participatory_processes:
+        participatory_process:
+          more_info_about: Viac informácií o procese %{resource_name}
+          take_part_in: Zúčastniť sa procesu %{resource_name}
+      social_media_links:
+        facebook: '%{organization} na Facebooku'
+        github: '%{organization} na GitHube'
+        instagram: '%{organization} na Instagrame'
+        x: '%{organization} na sieti X'
+        youtube: '%{organization} na YouTube'
+      system:
+        login_items:
+          logout: Odhlásiť sa
+      timeout_modal:
+        body: Boli ste neaktívni %{minutes} minút. Ak budete naďalej neaktívni, z bezpečnostných dôvodov budete automaticky odhlásení.
+        continue_session: Pokračovať v relácii
+        log_out: Odhlásiť sa
+        title: Chcete pokračovať vo svojej relácii?
+      user_menu:
+        account: 'Používateľský účet: %{name}'
+        configuration: Konfigurácia
+        log_out: Odhlásiť sa
+        title: Odkazy profilu
+        unread_conversations: Máte neprečítané konverzácie
+        unread_notifications: Máte neprečítané upozornenia
+      user_profile:
+        profile: Profil
+  password_validator:
+    denied: je zamietnuté
+    nickname_included_in_password: je príliš podobné vašej prezývke
+    password_repeated: nemožno znova použiť staré heslo
+  ransack:
+    predicates:
+      dtgt: po
+      dtgteq: po alebo rovné
+      dtlt: pred
+      dtlteq: pred alebo rovné
+  social_share_button:
+    x: X
   time:
+    buttons:
+      close: Zavrieť
+      reset: Obnoviť
     clock_format: 24
     formats:
+      ddmm: '%d.%m'
+      ddmmyyyy: '%d.%m.%Y'
       help:
         time_format: 'Formát: hh:mm'
+      long_with_particles: '%d. %B %Y o %H:%M'
+      tooltip: '%d.%m.%Y %H:%M %p %Z (GMT %:z)'
+  versions:
+    dropdown:
+      toggle: Prepnúť zobrazenie
+  views:
+    pagination:
+      next: Ďalej
+      pagination: Stránkovanie
+      previous: Predchádzajúce


### PR DESCRIPTION
#### :tophat: Description
Crowdin translations for Slovak are synced to `develop` and no longer backported to `release/0.29-stable`, our current version. This left many strings (e.g. matrix question types on the questionnaire answer page) falling back to English instead of Slovak.

This PR patches `sk.yml` with the missing translations, pulled directly from `develop`'s locale files (real Crowdin translations only, nothing invented). Keys untranslated on both branches are left out on purpose rather than guessed at.

The patch was generated with a script comparing the keys in `en.yml` on `release/0.29-stable` against `sk.yml` on `develop` (0.31), in order to find translations that already exist upstream but are missing from our current `sk.yml`, and add them.

#### Testing
* Enable in the env vars the `sk` locale when you create your app 
* Switch the platform language to Slovak (`sk`)
* Open a questionnaire/survey as a logged-out user
* Check the sign-in/sign-up prompts and matrix question labels display in Slovak

#### :pushpin: Related Issues
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=220995344&issue=OpenSourcePolitics%7Cintern-tasks%7C473

#### Tasks
- [x] Add locales using a homemade script