### PR TITLE
fix: Tries to fix the survey behavior 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module DecidimApp
       require "extends/commands/decidim/create_omniauth_registration_extends"
       require "extends/commands/decidim/forms/admin/update_questionnaire_extends"
       require "extends/commands/decidim/admin/content_blocks/update_content_block_extends"
+      require "extends/commands/decidim/forms/answer_questionnaire_extends"
       # forms
       require "extends/forms/decidim/assemblies/admin/assembly_copy_form_extends"
       require "extends/forms/decidim/participatory_processes/admin/participatory_process_copy_form_extends"
@@ -50,6 +51,7 @@ module DecidimApp
       require "extends/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller_extends"
       require "extends/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_content_blocks_controller_extends"
       require "extends/controllers/decidim/proposals/proposals_controller_reorder_extends"
+      require "extends/controllers/decidim/surveys/surveys_controller_extends"
       # helpers
       require "extends/helpers/decidim/check_boxes_tree_helper_extends"
       require "extends/helpers/decidim/omniauth_helper_extends"
@@ -65,6 +67,7 @@ module DecidimApp
       require "extends/models/decidim/proposals/proposal_state_extends"
       require "extends/models/decidim/searchable_author_extends"
       require "extends/models/decidim/content_block_attachment_extends"
+      require "extends/models/decidim/forms/answer_extends"
       # permissions
       require "extends/permissions/initiatives/permissions_extends"
       # presenters

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,9 @@ en:
       force_euf_completion:
         alert: Please complete your profile before continuing. Required fields must be filled in.
     forms:
+      answer:
+        errors:
+          duplicate: You have already answered this question.
       questionnaire_answer_presenter:
         download_attachment: Download attachment
       questionnaires:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -136,6 +136,9 @@ fr:
       force_euf_completion:
         alert: Veuillez compléter votre profil avant de continuer. Les champs obligatoires doivent être renseignés.
     forms:
+      answer:
+        errors:
+          duplicate: Vous avez déjà répondu à cette question.
       questionnaire_answer_presenter:
         download_attachment: Télécharger la pièce jointe
       questionnaires:

--- a/lib/extends/commands/decidim/forms/answer_questionnaire_extends.rb
+++ b/lib/extends/commands/decidim/forms/answer_questionnaire_extends.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module AnswerQuestionnaireExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def answer_questionnaire
+      @main_form = @form
+      @errors = nil
+
+      Decidim::Forms::Answer.transaction(requires_new: true) do
+        form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).each do |form_answer|
+          answer = Decidim::Forms::Answer.find_or_initialize_by(
+            user: current_user,
+            questionnaire: @questionnaire,
+            question: form_answer.question,
+            session_token: form.context.session_token
+          )
+          answer.body = form_answer.body
+          answer.ip_hash = form.context.ip_hash
+          answer.choices.destroy_all if answer.persisted?
+
+          build_choices(answer, form_answer)
+
+          answer.save!
+
+          next unless form_answer.question.has_attachments?
+
+          @form = form_answer
+          @attached_to = answer
+
+          build_attachments
+
+          if attachments_invalid?
+            @errors = true
+            next
+          end
+
+          create_attachments if process_attachments?
+          document_cleanup!
+        end
+
+        @form = @main_form
+        raise ActiveRecord::Rollback if @errors
+      end
+    end
+  end
+end
+
+Decidim::Forms::AnswerQuestionnaire.include(AnswerQuestionnaireExtends)

--- a/lib/extends/controllers/decidim/surveys/surveys_controller_extends.rb
+++ b/lib/extends/controllers/decidim/surveys/surveys_controller_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SurveysControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def visitor_already_answered?
+      questionnaire.answered_by?(current_user || session_token)
+    end
+
+    def session_token
+      return nil unless current_user || request&.session
+
+      @session_token ||= tokenize(current_user&.id || request.session.id.to_s)
+    end
+  end
+end
+
+Decidim::Surveys::SurveysController.include(SurveysControllerExtends)

--- a/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
+++ b/lib/extends/lib/decidim/forms/user_answers_serializer_extend.rb
@@ -4,6 +4,17 @@ module UserAnswersSerializerExtends
   extend ActiveSupport::Concern
 
   included do
+    def serialize
+      answers_hash = hash_for(@answers.first)
+      answers_hash.merge!(questions_hash)
+
+      @answers.each do |answer|
+        answers_hash[translated_question_key(question_positions[answer.decidim_question_id], answer.question.body)] = normalize_body(answer)
+      end
+
+      answers_hash
+    end
+
     private
 
     def hash_for(answer)
@@ -20,6 +31,25 @@ module UserAnswersSerializerExtends
         answer_translated_attribute_name(:email) => answer&.user&.email.presence || "",
         answer_translated_attribute_name(:name) => answer&.user&.name || ""
       }
+    end
+
+    def questions_hash
+      questionnaire_id = @answers.first&.decidim_questionnaire_id
+      return {} unless questionnaire_id
+
+      questions = Decidim::Forms::Question.where(decidim_questionnaire_id: questionnaire_id).order(:position)
+      return {} if questions.none?
+
+      questions.each.inject({}) do |serialized, question|
+        question_positions[question.id] = question.position
+        serialized.update(
+          translated_question_key(question.position, question.body) => ""
+        )
+      end
+    end
+
+    def question_positions
+      @question_positions ||= {}
     end
 
     def answer_translated_attribute_name(attribute)

--- a/lib/extends/models/decidim/forms/answer_extends.rb
+++ b/lib/extends/models/decidim/forms/answer_extends.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module AnswerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    validates :decidim_question_id, uniqueness: {
+      scope: [:decidim_questionnaire_id, :session_token, :decidim_user_id],
+      message: ->(_object, _data) { I18n.t("decidim.forms.answer.errors.duplicate") }
+    }
+  end
+end
+
+Decidim::Forms::Answer.include(AnswerExtends)

--- a/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -1,0 +1,379 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Forms
+    describe AnswerQuestionnaire do
+      let(:command) { described_class.new(form, questionnaire) }
+      let(:form) do
+        QuestionnaireForm.from_params(
+          form_params
+        ).with_context(
+          current_organization:,
+          current_user:,
+          session_token:,
+          ip_hash:
+        )
+      end
+      let(:form_params) do
+        {
+          "responses" => [
+            {
+              "body" => "This is my first answer",
+              "question_id" => question1.id
+            },
+            {
+              "choices" => [
+                { "answer_option_id" => answer_option_ids[0], "body" => "My", "matrix_row_id" => matrix_row_ids[0] },
+                { "answer_option_id" => answer_option_ids[1], "body" => "second", "matrix_row_id" => matrix_row_ids[1] },
+                { "answer_option_id" => answer_option_ids[2], "body" => "answer", "matrix_row_id" => matrix_row_ids[2] }
+              ],
+              "question_id" => question2.id
+            },
+            {
+              "choices" => [
+                { "answer_option_id" => answer_option_ids[3], "body" => "Third", "position" => 0 },
+                { "answer_option_id" => answer_option_ids[4], "body" => "answer", "position" => 1 }
+              ],
+              "question_id" => question3.id
+            }
+          ],
+          "tos_agreement" => "1"
+        }
+      end
+      let(:matrix_row_ids) { matrix_rows.pluck(:id).map(&:to_s) }
+      let(:matrix_rows) { create_list(:question_matrix_row, 3, question: question2) }
+      let(:answer_option_ids) { answer_options.pluck(:id).map(&:to_s) }
+      let(:answer_options) { create_list(:answer_option, 5, question: question2) }
+      let(:question3) { create(:questionnaire_question, questionnaire:) }
+      let(:question2) { create(:questionnaire_question, questionnaire:) }
+      let(:question1) { create(:questionnaire_question, questionnaire:) }
+      let(:questionnaire) { create(:questionnaire, questionnaire_for: participatory_process) }
+      let(:participatory_process) { create(:participatory_process, organization: current_organization) }
+      let(:request) do
+        double(
+          session: { session_id: },
+          remote_ip:
+        )
+      end
+      let(:ip_hash) { tokenize(remote_ip) }
+      let(:remote_ip) { "1.1.1.1" }
+      let(:session_token) { tokenize(current_user&.id || session_id) }
+      let(:session_id) { "session-string" }
+      let(:current_user) { create(:user, organization: current_organization) }
+      let(:current_organization) { create(:organization) }
+
+      it_behaves_like "fires an ActiveSupport::Notification event", "decidim.forms.answer_questionnaire:after"
+
+      def tokenize(id)
+        "fake-hash-for-#{id}"
+      end
+
+      describe "when the form is invalid" do
+        before do
+          allow(form).to receive(:invalid?).and_return(true)
+        end
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+
+        it "does not create questionnaire answers" do
+          expect do
+            command.call
+          end.not_to change(Answer, :count)
+        end
+      end
+
+      describe "when the form is valid" do
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "creates a questionnaire answer for each question answered" do
+          expect do
+            command.call
+          end.to change(Answer, :count).by(3)
+          expect(Answer.all.map(&:questionnaire)).to eq([questionnaire, questionnaire, questionnaire])
+        end
+
+        it "creates answers with the correct information" do
+          command.call
+
+          expect(Answer.first.body).to eq("This is my first answer")
+          expect(Answer.second.choices.map { |a| [a.body, a.matrix_row.body] }).to eq([["My", matrix_rows.first.body], ["second", matrix_rows.second.body], ["answer", matrix_rows.third.body]])
+          expect(Answer.third.choices.pluck(:body, :position)).to eq([["Third", 0], ["answer", 1]])
+        end
+
+        context "and user is registered" do
+          let(:ip_hash) { nil }
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "have answers with session_token information" do
+            command.call
+
+            expect(Answer.first.session_token).to eq(tokenize(current_user.id))
+            expect(Answer.first.ip_hash).to be_nil
+            expect(Answer.second.session_token).to eq(tokenize(current_user.id))
+            expect(Answer.second.ip_hash).to be_nil
+            expect(Answer.third.session_token).to eq(tokenize(current_user.id))
+            expect(Answer.third.ip_hash).to be_nil
+          end
+        end
+
+        context "and an answer already exists for one of the questions (guard bypassed)" do
+          before do
+            allow(questionnaire).to receive(:answered_by?).and_return(false)
+          end
+
+          let!(:existing_answer) do
+            create(:answer, questionnaire:, question: question1, user: current_user, session_token:, body: "Old answer")
+          end
+
+          it "does not create a duplicate answer for that question" do
+            expect do
+              command.call
+            end.to change(Answer, :count).by(2) # question2 + question3 only, question1 is updated in place
+          end
+
+          it "updates the existing answer instead of duplicating it" do
+            command.call
+
+            expect(Answer.where(questionnaire:, question: question1).count).to eq(1)
+            expect(existing_answer.reload.body).to eq("This is my first answer")
+          end
+        end
+
+        context "with attachments" do
+          let(:question1) { create(:questionnaire_question, questionnaire:, question_type: :files) }
+          let(:uploaded_files) do
+            [
+              {
+                title: "Picture of the city",
+                file: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg"))
+              },
+              {
+                title: "Example document",
+                file: upload_test_file(Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf"))
+              }
+            ]
+          end
+          let(:form_params) do
+            {
+              "responses" => [
+                {
+                  "add_documents" => uploaded_files,
+                  "question_id" => question1.id
+                }
+              ],
+              "tos_agreement" => "1"
+            }
+          end
+
+          context "when attachments are allowed" do
+            it "creates multiple attachments for the proposal" do
+              expect { command.call }.to change(Decidim::Attachment, :count).by(2)
+              last_attachment = Decidim::Attachment.last
+              expect(last_attachment.attached_to).to be_a(Decidim::Forms::Answer)
+            end
+          end
+
+          context "when attachments are allowed and file is invalid" do
+            let(:uploaded_files) do
+              [
+                {
+                  title: "Picture of the city",
+                  file: upload_test_file(Decidim::Dev.asset("city.jpeg"), content_type: "image/jpeg")
+                },
+                {
+                  title: "Text document",
+                  file: upload_test_file(Decidim::Dev.asset("invalid_extension.log"), content_type: "text/plain")
+                }
+              ]
+            end
+
+            it "does not create attachments for the proposal" do
+              expect { command.call }.not_to change(Decidim::Attachment, :count)
+            end
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+          end
+
+          context "when the user has answered the survey" do
+            let!(:answer) { create(:answer, questionnaire:, question: question1, user: current_user) }
+
+            it "does not create questionnaire answers" do
+              expect { command.call }.not_to change(Answer, :count)
+            end
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+          end
+        end
+
+        context "when display_conditions are not mandatory on the same question but are fulfilled" do
+          let(:questionnaire_conditioned) { create(:questionnaire, questionnaire_for: participatory_process) }
+          let!(:option1) { create(:answer_option, question: condition_question) }
+          let!(:option2) { create(:answer_option, question: condition_question) }
+          let!(:option3) { create(:answer_option, question: condition_question) }
+          let!(:condition_question) do
+            create(
+              :questionnaire_question,
+              questionnaire: questionnaire_conditioned,
+              mandatory: false,
+              question_type: "single_option"
+            )
+          end
+          let!(:question) { create(:questionnaire_question, questionnaire: questionnaire_conditioned, question_type: "short_answer") }
+          let!(:display_condition) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option1, mandatory: false) }
+          let!(:display_condition2) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option3, mandatory: false) }
+          let(:form_params) do
+            {
+              "responses" => [
+                {
+                  "choices" => [
+                    { "body" => option1.body, "answer_option_id" => option1.id }
+                  ],
+                  "question_id" => condition_question.id
+                },
+                {
+                  "body" => "answer_test",
+                  "question_id" => question.id
+                }
+              ],
+              "tos_agreement" => "1"
+            }
+          end
+          let(:command) { described_class.new(form, questionnaire_conditioned) }
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a questionnaire answer for each question answered" do
+            expect do
+              command.call
+            end.to change(Answer, :count).by(2)
+            expect(Answer.all.map(&:questionnaire)).to eq([questionnaire_conditioned, questionnaire_conditioned])
+          end
+
+          it "creates answers with the correct information" do
+            command.call
+
+            expect(Answer.first.choices.first.answer_option).to eq(option1)
+            expect(Answer.second.body).to eq("answer_test")
+          end
+        end
+
+        context "when questionnaire component is a survey" do
+          let(:manifest_name) { "surveys" }
+          let(:manifest) { Decidim.find_component_manifest(manifest_name) }
+
+          let!(:component) do
+            create(:component,
+                   manifest:,
+                   participatory_space: participatory_process,
+                   published_at: nil)
+          end
+          let!(:survey) { create(:survey, component:, questionnaire:) }
+
+          let(:answers) do
+            survey.questionnaire.questions.map do |question|
+              create(:answer, questionnaire: survey.questionnaire, question:, user: current_user)
+            end
+          end
+
+          let(:event_arguments) do
+            {
+              resource: questionnaire,
+              extra: {
+                session_token:,
+                questionnaire:,
+                event_author: current_user
+              }
+            }
+          end
+          let(:mailer) { double :mailer }
+
+          it_behaves_like "fires an ActiveSupport::Notification event", "decidim.forms.answer_questionnaire:after"
+        end
+      end
+
+      describe "when the user is unregistered" do
+        let(:current_user) { nil }
+
+        context "and session exists" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "have answers session/ip information" do
+            command.call
+
+            expect(Answer.first.session_token).to eq(tokenize(session_id))
+            expect(Answer.first.ip_hash).to eq(ip_hash)
+            expect(Answer.second.session_token).to eq(tokenize(session_id))
+            expect(Answer.second.ip_hash).to eq(ip_hash)
+            expect(Answer.third.session_token).to eq(tokenize(session_id))
+            expect(Answer.third.ip_hash).to eq(ip_hash)
+          end
+        end
+
+        context "and visitor has answered the survey" do
+          let!(:answer) { create(:answer, questionnaire:, question: question1, session_token: tokenize(session_id)) }
+
+          it "does not create questionnaire answers" do
+            expect { command.call }.not_to change(Answer, :count)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "and the guard incorrectly treats two different visitors as the same one" do
+          before do
+            allow(questionnaire).to receive(:answered_by?).and_return(false)
+          end
+
+          let!(:existing_answer) do
+            create(:answer, questionnaire:, question: question1, user: nil, session_token: tokenize(session_id), body: "Old answer")
+          end
+
+          it "does not create a duplicate answer for that question" do
+            expect do
+              command.call
+            end.to change(Answer, :count).by(2)
+          end
+
+          it "updates the existing answer instead of duplicating it" do
+            command.call
+
+            expect(Answer.where(questionnaire:, question: question1).count).to eq(1)
+          end
+        end
+
+        context "and session is missing" do
+          let(:session_token) { nil }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "does not create questionnaire answers" do
+            expect do
+              command.call
+            end.not_to change(Answer, :count)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/decidim/forms/answer_spec.rb
+++ b/spec/models/decidim/forms/answer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Forms
+    describe Answer do
+      subject { answer }
+
+      let(:organization) { create(:organization) }
+      let(:user) { create(:user, organization:) }
+      let(:participatory_process) { create(:participatory_process, organization:) }
+      let(:questionnaire) { create(:questionnaire, questionnaire_for: participatory_process) }
+      let(:question) { create(:questionnaire_question, questionnaire:) }
+      let(:answer) { create(:answer, questionnaire:, question:, user:) }
+
+      it { is_expected.to be_valid }
+
+      it "has an association of questionnaire" do
+        expect(subject.questionnaire).to eq(questionnaire)
+      end
+
+      it "has an association of question" do
+        expect(subject.question).to eq(question)
+      end
+
+      it "has an association of user" do
+        expect(subject.user).to eq(user)
+      end
+
+      context "when the user does not belong to the same organization" do
+        it "is not valid" do
+          subject.user = create(:user)
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when question does not belong to the questionnaire" do
+        it "is not valid" do
+          subject.question = create(:questionnaire_question)
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when a duplicate answer already exists (answer_extends.rb)" do
+        let!(:existing_answer) { create(:answer, questionnaire:, question:, user:) }
+
+        it "is not valid for the same user answering the same question again" do
+          duplicate = build(:answer, questionnaire:, question:, user:)
+          expect(duplicate).not_to be_valid
+          expect(duplicate.errors[:decidim_question_id]).to be_present
+        end
+
+        context "and it is a different user" do
+          let(:other_user) { create(:user, organization:) }
+
+          it "is valid" do
+            other_answer = build(:answer, questionnaire:, question:, user: other_user)
+            expect(other_answer).to be_valid
+          end
+        end
+
+        context "and it is a different question" do
+          let(:other_question) { create(:questionnaire_question, questionnaire:) }
+
+          it "is valid" do
+            other_answer = build(:answer, questionnaire:, question: other_question, user:)
+            expect(other_answer).to be_valid
+          end
+        end
+      end
+
+      context "when two unregistered answers share the same session_token" do
+        let(:session_token) { "session-token-abc" }
+        let!(:existing_answer) { create(:answer, questionnaire:, question:, user: nil, session_token:) }
+
+        it "is not valid for a second answer with the same session_token on the same question" do
+          duplicate = build(:answer, questionnaire:, question:, user: nil, session_token:)
+          expect(duplicate).not_to be_valid
+        end
+
+        it "is valid for a different session_token" do
+          other_answer = build(:answer, questionnaire:, question:, user: nil, session_token: "session-token-xyz")
+          expect(other_answer).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -185,16 +185,6 @@ module Decidim
           end
 
           it "does not load the questionnaire description to memory every time when iterating an answer" do
-            # NOTE:
-            # For this test it is important to fetch the single user "answer
-            # sets" to an array and store them there because this is the same
-            # way the answers are loaded e.g. in the survey component export
-            # functionality. The export had previously a memory leak because the
-            # questionnaire is fetched individually for each "answer set" and if
-            # it has a very long description, it caused the description to be
-            # stored multiple times within the array (for each "answer set"
-            # separately) causing a out of memory errors when there is a large
-            # amount of answers.
             all_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire)
 
             initial_memory = memory_usage
@@ -208,12 +198,46 @@ module Decidim
             `ps -o rss #{Process.pid}`.lines.last.to_i
           end
         end
+
+        context "when a question's position changes mid-export" do
+          it "uses the position captured before iterating answers, not a live re-read per answer" do
+            original_questions_hash = subject.method(:questions_hash)
+            allow(subject).to receive(:questions_hash) do
+              result = original_questions_hash.call
+              questions.first.update_column(:position, 99) # rubocop:disable Rails/SkipsModelValidations
+              result
+            end
+
+            first_key = "1. #{translated(questions.first.body, locale: I18n.locale)}"
+
+            expect(serialized).to include(first_key => answers.first.body)
+          end
+        end
       end
 
       describe "questions_hash" do
         it "generates a hash of questions ordered by position" do
           questions.shuffle!
           expect(subject.instance_eval { questions_hash }.keys.map { |key| key[0].to_i }.uniq).to eq(questions.sort_by(&:position).map { |question| question.position + 1 })
+        end
+      end
+
+      describe "question_positions" do
+        it "is memoized across multiple calls within the same instance" do
+          subject.send(:questions_hash)
+          first_call = subject.send(:question_positions)
+          questions.first.update_column(:position, 42) # rubocop:disable Rails/SkipsModelValidations
+
+          expect(subject.send(:question_positions)).to equal(first_call)
+        end
+
+        it "maps each question id to its position" do
+          subject.send(:questions_hash)
+          positions = subject.send(:question_positions)
+
+          questions.each do |question|
+            expect(positions[question.id]).to eq(question.position)
+          end
         end
       end
     end

--- a/spec/system/unregistered_user_survey_spec.rb
+++ b/spec/system/unregistered_user_survey_spec.rb
@@ -83,6 +83,36 @@ describe "Answer a survey" do
       expect(last_answer.ip_hash).not_to be_empty
     end
 
+    it "gives distinct session tokens to two different unregistered visitors" do
+      Capybara.using_session("visitor_1") do
+        visit_component
+        fill_in question.body["en"], with: "First visitor's answer"
+        check "questionnaire_tos_agreement"
+        accept_confirm { click_on "Submit" }
+
+        within ".success.flash" do
+          expect(page).to have_content("successfully")
+        end
+      end
+
+      Capybara.using_session("visitor_2") do
+        visit_component
+        fill_in question.body["en"], with: "Second visitor's answer"
+        check "questionnaire_tos_agreement"
+        accept_confirm { click_on "Submit" }
+
+        within ".success.flash" do
+          expect(page).to have_content("successfully")
+        end
+      end
+
+      answers = questionnaire.answers.where(question:).order(:created_at)
+      expect(answers.count).to eq(2)
+      expect(answers.first.session_token).to be_present
+      expect(answers.second.session_token).to be_present
+      expect(answers.first.session_token).not_to eq(answers.second.session_token)
+    end
+
     context "and honeypot is filled" do
       it "fails with spam complain" do
         visit_component


### PR DESCRIPTION
#### :tophat: Description
Fixes duplicate answers on questionnaires that allow unregistered (non-logged-in) respondents.

The root cause was in `session_token`, used to identify anonymous respondents: it read `session[:session_id]`, a key that is never actually assigned anywhere in the codebase. This made `session_token` return the same blank value for every anonymous visitor, so different respondents became indistinguishable from one another once answers were stored/exported, which is what looked like duplicates. It now uses `request.session.id`, the actual Rails session identifier, giving each anonymous visitor a stable, unique token.

On top of that:
- `AnswerQuestionnaire` now uses `find_or_initialize_by` instead of `Answer.new`, so a resubmission for the same respondent/question updates the existing answer instead of creating a second one.
- A `uniqueness` validation was added on `Answer` as a model-level safety net against duplicates, independent of the two fixes above.
- `UserAnswersSerializer` now captures question positions once at the start of an export instead of re-reading them live per answer, to avoid inconsistent column mapping if the questionnaire structure changes mid-export.

None of this changes the respondent-facing experience, same forms, same flow, just correct identification and data underneath.

There have also been separate, unconfirmed reports of answers appearing shifted/misaligned on submit and/or export. We could not pin down a cause for that with certainty. It's possible (not confirmed) that the `session_token` fix also alleviates part of it, since before this fix, every unregistered respondent shared the same blank identifier, meaning several different people's answers could end up merged under a single respondent row in an export, which could look like misalignment. This is a plausible side-effect at best, not a verified fix for that specific report.

#### :pushpin: Related Issues
- Tries to fix https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=211285851&issue=OpenSourcePolitics%7Cintern-tasks%7C464

#### Tasks
- [x] `surveys_controller_extends.rb`: fixed `session_token`/`visitor_already_answered?` to use `request.session.id` instead of the never-assigned `session[:session_id]`
- [x] `answer_questionnaire_extends.rb`: switched to `find_or_initialize_by` instead of `Answer.new` to make answer submission idempotent
- [x] `answer_extends.rb`: added a `uniqueness` validation on `Answer` as a model-level duplicate guard
- [x] `user_answers_serializer_extends.rb`: cache question positions once at the start of export instead of re-reading them live per answer
- [x] Add specs